### PR TITLE
fix: windows style ending slash causes python error

### DIFF
--- a/src/dbt_client/dbtCommandFactory.ts
+++ b/src/dbt_client/dbtCommandFactory.ts
@@ -82,7 +82,7 @@ export class DBTCommandFactory {
         runModelCommandAdditionalParams.length > 0
           ? " " + runModelCommandAdditionalParams.join(" ")
           : ""
-      }`,
+      } ${profilesDirParams.join(" ")}`,
       statusMessage: "Running dbt models...",
       processExecutionParams: {
         cwd: projectRoot.fsPath,
@@ -221,8 +221,11 @@ export class DBTCommandFactory {
   private dbtCommand(cmd: string | string[]): string {
     // Lets pass through these params here too
     const dbtCustomRunnerImport = workspace
-    .getConfiguration("dbt")
-    .get<string>("dbtCustomRunnerImport", "from dbt.cli.main import dbtRunner");
+      .getConfiguration("dbt")
+      .get<string>(
+        "dbtCustomRunnerImport",
+        "from dbt.cli.main import dbtRunner",
+      );
     return `has_dbt_runner = True
 try: 
     ${dbtCustomRunnerImport}

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -136,6 +136,9 @@ export class DBTProject implements Disposable {
       this.PythonEnvironment.environmentVariables.DBT_PROFILES_DIR ||
       join(os.homedir(), ".dbt");
     this.dbtProfilesDir = this.dbtProfilesDir.replace("~", os.homedir());
+    // remove the trailing slashes if they exists,
+    // causes the quote to be escaped when passing to python
+    this.dbtProfilesDir = this.dbtProfilesDir.replace(/\\+$/, "");
     console.log("Using profile directory " + this.dbtProfilesDir);
     this.projectName = projectConfig.name;
     this.targetPath = this.findTargetPath(projectConfig);


### PR DESCRIPTION
 if profiles directory override has a trailing slash, that can act as an escape char (windows style paths eg: C:\Users\Username\.dbt\ )

additional housekeeping - update command string that gets displayed when running a dbt command.

resolves #639 

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
