### PR TITLE
feat: hover providers for refs and sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
   ],
   "main": "./dist/extension",
   "contributes": {
-    "capabilities": {
-      "hoverProvider": "true"
-    },
     "snippets": [
       {
         "language": "jinja-sql",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "engines": {
     "vscode": "^1.82.0"
   },
+  "capabilities": {
+    "hoverProvider": true
+  },
   "categories": [
     "Other",
     "Programming Languages",
@@ -35,6 +38,9 @@
   ],
   "main": "./dist/extension",
   "contributes": {
+    "capabilities": {
+      "hoverProvider": "true"
+    },
     "snippets": [
       {
         "language": "jinja-sql",

--- a/src/dbtPowerUserExtension.ts
+++ b/src/dbtPowerUserExtension.ts
@@ -11,6 +11,7 @@ import { TreeviewProviders } from "./treeview_provider";
 import { provideSingleton } from "./utils";
 import { WebviewViewProviders } from "./webview_provider";
 import { TelemetryService } from "./telemetry";
+import { HoverProviders } from "./hover_provider";
 
 @provideSingleton(DBTPowerUserExtension)
 export class DBTPowerUserExtension implements Disposable {
@@ -34,6 +35,7 @@ export class DBTPowerUserExtension implements Disposable {
     private documentFormattingEditProviders: DocumentFormattingEditProviders,
     private statusBars: StatusBars,
     private telemetry: TelemetryService,
+    private hoverProviders: HoverProviders,
   ) {
     this.disposables.push(
       this.dbtProjectContainer,
@@ -47,6 +49,7 @@ export class DBTPowerUserExtension implements Disposable {
       this.documentFormattingEditProviders,
       this.statusBars,
       this.telemetry,
+      this.hoverProviders,
     );
   }
 

--- a/src/hover_provider/index.ts
+++ b/src/hover_provider/index.ts
@@ -2,7 +2,7 @@ import { Disposable, languages } from "vscode";
 import { DBTPowerUserExtension } from "../dbtPowerUserExtension";
 import { provideSingleton } from "../utils";
 import { ModelHoverProvider } from "./modelHoverProvider";
-import { SourceHoverProvider } from "./sourceDefinitionProvider";
+import { SourceHoverProvider } from "./sourceHoverProvider";
 
 @provideSingleton(HoverProviders)
 export class HoverProviders implements Disposable {

--- a/src/hover_provider/index.ts
+++ b/src/hover_provider/index.ts
@@ -1,0 +1,27 @@
+import { Disposable, languages } from "vscode";
+import { DBTPowerUserExtension } from "../dbtPowerUserExtension";
+import { provideSingleton } from "../utils";
+import { ModelHoverProvider } from "./modelHoverProvider";
+
+@provideSingleton(HoverProviders)
+export class HoverProviders implements Disposable {
+  private disposables: Disposable[] = [];
+
+  constructor(private modelHoverProvider: ModelHoverProvider) {
+    this.disposables.push(
+      languages.registerHoverProvider(
+        DBTPowerUserExtension.DBT_SQL_SELECTOR,
+        this.modelHoverProvider,
+      ),
+    );
+  }
+
+  dispose() {
+    while (this.disposables.length) {
+      const x = this.disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+  }
+}

--- a/src/hover_provider/index.ts
+++ b/src/hover_provider/index.ts
@@ -2,16 +2,26 @@ import { Disposable, languages } from "vscode";
 import { DBTPowerUserExtension } from "../dbtPowerUserExtension";
 import { provideSingleton } from "../utils";
 import { ModelHoverProvider } from "./modelHoverProvider";
+import { SourceHoverProvider } from "./sourceDefinitionProvider";
 
 @provideSingleton(HoverProviders)
 export class HoverProviders implements Disposable {
   private disposables: Disposable[] = [];
 
-  constructor(private modelHoverProvider: ModelHoverProvider) {
+  constructor(
+    private modelHoverProvider: ModelHoverProvider,
+    private sourceHoverProvider: SourceHoverProvider,
+  ) {
     this.disposables.push(
       languages.registerHoverProvider(
         DBTPowerUserExtension.DBT_SQL_SELECTOR,
         this.modelHoverProvider,
+      ),
+    );
+    this.disposables.push(
+      languages.registerHoverProvider(
+        DBTPowerUserExtension.DBT_SQL_SELECTOR,
+        this.sourceHoverProvider,
       ),
     );
   }

--- a/src/hover_provider/modelHoverProvider.ts
+++ b/src/hover_provider/modelHoverProvider.ts
@@ -129,7 +129,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
       content.appendMarkdown(
         `<span style="color:#347890;">(ref)&nbsp;</span><span><strong>${node.alias}</strong></span>`,
       );
-      if (node.description !== null) {
+      if (node.description !== "") {
         content.appendMarkdown(`</br><span>${node.description}</span>`);
       }
       content.appendText("\n");
@@ -140,18 +140,19 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
       for (const colKey in node.columns) {
         const column = node.columns[colKey];
         content.appendMarkdown(
-          `<br/><span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
+          `<span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
         );
         if (column.data_type !== null) {
           content.appendMarkdown(
             `<span>-&nbsp;${column.data_type.toUpperCase()}</span>`,
           );
         }
-        if (column.description !== null) {
+        if (column.description !== "") {
           content.appendMarkdown(
             `<br/><span><em>${column.description}</em></span>`,
           );
         }
+        content.appendMarkdown("</br>");
       }
       return content;
     }

--- a/src/hover_provider/modelHoverProvider.ts
+++ b/src/hover_provider/modelHoverProvider.ts
@@ -56,7 +56,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
       const project = this.dbtProjectContainer.findDBTProject(document.uri);
       if (!project) {
         console.error(
-          "Could not load definition provider, project not found in container for " +
+          "Could not load hover provider, project not found in container for " +
             document.uri.fsPath,
         );
         return;
@@ -143,7 +143,9 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
           `<br/><span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
         );
         if (column.data_type !== null) {
-          content.appendMarkdown(`<span>${column.data_type}&nbsp;</span>`);
+          content.appendMarkdown(
+            `<span>-&nbsp;${column.data_type.toUpperCase()}</span>`,
+          );
         }
         if (column.description !== null) {
           content.appendMarkdown(

--- a/src/hover_provider/modelHoverProvider.ts
+++ b/src/hover_provider/modelHoverProvider.ts
@@ -1,0 +1,158 @@
+import {
+  CancellationToken,
+  HoverProvider,
+  Disposable,
+  Position,
+  ProviderResult,
+  Range,
+  TextDocument,
+  Uri,
+  Hover,
+  MarkdownString,
+} from "vscode";
+import { NodeMetaMap } from "../domain";
+import { DBTProjectContainer } from "../manifest/dbtProjectContainer";
+import { ManifestCacheChangedEvent } from "../manifest/event/manifestCacheChangedEvent";
+import { provideSingleton } from "../utils";
+import { TelemetryService } from "../telemetry";
+
+@provideSingleton(ModelHoverProvider)
+export class ModelHoverProvider implements HoverProvider, Disposable {
+  private modelToLocationMap: Map<string, NodeMetaMap> = new Map();
+  private static readonly IS_REF = /(ref)\([^)]*\)/;
+  private static readonly GET_DBT_MODEL = /(?!'|")([^(?!'|")]*)(?='|")/gi;
+  private disposables: Disposable[] = [];
+
+  constructor(
+    private dbtProjectContainer: DBTProjectContainer,
+    private telemetry: TelemetryService,
+  ) {
+    this.disposables.push(
+      dbtProjectContainer.onManifestChanged((event) =>
+        this.onManifestCacheChanged(event),
+      ),
+    );
+  }
+
+  dispose() {
+    while (this.disposables.length) {
+      const x = this.disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+  }
+
+  provideHover(
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+  ): ProviderResult<Hover> {
+    return new Promise((resolve) => {
+      const hover = document.getText(document.getWordRangeAtPosition(position));
+      const word = document.getText(
+        document.getWordRangeAtPosition(position, ModelHoverProvider.IS_REF),
+      );
+      const project = this.dbtProjectContainer.findDBTProject(document.uri);
+      if (!project) {
+        console.error(
+          "Could not load definition provider, project not found in container for " +
+            document.uri.fsPath,
+        );
+        return;
+      }
+      if (word !== undefined && hover !== "ref") {
+        const dbtModel = word.match(ModelHoverProvider.GET_DBT_MODEL);
+        if (dbtModel && dbtModel.length === 1) {
+          const mdString = this.getDefinitionFor(
+            project.getProjectName(),
+            dbtModel[0],
+            document.uri,
+          );
+          if (mdString !== undefined) {
+            const hover = new Hover(mdString, new Range(position, position));
+            resolve(hover);
+          }
+          this.telemetry.sendTelemetryEvent("provideModelDefinition", {
+            type: "single",
+          });
+          return;
+        }
+        if (dbtModel && dbtModel.length === 3) {
+          const mdString = this.getDefinitionFor(
+            dbtModel[0],
+            dbtModel[2],
+            document.uri,
+          );
+          if (mdString !== undefined) {
+            const hover = new Hover(mdString, new Range(position, position));
+            resolve(hover);
+          }
+          this.telemetry.sendTelemetryEvent("provideModelDefinition", {
+            type: "dual",
+          });
+          return;
+        }
+      }
+      resolve(undefined);
+    });
+  }
+
+  private onManifestCacheChanged(event: ManifestCacheChangedEvent): void {
+    event.added?.forEach((added) => {
+      this.modelToLocationMap.set(added.projectRoot.fsPath, added.nodeMetaMap);
+    });
+    event.removed?.forEach((removed) => {
+      this.modelToLocationMap.delete(removed.projectRoot.fsPath);
+    });
+  }
+
+  private getDefinitionFor(
+    projectName: string,
+    modelName: string,
+    currentFilePath: Uri,
+  ): MarkdownString | undefined {
+    const projectRootpath =
+      this.dbtProjectContainer.getProjectRootpath(currentFilePath);
+    if (projectRootpath === undefined) {
+      return;
+    }
+    const nodeMap = this.modelToLocationMap.get(projectRootpath.fsPath);
+    if (nodeMap === undefined) {
+      return;
+    }
+    const node = nodeMap.get(modelName);
+    if (node) {
+      const content = new MarkdownString();
+      content.supportHtml = true;
+      content.isTrusted = true;
+      content.appendMarkdown(
+        `<span style="color:#347890;">(ref)&nbsp;</span><span>${node.alias}</span>`,
+      );
+      if (node.description !== null) {
+        content.appendMarkdown(`<span>${node.description}</span>`);
+      }
+      content.appendText("\n");
+      content.appendText("\n");
+      content.appendMarkdown("---");
+      content.appendText("\n");
+      content.appendText("\n");
+      for (const colKey in node.columns) {
+        const column = node.columns[colKey];
+        content.appendMarkdown(
+          `<br/><span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
+        );
+        if (column.data_type !== null) {
+          content.appendMarkdown(`<span>${column.data_type}&nbsp;</span>`);
+        }
+        if (column.description !== null) {
+          content.appendMarkdown(
+            `<br/><span><em>${column.description}</em></span>`,
+          );
+        }
+      }
+      return content;
+    }
+    return undefined;
+  }
+}

--- a/src/hover_provider/modelHoverProvider.ts
+++ b/src/hover_provider/modelHoverProvider.ts
@@ -130,7 +130,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
         `<span style="color:#347890;">(ref)&nbsp;</span><span>${node.alias}</span>`,
       );
       if (node.description !== null) {
-        content.appendMarkdown(`<span>${node.description}</span>`);
+        content.appendMarkdown(`</br><span>${node.description}</span>`);
       }
       content.appendText("\n");
       content.appendText("\n");

--- a/src/hover_provider/modelHoverProvider.ts
+++ b/src/hover_provider/modelHoverProvider.ts
@@ -127,7 +127,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
       content.supportHtml = true;
       content.isTrusted = true;
       content.appendMarkdown(
-        `<span style="color:#347890;">(ref)&nbsp;</span><span>${node.alias}</span>`,
+        `<span style="color:#347890;">(ref)&nbsp;</span><span><strong>${node.alias}</strong></span>`,
       );
       if (node.description !== null) {
         content.appendMarkdown(`</br><span>${node.description}</span>`);

--- a/src/hover_provider/modelHoverProvider.ts
+++ b/src/hover_provider/modelHoverProvider.ts
@@ -64,7 +64,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
       if (word !== undefined && hover !== "ref") {
         const dbtModel = word.match(ModelHoverProvider.GET_DBT_MODEL);
         if (dbtModel && dbtModel.length === 1) {
-          const mdString = this.getDefinitionFor(
+          const mdString = this.getHoverMarkdownFor(
             project.getProjectName(),
             dbtModel[0],
             document.uri,
@@ -79,7 +79,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
           return;
         }
         if (dbtModel && dbtModel.length === 3) {
-          const mdString = this.getDefinitionFor(
+          const mdString = this.getHoverMarkdownFor(
             dbtModel[0],
             dbtModel[2],
             document.uri,
@@ -107,7 +107,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
     });
   }
 
-  private getDefinitionFor(
+  private getHoverMarkdownFor(
     projectName: string,
     modelName: string,
     currentFilePath: Uri,

--- a/src/hover_provider/modelHoverProvider.ts
+++ b/src/hover_provider/modelHoverProvider.ts
@@ -73,7 +73,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
             const hover = new Hover(mdString, new Range(position, position));
             resolve(hover);
           }
-          this.telemetry.sendTelemetryEvent("provideModelDefinition", {
+          this.telemetry.sendTelemetryEvent("provideModelHover", {
             type: "single",
           });
           return;
@@ -88,7 +88,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
             const hover = new Hover(mdString, new Range(position, position));
             resolve(hover);
           }
-          this.telemetry.sendTelemetryEvent("provideModelDefinition", {
+          this.telemetry.sendTelemetryEvent("provideModelHover", {
             type: "dual",
           });
           return;

--- a/src/hover_provider/sourceDefinitionProvider.ts
+++ b/src/hover_provider/sourceDefinitionProvider.ts
@@ -123,28 +123,6 @@ export class SourceHoverProvider implements HoverProvider, Disposable {
       content.appendMarkdown(
         `<span style="color:#347890;">(source)&nbsp;</span><span><strong>${node.name}</strong></span>`,
       );
-      // if (node.description !== null) {
-      //   content.appendMarkdown(`</br><span>${node.description}</span>`);
-      // }
-      // content.appendText("\n");
-      // content.appendText("\n");
-      // content.appendMarkdown("---");
-      // content.appendText("\n");
-      // content.appendText("\n");
-      // for (const colKey in node.columns) {
-      //   const column = node.columns[colKey];
-      //   content.appendMarkdown(
-      //     `<br/><span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
-      //   );
-      //   if (column.data_type !== null) {
-      //     content.appendMarkdown(`<span>${column.data_type}&nbsp;</span>`);
-      //   }
-      //   if (column.description !== null) {
-      //     content.appendMarkdown(
-      //       `<br/><span><em>${column.description}</em></span>`,
-      //     );
-      //   }
-      // }
       return content;
     }
     return undefined;

--- a/src/hover_provider/sourceDefinitionProvider.ts
+++ b/src/hover_provider/sourceDefinitionProvider.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "fs";
+import {
+  CancellationToken,
+  Definition,
+  DefinitionLink,
+  HoverProvider,
+  Disposable,
+  Location,
+  Position,
+  ProviderResult,
+  TextDocument,
+  Uri,
+  Hover,
+  MarkdownString,
+} from "vscode";
+import { SourceMetaMap } from "../domain";
+import { DBTProjectContainer } from "../manifest/dbtProjectContainer";
+import { ManifestCacheChangedEvent } from "../manifest/event/manifestCacheChangedEvent";
+import { isEnclosedWithinCodeBlock, provideSingleton } from "../utils";
+import { TelemetryService } from "../telemetry";
+
+@provideSingleton(SourceHoverProvider)
+export class SourceHoverProvider implements HoverProvider, Disposable {
+  private sourceMetaMap: Map<string, SourceMetaMap> = new Map();
+  private static readonly IS_SOURCE = /(source)\([^)]*\)/;
+  private static readonly GET_SOURCE_INFO = /(?!['"])(\w+)(?=['"])/g;
+  private disposables: Disposable[] = [];
+
+  constructor(
+    private dbtProjectContainer: DBTProjectContainer,
+    private telemetry: TelemetryService,
+  ) {
+    this.disposables.push(
+      dbtProjectContainer.onManifestChanged((event) =>
+        this.onManifestCacheChanged(event),
+      ),
+    );
+  }
+
+  dispose() {
+    while (this.disposables.length) {
+      const x = this.disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+  }
+
+  provideHover(
+    document: TextDocument,
+    position: Position,
+    token: CancellationToken,
+  ): ProviderResult<Hover> {
+    return new Promise((resolve) => {
+      const hover = document.getText(document.getWordRangeAtPosition(position));
+      const range = document.getWordRangeAtPosition(
+        position,
+        SourceHoverProvider.IS_SOURCE,
+      );
+      const word = document.getText(range);
+
+      const linePrefix = document
+        .lineAt(position)
+        .text.substr(0, position.character);
+
+      if (
+        !isEnclosedWithinCodeBlock(document, position) ||
+        !linePrefix.includes("source") ||
+        hover === "source"
+      ) {
+        resolve(undefined);
+        return;
+      }
+
+      const source = word.match(SourceHoverProvider.GET_SOURCE_INFO);
+      if (source === null || source === undefined) {
+        resolve(undefined);
+        return;
+      }
+      if (source.length < 2) {
+        resolve(undefined);
+        return;
+      }
+      const mdString = this.getSourceHover(source[0], document.uri, source[1]);
+      if (mdString !== undefined) {
+        const hover = new Hover(mdString);
+        resolve(hover);
+      }
+      this.telemetry.sendTelemetryEvent("provideSourceDefinition");
+    });
+  }
+
+  private onManifestCacheChanged(event: ManifestCacheChangedEvent): void {
+    event.added?.forEach((added) => {
+      this.sourceMetaMap.set(added.projectRoot.fsPath, added.sourceMetaMap);
+    });
+    event.removed?.forEach((removed) => {
+      this.sourceMetaMap.delete(removed.projectRoot.fsPath);
+    });
+  }
+
+  private getSourceHover(
+    sourceName: string,
+    currentFilePath: Uri,
+    tableName: string,
+  ): MarkdownString | undefined {
+    const projectRootpath =
+      this.dbtProjectContainer.getProjectRootpath(currentFilePath);
+    if (projectRootpath === undefined) {
+      return;
+    }
+    const sourceMap = this.sourceMetaMap.get(projectRootpath.fsPath);
+    if (sourceMap === undefined) {
+      return;
+    }
+    const node = sourceMap
+      .get(sourceName)
+      ?.tables.find((table) => table.name === tableName);
+    if (node) {
+      const content = new MarkdownString();
+      content.supportHtml = true;
+      content.isTrusted = true;
+      content.appendMarkdown(
+        `<span style="color:#347890;">(source)&nbsp;</span><span><strong>${node.name}</strong></span>`,
+      );
+      // if (node.description !== null) {
+      //   content.appendMarkdown(`</br><span>${node.description}</span>`);
+      // }
+      // content.appendText("\n");
+      // content.appendText("\n");
+      // content.appendMarkdown("---");
+      // content.appendText("\n");
+      // content.appendText("\n");
+      // for (const colKey in node.columns) {
+      //   const column = node.columns[colKey];
+      //   content.appendMarkdown(
+      //     `<br/><span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
+      //   );
+      //   if (column.data_type !== null) {
+      //     content.appendMarkdown(`<span>${column.data_type}&nbsp;</span>`);
+      //   }
+      //   if (column.description !== null) {
+      //     content.appendMarkdown(
+      //       `<br/><span><em>${column.description}</em></span>`,
+      //     );
+      //   }
+      // }
+      return content;
+    }
+    return undefined;
+  }
+}

--- a/src/hover_provider/sourceHoverProvider.ts
+++ b/src/hover_provider/sourceHoverProvider.ts
@@ -86,7 +86,7 @@ export class SourceHoverProvider implements HoverProvider, Disposable {
         const hover = new Hover(mdString);
         resolve(hover);
       }
-      this.telemetry.sendTelemetryEvent("provideSourceDefinition");
+      this.telemetry.sendTelemetryEvent("provideSourceHover");
     });
   }
 


### PR DESCRIPTION
## Overview
Starts to resolve #525
This is a real copy paste paint by numbers kind of job. I'm modeling all this code on how the definition provider is done. There is likely some code that is worth abstracting here and the hover itself isn't the prettiest but I thought this was a good start. Happy to keep iterating on this if folks want a more full featured version of this.

Additional features this could use:
1. Parse tests from the manifest for the refs so you can show tests
2. Parse descriptions/columns/types from sources
3. Do a macro hover provider too.
4. Better styling on the markdown

I tested this on a jaffle shop repo. Here are some screenshots:
![Screenshot 2023-09-16 at 2 46 54 PM](https://github.com/AltimateAI/vscode-dbt-power-user/assets/79863718/a7f67893-e7bc-4115-9e9b-8bce6cee7332)
![Screenshot 2023-09-16 at 2 46 58 PM](https://github.com/AltimateAI/vscode-dbt-power-user/assets/79863718/fbe73403-c487-4d14-98fa-c84ddcf2b40f)
![Screenshot 2023-09-16 at 2 47 02 PM](https://github.com/AltimateAI/vscode-dbt-power-user/assets/79863718/2c898fb1-ef6d-434e-90fe-1bf3eb39169a)

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
