### PR TITLE
Add enableGenerateModelCodeLens option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Telemetry is used for error and usage reporting in order to make the extension b
 
 You can select a file name template and prefix in the settings.
 
+If this feature is not desired, it can be disabled by setting "dbt.enableGenerateModelCodeLens" to false.
+
 ### <a id="doceditor">Edit the documentation from your model</a>
 
 ![Edit the documentation from your model](./media/images/documentation-editor.png)

--- a/package.json
+++ b/package.json
@@ -109,6 +109,11 @@
             "description": "Override the default scale of the result table that is used by the `Preview SQL Query` command.",
             "default": 1
           },
+          "dbt.enableGenerateModelCodeLens": {
+            "type": "boolean",
+            "description": "Enable the code lens that allows you to generate a model from a source yml file.",
+            "default": true
+          },
           "dbt.fileNameTemplateGenerateModel": {
             "type": "string",
             "enum": [

--- a/src/code_lens_provider/sourceModelCreationCodeLensProvider.ts
+++ b/src/code_lens_provider/sourceModelCreationCodeLensProvider.ts
@@ -7,6 +7,7 @@ import {
   Range,
   TextDocument,
   Uri,
+  workspace,
 } from "vscode";
 import { CST, LineCounter, Parser } from "yaml";
 import { provideSingleton } from "../utils";
@@ -124,32 +125,38 @@ export class SourceModelCreationCodeLensProvider implements CodeLensProvider {
               }
 
               // add all tables
-              for (const i in currentTables) {
-                const table = currentTables[i];
-                const params: GenerateModelFromSourceParams = {
-                  currentDoc: document.uri,
-                  sourceName: currentSource!,
-                  database: currentDatabase!,
-                  schema: currentSchema!,
-                  tableName: table.tableName,
-                  tableIdentifier: table.tableIdentifier,
-                };
-                this.codeLenses.push(
-                  new CodeLens(
-                    new Range(
-                      table.pos.line - 1,
-                      table.pos.col,
-                      table.pos.line - 1,
-                      table.pos.col,
+              if (
+                workspace
+                  .getConfiguration("dbt")
+                  .get<boolean>("enableGenerateModelCodeLens", true)
+              ) {
+                for (const i in currentTables) {
+                  const table = currentTables[i];
+                  const params: GenerateModelFromSourceParams = {
+                    currentDoc: document.uri,
+                    sourceName: currentSource!,
+                    database: currentDatabase!,
+                    schema: currentSchema!,
+                    tableName: table.tableName,
+                    tableIdentifier: table.tableIdentifier,
+                  };
+                  this.codeLenses.push(
+                    new CodeLens(
+                      new Range(
+                        table.pos.line - 1,
+                        table.pos.col,
+                        table.pos.line - 1,
+                        table.pos.col,
+                      ),
+                      {
+                        title: "Generate model",
+                        tooltip: "Generate model based on source configuration",
+                        command: "dbtPowerUser.createModelBasedonSourceConfig",
+                        arguments: [params],
+                      },
                     ),
-                    {
-                      title: "Generate model",
-                      tooltip: "Generate model based on source configuration",
-                      command: "dbtPowerUser.createModelBasedonSourceConfig",
-                      arguments: [params],
-                    },
-                  ),
-                );
+                  );
+                }
               }
               currentDatabase = undefined;
               currentSchema = undefined;


### PR DESCRIPTION
## Overview
It is not desirable for all users to have CodeLens for the Generate model in schema.yml.

My project has a policy of not creating views for sources, so this PR add a setting option to prevent members from clicking on CodeLens.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [x] `README.md` updated and added information about my change
