### PR TITLE
Support Variable Expansion in sqlFmtPath Setting

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -11,7 +11,11 @@ import {
 } from "vscode";
 import * as which from "which";
 import { CommandProcessExecutionFactory } from "../commandProcessExecution";
-import { extendErrorWithSupportLinks, provideSingleton } from "../utils";
+import {
+  extendErrorWithSupportLinks,
+  provideSingleton,
+  substituteSettingsVariables,
+} from "../utils";
 import { TelemetryService } from "../telemetry";
 
 @provideSingleton(DbtDocumentFormattingEditProvider)
@@ -31,10 +35,15 @@ export class DbtDocumentFormattingEditProvider
     return this.executeSqlFmt(document);
   }
 
-  private async executeSqlFmt(document: TextDocument) {
-    const sqlFmtPathSetting = workspace
+  private getSqlFmtPathSetting(): string | undefined {
+    const value = workspace
       .getConfiguration("dbt")
       .get<string>("sqlFmtPath", "");
+    return value ? substituteSettingsVariables(value) : undefined;
+  }
+
+  private async executeSqlFmt(document: TextDocument) {
+    const sqlFmtPathSetting = this.getSqlFmtPathSetting();
     const sqlFmtAdditionalParamsSetting = workspace
       .getConfiguration("dbt")
       .get<string[]>("sqlFmtAdditionalParams", [])


### PR DESCRIPTION
With this PR, we're enhancing the functionality of the DbtDocumentFormattingEditProvider class to support variable expansion, such as ${workspaceFolder}, when setting up the sqlFmtPath. This will provide users with more flexibility and better integration with diverse workspace configurations :)

## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234
-->

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
