### PR TITLE
Add custom dbt runner import

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ Avoid using the setting `dbt.dbtPythonPathOverride` unless using Meltano, the ex
 
 When you set the Python interpreter, the extension will try to detect dbt and you should be able to make use of the features listed below.
 
+### Select the custom dbtRunner.
+
+In case you want to use a custom runner. You can overwrite the import string for it.
+
+For an example, you have module `my_custom_runner`:
+```python
+from dbt.cli.main import dbtRunner
+
+class dbtCustomRunner(dbtRunner):
+    def invoke(self, *args, **kwargs):
+        print("Hello from overwritten runner!")
+        print("Staring invoke...")
+        return dbtRunner.invoke(self, *args, **kwargs)
+        print("Invoke finished!")
+```
+
+`dbt.dbtPythonPathOverride` = `from my_custom_runner import dbtCustomRunner as dbtRunner`
+
 ### Environment variables
 
 This extension supports environment variables in various ways;

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ class dbtCustomRunner(dbtRunner):
         print("Invoke finished!")
 ```
 
-`dbt.dbtPythonPathOverride` = `from my_custom_runner import dbtCustomRunner as dbtRunner`
+`dbt.dbtCustomRunnerImport` = `from my_custom_runner import dbtCustomRunner as dbtRunner`
 
 ### Environment variables
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
             "type": "string",
             "description": "Path to a python executable or entrypoint. If undefined, we will use the Python extension's configured environment. Most users will not need to change this setting without specific reasoning such as custom wrappers and should instead modify the Python extensions selected interpreter."
           },
+          "dbt.dbtCustomRunnerImport": {
+            "type": "string",
+            "description": "Python import string to import custom dbt runner. ",
+            "default": "from dbt.cli.main import dbtRunner"
+          },
           "dbt.allowListFolders": {
             "type": "array",
             "items": {

--- a/src/dbt_client/dbtCommandFactory.ts
+++ b/src/dbt_client/dbtCommandFactory.ts
@@ -219,9 +219,13 @@ export class DBTCommandFactory {
   }
 
   private dbtCommand(cmd: string | string[]): string {
+    // Lets pass through these params here too
+    const dbtCustomRunnerImport = workspace
+    .getConfiguration("dbt")
+    .get<string>("dbtCustomRunnerImport", "from dbt.cli.main import dbtRunner");
     return `has_dbt_runner = True
 try: 
-    from dbt.cli.main import dbtRunner
+    ${dbtCustomRunnerImport}
 except:
     has_dbt_runner = False
 if has_dbt_runner:


### PR DESCRIPTION
## Overview
Hi!

I am using the custom dbt runner for my dbt packages. I need some way to make it configurable. I want to try this approach:
1. Add a parameter containing a Python import row with the custom runner to settings. 
2. Use the parameter in the method that creates the dbt command(`dbtCommand`)

For an example, I have module `my_custom_runner`:

```
from dbt.cli.main import dbtRunner

class dbtCustomRunner(dbtRunner):
    def invoke(self, *args, **kwargs):
        print("Hello from overwritten runner!")
        print("Staring invoke...")
        return dbtRunner.invoke(self, *args, **kwargs)
        print("Invoke finished!")
```

`dbt.dbtCustomRunnerImport` = `from my_custom_runner import dbtCustomRunner as dbtRunner`

Then the extension will use the overwritten custom runner from my package.

  Example:
    resolves #565

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [x] `README.md` updated and added information about my change
