### PR TITLE
fix: outputs panel colors and extra endlines

### DIFF
--- a/src/commandProcessExecution.ts
+++ b/src/commandProcessExecution.ts
@@ -128,6 +128,6 @@ export class CommandProcessExecution {
   }
 
   private formatText(text: string) {
-    return `\r${text.split(/(\r?\n)/g).join("\r")}\r`;
+    return `${text.split(/(\r?\n)+/g).join("\r")}`;
   }
 }

--- a/src/dbt_client/dbtTerminal.ts
+++ b/src/dbt_client/dbtTerminal.ts
@@ -1,5 +1,5 @@
 import { EventEmitter, Terminal, window } from "vscode";
-import { provideSingleton } from "../utils";
+import { provideSingleton, stripANSI } from "../utils";
 
 @provideSingleton(DBTTerminal)
 export class DBTTerminal {
@@ -15,7 +15,7 @@ export class DBTTerminal {
   }
 
   log(message: string) {
-    this.outputChannel.append(message);
+    this.outputChannel.append(stripANSI(message));
     if (this.terminal !== undefined) {
       this.writeEmitter.fire(message);
     }

--- a/src/manifest/modules/dbtProjectLog.ts
+++ b/src/manifest/modules/dbtProjectLog.ts
@@ -9,7 +9,7 @@ import {
   window,
   workspace,
 } from "vscode";
-import { provideSingleton, setupWatcherHandler } from "../../utils";
+import { provideSingleton, setupWatcherHandler, stripANSI } from "../../utils";
 import { ProjectConfigChangedEvent } from "../event/projectConfigChangedEvent";
 
 @provideSingleton(DBTProjectLogFactory)
@@ -93,7 +93,9 @@ export class DBTProjectLog implements Disposable {
             break;
           }
           this.logPosition += bytesRead;
-          this.outputChannel.appendLine(buffer.toString("utf8", 0, bytesRead));
+          this.outputChannel.appendLine(
+            stripANSI(buffer.toString("utf8", 0, bytesRead)),
+          );
         }
       } catch (error) {
         console.log("Could not read log file", error);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,3 +125,10 @@ export function extendErrorWithSupportLinks(error: string): string {
     "If the issue persists, please seek help in our dbt Community Slack channel [#tools-dbt-power-user](https://getdbt.slack.com/archives/C05KPDGRMDW) or report it on [GitHub](https://github.com/innoverio/vscode-dbt-power-user/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml)"
   );
 }
+
+export function stripANSI(src: string): string {
+  return src.replace(
+    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+    "",
+  );
+}


### PR DESCRIPTION
remove ansi colors added by dbt output.
The terminal seems to be able to render ansi colors but the outputs panels dont support custom ansi colors yet - only lang highlights. There are open issues in vscode github but does not look like they will incorporate the requests - so removing colors from the output lines for now.
also removing the additional endlines that appear in outputs panel. again, terminal seems to handle these extras well outputs looks like a basic log dump that renders everything. currently it is unusable with the weird chars and extra endlines so trying to fix that a bit.. adding images below:

new:
<img width="887" alt="image" src="https://github.com/AltimateAI/vscode-dbt-power-user/assets/1217072/4a7b54e4-24c2-4eca-9de2-9216d6558be7">

old:
<img width="907" alt="image" src="https://github.com/AltimateAI/vscode-dbt-power-user/assets/1217072/b53278a7-8745-4f5a-ac78-f50f93fc524d">


## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
