### PR TITLE
Add descriptions and column metadata to the source metadata

### DIFF
--- a/src/domain.ts
+++ b/src/domain.ts
@@ -43,6 +43,8 @@ interface SourceMetaData {
 interface SourceTable {
   name: string;
   path: string;
+  description: string;
+  columns: { [columnName: string]: ColumnMetaData };
 }
 
 interface DocMetaData {

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -1,10 +1,13 @@
 import * as path from "path";
+import { MarkdownString } from "vscode";
 
 export type NodeMetaMap = Map<string, NodeMetaData>;
 export type MacroMetaMap = Map<string, MacroMetaData>;
 export type SourceMetaMap = Map<string, SourceMetaData>;
 export type TestMetaMap = Map<string, TestMetaData>;
 export type DocMetaMap = Map<string, DocMetaData>;
+export type NodeMetaType = NodeMetaData;
+export type SourceMetaType = SourceTable;
 
 interface MacroMetaData {
   path: string;
@@ -18,6 +21,7 @@ interface NodeMetaData {
   database: string;
   schema: string;
   alias: string;
+  name: string;
   package_name: string;
   description: string;
   patch_path: string;

--- a/src/hover_provider/modelHoverProvider.ts
+++ b/src/hover_provider/modelHoverProvider.ts
@@ -15,6 +15,7 @@ import { DBTProjectContainer } from "../manifest/dbtProjectContainer";
 import { ManifestCacheChangedEvent } from "../manifest/event/manifestCacheChangedEvent";
 import { provideSingleton } from "../utils";
 import { TelemetryService } from "../telemetry";
+import { GenerateHoverMarkdownString } from "./utils";
 
 @provideSingleton(ModelHoverProvider)
 export class ModelHoverProvider implements HoverProvider, Disposable {
@@ -123,38 +124,7 @@ export class ModelHoverProvider implements HoverProvider, Disposable {
     }
     const node = nodeMap.get(modelName);
     if (node) {
-      const content = new MarkdownString();
-      content.supportHtml = true;
-      content.isTrusted = true;
-      content.appendMarkdown(
-        `<span style="color:#347890;">(ref)&nbsp;</span><span><strong>${node.alias}</strong></span>`,
-      );
-      if (node.description !== "") {
-        content.appendMarkdown(`</br><span>${node.description}</span>`);
-      }
-      content.appendText("\n");
-      content.appendText("\n");
-      content.appendMarkdown("---");
-      content.appendText("\n");
-      content.appendText("\n");
-      for (const colKey in node.columns) {
-        const column = node.columns[colKey];
-        content.appendMarkdown(
-          `<span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
-        );
-        if (column.data_type !== null) {
-          content.appendMarkdown(
-            `<span>-&nbsp;${column.data_type.toUpperCase()}</span>`,
-          );
-        }
-        if (column.description !== "") {
-          content.appendMarkdown(
-            `<br/><span><em>${column.description}</em></span>`,
-          );
-        }
-        content.appendMarkdown("</br>");
-      }
-      return content;
+      return GenerateHoverMarkdownString(node, "ref");
     }
     return undefined;
   }

--- a/src/hover_provider/sourceHoverProvider.ts
+++ b/src/hover_provider/sourceHoverProvider.ts
@@ -18,6 +18,7 @@ import { DBTProjectContainer } from "../manifest/dbtProjectContainer";
 import { ManifestCacheChangedEvent } from "../manifest/event/manifestCacheChangedEvent";
 import { isEnclosedWithinCodeBlock, provideSingleton } from "../utils";
 import { TelemetryService } from "../telemetry";
+import { GenerateHoverMarkdownString } from "./utils";
 
 @provideSingleton(SourceHoverProvider)
 export class SourceHoverProvider implements HoverProvider, Disposable {
@@ -117,38 +118,7 @@ export class SourceHoverProvider implements HoverProvider, Disposable {
       .get(sourceName)
       ?.tables.find((table) => table.name === tableName);
     if (node) {
-      const content = new MarkdownString();
-      content.supportHtml = true;
-      content.isTrusted = true;
-      content.appendMarkdown(
-        `<span style="color:#347890;">(source)&nbsp;</span><span><strong>${node.name}</strong></span>`,
-      );
-      if (node.description !== "") {
-        content.appendMarkdown(`</br><span>${node.description}</span>`);
-      }
-      content.appendText("\n");
-      content.appendText("\n");
-      content.appendMarkdown("---");
-      content.appendText("\n");
-      content.appendText("\n");
-      for (const colKey in node.columns) {
-        const column = node.columns[colKey];
-        content.appendMarkdown(
-          `<span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
-        );
-        if (column.data_type !== null) {
-          content.appendMarkdown(
-            `<span>-&nbsp;${column.data_type.toUpperCase()}</span>`,
-          );
-        }
-        if (column.description !== "") {
-          content.appendMarkdown(
-            `<br/><span><em>${column.description}</em></span>`,
-          );
-        }
-        content.appendMarkdown("</br>");
-      }
-      return content;
+      return GenerateHoverMarkdownString(node, "source");
     }
     return undefined;
   }

--- a/src/hover_provider/sourceHoverProvider.ts
+++ b/src/hover_provider/sourceHoverProvider.ts
@@ -123,6 +123,31 @@ export class SourceHoverProvider implements HoverProvider, Disposable {
       content.appendMarkdown(
         `<span style="color:#347890;">(source)&nbsp;</span><span><strong>${node.name}</strong></span>`,
       );
+      if (node.description !== "") {
+        content.appendMarkdown(`</br><span>${node.description}</span>`);
+      }
+      content.appendText("\n");
+      content.appendText("\n");
+      content.appendMarkdown("---");
+      content.appendText("\n");
+      content.appendText("\n");
+      for (const colKey in node.columns) {
+        const column = node.columns[colKey];
+        content.appendMarkdown(
+          `<span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
+        );
+        if (column.data_type !== null) {
+          content.appendMarkdown(
+            `<span>-&nbsp;${column.data_type.toUpperCase()}</span>`,
+          );
+        }
+        if (column.description !== "") {
+          content.appendMarkdown(
+            `<br/><span><em>${column.description}</em></span>`,
+          );
+        }
+        content.appendMarkdown("</br>");
+      }
       return content;
     }
     return undefined;

--- a/src/hover_provider/utils.ts
+++ b/src/hover_provider/utils.ts
@@ -1,7 +1,7 @@
 import { MarkdownString } from "vscode";
 import { NodeMetaType, SourceMetaType } from "../domain";
 
-export function GenerateHoverMarkdownString(
+export function generateHoverMarkdownString(
   node: NodeMetaType | SourceMetaType,
   nodeType: string,
 ): MarkdownString {

--- a/src/hover_provider/utils.ts
+++ b/src/hover_provider/utils.ts
@@ -1,0 +1,40 @@
+import { MarkdownString } from "vscode";
+import { NodeMetaType, SourceMetaType } from "../domain";
+
+export function GenerateHoverMarkdownString(
+  node: NodeMetaType | SourceMetaType,
+  nodeType: string,
+): MarkdownString {
+  const content = new MarkdownString();
+  content.supportHtml = true;
+  content.isTrusted = true;
+  content.appendMarkdown(
+    `<span style="color:#347890;">(${nodeType})&nbsp;</span><span><strong>${node.name}</strong></span>`,
+  );
+  if (node.description !== "") {
+    content.appendMarkdown(`</br><span>${node.description}</span>`);
+  }
+  content.appendText("\n");
+  content.appendText("\n");
+  content.appendMarkdown("---");
+  content.appendText("\n");
+  content.appendText("\n");
+  for (const colKey in node.columns) {
+    const column = node.columns[colKey];
+    content.appendMarkdown(
+      `<span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
+    );
+    if (column.data_type !== null) {
+      content.appendMarkdown(
+        `<span>-&nbsp;${column.data_type.toUpperCase()}</span>`,
+      );
+    }
+    if (column.description !== "") {
+      content.appendMarkdown(
+        `<br/><span><em>${column.description}</em></span>`,
+      );
+    }
+    content.appendMarkdown("</br>");
+  }
+  return content;
+}

--- a/src/manifest/parsers/nodeParser.ts
+++ b/src/manifest/parsers/nodeParser.ts
@@ -50,6 +50,7 @@ export class NodeParser {
               database,
               schema,
               alias,
+              name,
               package_name,
               uniqueId: unique_id,
               columns,

--- a/src/manifest/parsers/sourceParser.ts
+++ b/src/manifest/parsers/sourceParser.ts
@@ -24,7 +24,14 @@ export class SourceParser {
         .reduce(
           (
             previousValue: SourceMetaMap,
-            { source_name, name, original_file_path, unique_id },
+            {
+              source_name,
+              name,
+              original_file_path,
+              unique_id,
+              description,
+              columns,
+            },
           ) => {
             let source = previousValue.get(source_name);
             if (!source) {
@@ -32,7 +39,12 @@ export class SourceParser {
               previousValue.set(source_name, source);
             }
             const fullPath = path.join(rootPath, original_file_path);
-            source.tables.push({ name, path: fullPath });
+            source.tables.push({
+              name,
+              path: fullPath,
+              description: description,
+              columns: columns,
+            });
             return previousValue;
           },
           sourceMetaMap,


### PR DESCRIPTION
## Overview
Resolves half of #594 

Parsing the descriptions and columns for sources and adding that info into the Hover provider for sources. I'm just pattern matching what is happening in the model parsing and it all lined up. 

Now the description and columns show up in the source hover box too:
![Screenshot 2023-09-23 at 10 03 59 AM](https://github.com/AltimateAI/vscode-dbt-power-user/assets/79863718/bb5a2d54-42df-46f0-8d97-2864b84a42be)

Macros has similar metadata (descriptions and even function arguments/types -- see [macro properties dbt docs](https://docs.getdbt.com/reference/macro-properties)) but even the most popular packages like dbt_utils don't fill out those properties. I think adding that would be a good follow up. It might encourage package developers to actually fill out the properties.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
