### PR TITLE
fix: showing columns even if ai not enabled

### DIFF
--- a/new_lineage_panel/src/CustomNodes.tsx
+++ b/new_lineage_panel/src/CustomNodes.tsx
@@ -18,7 +18,7 @@ import {
   processColumnLineage,
   resetTableHighlights,
 } from "./graph";
-import { LineageContext, aiEnabled, openFile, isDarkMode } from "./App";
+import { LineageContext, openFile, isDarkMode } from "./App";
 import { Table, downstreamTables, upstreamTables } from "./service";
 import {
   COLUMNS_SIDEBAR,
@@ -243,23 +243,20 @@ export const TableNode: FunctionComponent<NodeProps> = ({ data }) => {
               {processed[0] ? "-" : "+"}
             </div>
 
-            {aiEnabled && (
-              <div
-                className={classNames(
-                  "nodrag",
-                  selected ? "text-blue" : "text-grey"
-                )}
-                onClick={onDetailsClick}
-              >
-                View Details
-              </div>
-            )}
+            <div
+              className={classNames(
+                "nodrag",
+                selected ? "text-blue" : "text-grey"
+              )}
+              onClick={onDetailsClick}
+            >
+              View Details
+            </div>
 
             <div
               className={classNames("nodrag", styles.open_file_button)}
               onClick={() => openFile(url)}
             >
-              {!aiEnabled && <span className="text-blue">Open file</span>}
               {isDarkMode ? <FolderDarkIcon /> : <FolderIcon />}
             </div>
             <div className="spacer" />

--- a/new_lineage_panel/src/TableDetails.tsx
+++ b/new_lineage_panel/src/TableDetails.tsx
@@ -18,7 +18,12 @@ import {
   downstreamTables,
   Table,
 } from "./service";
-import { endProgressBar, LineageContext, startProgressBar } from "./App";
+import {
+  aiEnabled,
+  endProgressBar,
+  LineageContext,
+  startProgressBar,
+} from "./App";
 import {
   createNewNodesEdges,
   layoutElementsOnCanvas,
@@ -50,8 +55,11 @@ const ColumnCard: FunctionComponent<{
     <div
       className={classNames(styles.column_card, {
         [styles.selected]: selected,
+        ["cursor-pointer"]: aiEnabled,
       })}
-      onClick={handleClick}
+      onClick={() => {
+        if (aiEnabled) handleClick();
+      }}
     >
       <div className="d-flex align-items-center gap-xs">
         <ColumnDatatype datatype={column.datatype} />

--- a/new_lineage_panel/src/index.css
+++ b/new_lineage_panel/src/index.css
@@ -158,3 +158,7 @@ body {
   color: var(--input-placeholder-color) !important;
   opacity: 1 !important;
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/new_lineage_panel/src/styles.module.scss
+++ b/new_lineage_panel/src/styles.module.scss
@@ -100,7 +100,6 @@ $size: 1.2em;
   border-radius: 0.6em;
   padding: 0.8em;
   border: 1px solid var(--card-border-color);
-  cursor: pointer;
   background-color: var(--card-bg);
   &.selected {
     border-color: #e38e00;


### PR DESCRIPTION
## Overview
even if ai is disabled
- showing view details in table node 
- showing columns on clicking view details
- preventing click on column. If ai is enabled, then allowing click on column

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
