### PR TITLE
fix: support dbt path resolver in multi root workspace.

### DIFF
--- a/src/dbt_client/index.ts
+++ b/src/dbt_client/index.ts
@@ -64,7 +64,7 @@ export class DBTClient implements Disposable {
   }
 
   async detectDBT(): Promise<void> {
-    await this.pythonEnvironment.initialize();
+    await this.pythonEnvironment.initialize(this);
     this.disposables.push(
       this.pythonEnvironment.onPythonEnvironmentChanged(() => {
         this.checkAllInstalled();

--- a/src/manifest/pythonEnvironment.ts
+++ b/src/manifest/pythonEnvironment.ts
@@ -1,10 +1,10 @@
-import { Disposable, Event, extensions, Uri, workspace } from "vscode";
+import { Disposable, Event, extensions, Uri, window, workspace } from "vscode";
 import { EnvironmentVariables } from "../domain";
 import { provideSingleton, substituteSettingsVariables } from "../utils";
 import { TelemetryService } from "../telemetry";
-import { PythonExtension } from "@vscode/python-extension";
-import * as path from "path";
-import * as fs from "fs";
+import { DBTClient } from "../dbt_client";
+import { CommandProcessExecutionFactory } from "../commandProcessExecution";
+import { DBTCommandFactory } from "../dbt_client/dbtCommandFactory";
 
 interface PythonExecutionDetails {
   getPythonPath: () => string;
@@ -17,7 +17,11 @@ export class PythonEnvironment implements Disposable {
   private executionDetails?: PythonExecutionDetails;
   private disposables: Disposable[] = [];
 
-  constructor(private telemetry: TelemetryService) {}
+  constructor(
+    private telemetry: TelemetryService,
+    private dbtCommandFactory: DBTCommandFactory,
+    private commandProcessExecutionFactory: CommandProcessExecutionFactory,
+  ) {}
 
   dispose() {
     while (this.disposables.length) {
@@ -42,12 +46,12 @@ export class PythonEnvironment implements Disposable {
     return this.executionDetails!.onDidChangeExecutionDetails;
   }
 
-  async initialize(): Promise<void> {
+  async initialize(client: DBTClient): Promise<void> {
     if (this.executionDetails !== undefined) {
       return;
     }
 
-    this.executionDetails = await this.activatePythonExtension();
+    this.executionDetails = await this.activatePythonExtension(client);
   }
 
   private getPythonPathFromConfig(): string | undefined {
@@ -70,7 +74,9 @@ export class PythonEnvironment implements Disposable {
     );
   };
 
-  private async activatePythonExtension(): Promise<PythonExecutionDetails> {
+  private async activatePythonExtension(
+    client: DBTClient,
+  ): Promise<PythonExecutionDetails> {
     const extension = extensions.getExtension("ms-python.python")!;
 
     if (!extension.isActive) {
@@ -80,25 +86,37 @@ export class PythonEnvironment implements Disposable {
 
     const api = extension.exports;
 
+    const dbtInstalledPythonPath: string[] = [];
+    for (const workspaceFolder of workspace.workspaceFolders || []) {
+      const candidatePythonPath = api.settings.getExecutionDetails(
+        workspaceFolder.uri,
+      ).execCommand[0];
+
+      const dbtInstalledCommand =
+        this.dbtCommandFactory.createVerifyDbtInstalledCommand();
+      const checkDBTInstalledProcess =
+        this.commandProcessExecutionFactory.createCommandProcessExecution({
+          command: candidatePythonPath,
+          args: dbtInstalledCommand.processExecutionParams.args,
+        });
+
+      try {
+        await checkDBTInstalledProcess.complete();
+      } catch {
+        continue;
+      }
+
+      dbtInstalledPythonPath.push(candidatePythonPath);
+    }
+
     return (this.executionDetails = {
       getPythonPath: () => {
-        const pythonPath: string = api.settings.getExecutionDetails(
-          workspace.workspaceFile,
-        ).execCommand[0];
-
-        if (!findDBTPath(pythonPath)) {
-          for (const workspaceFolder of workspace.workspaceFolders || []) {
-            const candidatePythonPath = api.settings.getExecutionDetails(
-              workspaceFolder.uri,
-            ).execCommand[0];
-
-            if (findDBTPath(candidatePythonPath)) {
-              return candidatePythonPath;
-            }
-          }
+        if (dbtInstalledPythonPath.length > 0) {
+          return dbtInstalledPythonPath[0];
+        } else {
+          return api.settings.getExecutionDetails(workspace.workspaceFile)
+            .execCommand[0];
         }
-
-        return pythonPath;
       },
       onDidChangeExecutionDetails: api.settings.onDidChangeExecutionDetails,
       getEnvVars: () => {
@@ -142,9 +160,4 @@ export class PythonEnvironment implements Disposable {
       },
     });
   }
-}
-
-function findDBTPath(pythonPath: string): boolean {
-  const dbtPath = path.join(path.dirname(pythonPath), "dbt");
-  return fs.existsSync(dbtPath);
 }


### PR DESCRIPTION
## Overview
In our project, we use [multi-root-workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces).

And we have installed `dbt` on 'dbt' workspace folder, not installed on workspace root.

In the current implementation, `dbt-power-user` searchs `dbt` of workspace root, so editor raises error in `dbt_project.yml`.

the error message of my editor is here:

<img width="887" alt="image" src="https://github.com/AltimateAI/vscode-dbt-power-user/assets/47286750/311f6d7f-f917-469a-8a9a-4f547416d3ba">

Ideally, I would like it to use the python paths in the current edit workspace folder, but this feature is too large, so I have changed the search logic to python environments when `dbt` is not installed in workspace root.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
