### PR TITLE
fix autocomplete quotes

### DIFF
--- a/src/autocompletion_provider/modelAutocompletionProvider.ts
+++ b/src/autocompletion_provider/modelAutocompletionProvider.ts
@@ -58,10 +58,10 @@ export class ModelAutocompletionProvider
     ) {
       let quoteFound = false;
       let quote = "";
-      if (linePrefix.endsWith("'")) {
+      if (linePrefix.startsWith("'")) {
         quoteFound = true;
         quote = "'";
-      } else if (linePrefix.endsWith('"')) {
+      } else if (linePrefix.startsWith('"')) {
         quoteFound = true;
         quote = '"';
       }

--- a/src/autocompletion_provider/modelAutocompletionProvider.ts
+++ b/src/autocompletion_provider/modelAutocompletionProvider.ts
@@ -48,9 +48,9 @@ export class ModelAutocompletionProvider
     token: CancellationToken,
     context: CompletionContext
   ): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
-    const linePrefix = document
+    let linePrefix = document
       .lineAt(position)
-      .text.substr(0, position.character);
+      .text.substring(0, position.character);
     if (
       (linePrefix.match(ModelAutocompletionProvider.MODEL_PATTERN) ||
         linePrefix.match(ModelAutocompletionProvider.PACKAGE_PATTERN)) &&
@@ -58,10 +58,18 @@ export class ModelAutocompletionProvider
     ) {
       let quoteFound = false;
       let quote = "";
-      if (linePrefix.startsWith("'")) {
+      const refString = "ref(";
+      const refStringPosition = linePrefix.indexOf(refString);
+      if (refStringPosition !== -1) {
+        linePrefix = linePrefix.substring(
+          0,
+          refStringPosition + refString.length + 1
+        );
+      }
+      if (linePrefix.endsWith("'")) {
         quoteFound = true;
         quote = "'";
-      } else if (linePrefix.startsWith('"')) {
+      } else if (linePrefix.endsWith('"')) {
         quoteFound = true;
         quote = '"';
       }


### PR DESCRIPTION
## Overview

resolves #301

Fixed an issue when autocomplete doesn't consider existing single quotes and provides text with double quotes.
Was: `select * from {{ ref('"model_name"') }}`
Now: `select * from {{ ref('model_name') }}`

As far a I've checked the fix is working for me. As I'm seeing TypeScript for the first time, it would be nice if somebody will point to mistakes.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
