### PR TITLE
Adding an allow list configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can enable format on save for python by having the following values in your 
   }
 ```
 
-#### Configure `dbt.allowListFolders` (Optional)
+### Configure `dbt.allowListFolders` (Optional)
 
 To specify project folders explicitly and control which projects are included in the build process, you can configure the `dbt.allowListFolders` setting. This can be particularly useful when you have a large number of projects in the same workspace. You can define workspace-relative paths to include as follows:
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ You can enable format on save for python by having the following values in your 
   }
 ```
 
+#### Configure `dbt.allowListFolders` (Optional)
+
+To specify project folders explicitly and control which projects are included in the build process, you can configure the `dbt.allowListFolders` setting. This can be particularly useful when you have a large number of projects in the same workspace. You can define workspace-relative paths to include as follows:
+
+```json
+"dbt.allowListFolders": [
+  "folder1",
+  "folder2"
+]
+```
+
+If this setting is not specified or is left empty, no filtering will be applied, and all projects will be parsed.
+
 ### Telemetry
 
 Telemetry is used for error and usage reporting in order to make the extension better.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,14 @@
             "type": "string",
             "description": "Path to a python executable or entrypoint. If undefined, we will use the Python extension's configured environment. Most users will not need to change this setting without specific reasoning such as custom wrappers and should instead modify the Python extensions selected interpreter."
           },
+          "dbt.allowListFolders": {
+            "type": "array",
+            "items": {
+            "type": "string"
+            },
+            "default": [],
+            "description": "Define workspace-relative paths to include. Only projects within these folders will be built. If empty, no filtering is applied."
+          },
           "dbt.runModelCommandAdditionalParams": {
             "type": "array",
             "items": {

--- a/src/manifest/dbtWorkspaceFolder.ts
+++ b/src/manifest/dbtWorkspaceFolder.ts
@@ -65,7 +65,7 @@ export class DBTWorkspaceFolder implements Disposable {
       )
       // TODO: also filter out projects within the target folder of another project
       //  This is somewhat difficult as we would need to parse the target-path variable of the project.
-      .map((uri) => Uri.file(uri.path.split("/")!.slice(0, -1).join("/")))      ;
+      .map((uri) => Uri.file(uri.path.split("/")!.slice(0, -1).join("/")));
     if (projectFiles.length > 20) {
       window.showWarningMessage(
         `dbt Power User detected ${projectFiles.length} projects in your work space, this will negatively affect performance.`,

--- a/src/manifest/dbtWorkspaceFolder.ts
+++ b/src/manifest/dbtWorkspaceFolder.ts
@@ -52,12 +52,20 @@ export class DBTWorkspaceFolder implements Disposable {
         `**/{${DBTProject.DBT_MODULES.join(",")}}`,
       ),
     );
+    const allowListFolders = workspace
+      .getConfiguration("dbt")
+      .get<string[]>("allowListFolders", [])
+      .map((folder) => Uri.joinPath(Uri.file(this.workspaceFolder.uri.path), folder).fsPath);
+
     const projectFiles = dbtProjectFiles
       .filter((uri) => statSync(uri.fsPath).isFile())
       .filter((uri) => this.notInVenv(uri.fsPath))
+      .filter((uri) =>
+        allowListFolders.length === 0 || allowListFolders.some((folder) => uri.toString().includes(folder))
+      )
       // TODO: also filter out projects within the target folder of another project
       //  This is somewhat difficult as we would need to parse the target-path variable of the project.
-      .map((uri) => Uri.file(uri.path.split("/")!.slice(0, -1).join("/")));
+      .map((uri) => Uri.file(uri.path.split("/")!.slice(0, -1).join("/")))      ;
     if (projectFiles.length > 20) {
       window.showWarningMessage(
         `dbt Power User detected ${projectFiles.length} projects in your work space, this will negatively affect performance.`,


### PR DESCRIPTION
## Overview
Adds an optional folder allowlist configuration.

## Motivation
Introduce an 'allowlist' feature to enable users to specify project folders explicitly, ensuring that only projects within these folders are included in the build process. This provides greater control over project compilation and improves workspace performance by preventing the accidental compilation of unrelated projects.

## Issue
With our monorepo structure, we are unable to use the extension because it attempts to spin up several hundred projects at once causing device OOM's and reboots. Adding an allowlist will help us to specifically target the projects we work on.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [x] `README.md` updated and added information about my change
