### PR TITLE
fix: add jinja-yaml alongside yaml lang selectors.

### DIFF
--- a/src/dbtPowerUserExtension.ts
+++ b/src/dbtPowerUserExtension.ts
@@ -19,7 +19,16 @@ export class DBTPowerUserExtension implements Disposable {
     { language: "jinja-sql", scheme: "file" },
     { language: "sql", scheme: "file" },
   ];
-  static DBT_YAML_SELECTOR = { language: "yaml", scheme: "file" };
+  static DBT_YAML_SELECTOR = [
+    { language: "yaml", scheme: "file" },
+    { language: "jinja-yaml", scheme: "file" },
+  ];
+  static DBT_YAML_SQL_SELECTOR = [
+    { language: "jinja-sql", scheme: "file" },
+    { language: "sql", scheme: "file" },
+    { language: "yaml", scheme: "file" },
+    { language: "jinja-yaml", scheme: "file" },
+  ];
 
   private disposables: Disposable[] = [];
 

--- a/src/definition_provider/index.ts
+++ b/src/definition_provider/index.ts
@@ -18,7 +18,7 @@ export class DefinitionProviders implements Disposable {
   ) {
     this.disposables.push(
       languages.registerDefinitionProvider(
-        DBTPowerUserExtension.DBT_SQL_SELECTOR,
+        DBTPowerUserExtension.DBT_YAML_SQL_SELECTOR,
         this.modelDefinitionProvider,
       ),
       languages.registerDefinitionProvider(
@@ -26,11 +26,11 @@ export class DefinitionProviders implements Disposable {
         this.macroDefinitionProvider,
       ),
       languages.registerDefinitionProvider(
-        DBTPowerUserExtension.DBT_SQL_SELECTOR,
+        DBTPowerUserExtension.DBT_YAML_SQL_SELECTOR,
         this.sourceDefinitionProvider,
       ),
       languages.registerDefinitionProvider(
-        DBTPowerUserExtension.DBT_YAML_SELECTOR,
+        DBTPowerUserExtension.DBT_YAML_SQL_SELECTOR,
         this.docDefinitionsProvider,
       ),
     );


### PR DESCRIPTION
this fixes the issue where doc source provider was not working for yaml's recognized as jinja-yaml. also should fix the issue where generate sources isnt appearing for some yaml (assuming they were also recognized as jinja-yaml)

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
