### PR TITLE
fix: throw error when query limit is not positive

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
           "dbt.queryLimit": {
             "type": "integer",
             "description": "The maximum number of rows the `Preview SQL Query` command returns.",
-            "default": 500
+            "default": 500,
+            "minimum": 1
           },
           "dbt.queryTemplate": {
             "type": "string",

--- a/query_panel/index.html
+++ b/query_panel/index.html
@@ -177,6 +177,9 @@
             <vscode-text-field v-model.number="limit" type="number"
               >Query Limit</vscode-text-field
             >
+            <div class="error-title" v-show="isQueryLimitValid">
+              Query limit should be positive value
+            </div>
             <br /><br />
             <label>Table Scale: {{ scale }}</label><br />
             <input

--- a/query_panel/main.js
+++ b/query_panel/main.js
@@ -406,6 +406,9 @@ const app = createApp({
         "javascript",
       );
     },
+    isQueryLimitValid() {
+      return this.limit <= 0;
+    },
   },
   watch: {
     async limit(limit) {

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -983,6 +983,10 @@ select * from renamed
       .getConfiguration("dbt")
       .get<number>("queryLimit", 500);
 
+    if (limit <= 0) {
+      window.showErrorMessage("Please enter a positive number for query limit");
+      return;
+    }
     const queryTemplate = workspace
       .getConfiguration("dbt")
       .get<string>(

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -166,7 +166,7 @@ export class QueryResultPanel implements WebviewViewProvider {
             break;
           case InboundCommand.UpdateConfig:
             const configMessage = message as RecConfig;
-            if (configMessage.limit) {
+            if (configMessage.limit !== undefined) {
               workspace
                 .getConfiguration("dbt")
                 .update("queryLimit", configMessage.limit);


### PR DESCRIPTION
## Overview
This PR throws error if users enters a 0 or negative value in the query limit, both in query panel and also extension settings

resolves: https://github.com/AltimateAI/vscode-dbt-power-user/issues/756

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
