### PR TITLE
Pass changed document text to sqlfmt through stdin instead of file path

### DIFF
--- a/src/commandProcessExecution.ts
+++ b/src/commandProcessExecution.ts
@@ -52,7 +52,7 @@ export class CommandProcessExecution {
     }
   }
 
-  async complete(): Promise<string> {
+  async complete(stdin?: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       const commandProcess = this.spawn();
       let stdoutBuffer = "";
@@ -78,6 +78,11 @@ export class CommandProcessExecution {
         console.warn(error);
         reject(`${error}`);
       });
+
+      if (stdin) {
+        commandProcess.stdin.write(stdin);
+        commandProcess.stdin.end();
+      }
     });
   }
 

--- a/src/dbt_client/index.ts
+++ b/src/dbt_client/index.ts
@@ -160,13 +160,13 @@ export class DBTClient implements Disposable {
       );
     }
 
-    return this.commandProcessExecutionFactory.createCommandProcessExecution(
-      this.pythonEnvironment.pythonPath,
+    return this.commandProcessExecutionFactory.createCommandProcessExecution({
+      command: this.pythonEnvironment.pythonPath,
       args,
       cwd,
       token,
-      this.pythonEnvironment.environmentVariables,
-    );
+      envVars: this.pythonEnvironment.environmentVariables,
+    });
   }
 
   private raiseDBTNotInstalledEvent(): void {

--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -65,9 +65,14 @@ export class DbtDocumentFormattingEditProvider
         sqlFmtPath: sqlFmtPathSetting ? "setting" : "path",
       });
       try {
+        console.log(document.getText());
         await this.commandProcessExecutionFactory
-          .createCommandProcessExecution(sqlFmtPath, sqlFmtArgs)
-          .complete(document.getText());
+          .createCommandProcessExecution({
+            command: sqlFmtPath,
+            args: sqlFmtArgs,
+            stdin: document.getText(),
+          })
+          .complete();
         return [];
       } catch (diffOutput) {
         try {

--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -17,9 +17,6 @@ import {
   substituteSettingsVariables,
 } from "../utils";
 import { TelemetryService } from "../telemetry";
-import { readFileSync } from "fs";
-
-const channel = window.createOutputChannel("vscode-dbt-power-user");
 
 @provideSingleton(DbtDocumentFormattingEditProvider)
 export class DbtDocumentFormattingEditProvider
@@ -30,25 +27,12 @@ export class DbtDocumentFormattingEditProvider
     private telemetry: TelemetryService,
   ) {}
 
-  async provideDocumentFormattingEdits(
+  provideDocumentFormattingEdits(
     document: TextDocument,
     options: FormattingOptions,
     token: CancellationToken,
-  ): Promise<TextEdit[]> {
-    // channel.appendLine("executeSqlFmt");
-    // channel.appendLine(">----- new document -----<");
-    // channel.appendLine(document.getText());
-
-    // channel.appendLine(">----- file content -----<");
-    // channel.appendLine("path: " + document.uri.fsPath);
-    // const content = readFileSync(document.uri.fsPath);
-    // channel.appendLine("file content");
-    // channel.appendLine(content.toString());
-
-    const edit = await this.executeSqlFmt(document);
-    // channel.appendLine(JSON.stringify(edit));
-    // channel.appendLine("\n\n\n");
-    return edit;
+  ): ProviderResult<TextEdit[]> {
+    return this.executeSqlFmt(document);
   }
 
   private getSqlFmtPathSetting(): string | undefined {

--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -65,7 +65,6 @@ export class DbtDocumentFormattingEditProvider
         sqlFmtPath: sqlFmtPathSetting ? "setting" : "path",
       });
       try {
-        console.log(document.getText());
         await this.commandProcessExecutionFactory
           .createCommandProcessExecution({
             command: sqlFmtPath,


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234
-->

Slack: https://getdbt.slack.com/archives/C05KPDGRMDW/p1696953977216509

### Problem
With the formatOnSave option turned on, the first time I pressed save the file it doesn't get formatted but it does in the second save.

### Cause
The existing implementation passes the file path to `sqlfmt` rather than the changed content. Since the file is not yet saved when I hit the first save, `sqlfmt` reads the previous version of the file and no formatting occurs, and the unformatted new content is saved to the file. And when I hit the second save, finally the file gets formatted because `sqlfmt` now can read the unformatted content from the file.

### Solution
Pass modified content of the file to `sqlfmt` instead of the file path
- CommandProcessExecution.complete is extended to get a string and pass it into spawned process as stdin.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
