### PR TITLE
feat: allow users to change profiles.yml without having to reload window

### DIFF
--- a/dbt_integration.py
+++ b/dbt_integration.py
@@ -61,7 +61,6 @@ if TYPE_CHECKING:
     from dbt.adapters.base import BaseRelation  # type: ignore
     from dbt.contracts.connection import AdapterResponse
 
-
 Primitive = Union[bool, str, float, None]
 PrimitiveDict = Dict[str, Primitive]
 
@@ -234,8 +233,6 @@ class DbtProject:
             target_path=target_path,
         )
 
-        self.init_project()
-
         # Utilities
         self._sql_parser: Optional[SqlBlockParser] = None
         self._macro_parser: Optional[SqlMacroParser] = None
@@ -256,8 +253,10 @@ class DbtProject:
     def init_project(self):
         set_from_args(self.args, self.args)
         self.config = RuntimeConfig.from_args(self.args)
-        if hasattr(self, "adapter"):
-            self.adapter.cleanup_all()
+        # looks like the adapter do not follow the AdapterProtocol defined by dbt.
+        # both postgres and snowflake dont have a cleanup_all method defined.
+        # if hasattr(self, "adapter"):
+        #     self.adapter.cleanup_all()
         self.adapter = self.get_adapter()
         self.adapter.connections.set_connection_name()
         self.config.adapter = self.adapter

--- a/dbt_integration.py
+++ b/dbt_integration.py
@@ -245,7 +245,6 @@ class DbtProject:
         # Tracks internal state version
         self._version: int = 1
         self.mutex = threading.Lock()
-        # atexit.register(lambda dbt_project: dbt_project.adapter.connections.cleanup_all, self)
 
     def get_adapter(self):
         """This inits a new Adapter which is fundamentally different than
@@ -256,10 +255,6 @@ class DbtProject:
     def init_project(self):
         set_from_args(self.args, self.args)
         self.config = RuntimeConfig.from_args(self.args)
-        # looks like the adapter do not follow the AdapterProtocol defined by dbt.
-        # both postgres and snowflake dont have a cleanup_all method defined.
-        # if hasattr(self, "adapter"):
-        #     self.adapter.cleanup_all()
         self.adapter = self.get_adapter()
         self.adapter.connections.set_connection_name()
         self.config.adapter = self.adapter

--- a/dbt_integration.py
+++ b/dbt_integration.py
@@ -169,6 +169,9 @@ class ConfigInterface:
         self.profile = profile
         self.target_path = target_path
 
+    def __str__(self):
+        return f"ConfigInterface(threads={self.threads}, target={self.target}, profiles_dir={self.profiles_dir}, project_dir={self.project_dir}, profile={self.profile}, target_path={self.target_path})"
+
 
 class ManifestProxy(UserDict):
     """Proxy for manifest dictionary (`flat_graph`), if we need mutation then we should
@@ -348,7 +351,12 @@ class DbtProject:
 
     def safe_parse_project(self, reinit: bool = False) -> None:
         self.clear_caches()
-        _config_pointer = copy(self.config)
+        # doing this so that we can allow inits to fail when config is
+        # bad and restart after the user sets it up correctly
+        if hasattr(self, "config"):
+            _config_pointer = copy(self.config)
+        else:
+            _config_pointer = None
         try:
             self.parse_project(init=reinit)
             self.write_manifest_artifact()

--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -82,7 +82,7 @@ export class WalkthroughCommands {
       return;
     }
     const answer = await window.showInformationMessage(
-      `Do you want to validate the project: ${projectContext.label}? This will run the command 'dbt deps' inside this project. Do you want to continue?`,
+      `Do you want to install packages for the project: ${projectContext.label}? This will run the command 'dbt deps' inside this project. Do you want to continue?`,
       PromptAnswer.YES,
       PromptAnswer.NO,
     );

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -1001,7 +1001,9 @@ select * from renamed
           [
             new Diagnostic(
               new Range(0, 0, 999, 999),
-              "An error occured while initializing the dbt project, probably the Python interpreter is not correctly setup: " +
+              "An error occured while initializing the dbt project. \nan update to the profiles file was detected at: " +
+                this.dbtProfilesDir +
+                " . \nException details: " +
                 exc.exception.message,
             ),
           ],


### PR DESCRIPTION
fixes: #601 

Scenarios tested: 
- switch from a valid target to another valid target - in both cases project should reload the new credentials/adapter type as specified in the target.
- switch from an invalid target (project still loaded) to a valid one 
- switch from an invalid profile (project loaded without configs) to a valid profile and a valid target

Scenarios not tested (and probably not supported)
- switching to an adapter type that is not installed in the environment
- dbt was not installed before and now it is
- changing profiles root directory (either by using extension settings or using dbt defaults)

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
