### PR TITLE
fix: safe creation of packages path

### DIFF
--- a/dbt_integration.py
+++ b/dbt_integration.py
@@ -83,8 +83,6 @@ JINJA_CONTROL_SEQS = ["{{", "}}", "{%", "%}", "{#", "#}"]
 
 T = TypeVar("T")
 
-ALTIMATE_PACKAGE_PATH = f"{os.path.dirname(os.path.abspath(__file__))}/altimate_packages"
-
 
 @contextlib.contextmanager
 def add_path(path):
@@ -101,6 +99,9 @@ def validate_sql(
     models: List[Dict],
 ):
     try:
+        ALTIMATE_PACKAGE_PATH = (
+            f"{os.path.dirname(os.path.abspath(__file__))}/altimate_packages"
+        )
         with add_path(ALTIMATE_PACKAGE_PATH):
             from altimate.validate_sql import validate_sql_from_models
 

--- a/dbt_integration.py
+++ b/dbt_integration.py
@@ -99,8 +99,9 @@ def validate_sql(
     models: List[Dict],
 ):
     try:
-        ALTIMATE_PACKAGE_PATH = (
-            f"{os.path.dirname(os.path.abspath(__file__))}/altimate_packages"
+        ALTIMATE_PACKAGE_PATH = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "altimate_packages"
         )
         with add_path(ALTIMATE_PACKAGE_PATH):
             from altimate.validate_sql import validate_sql_from_models


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234
-->

We are seeing exceptions related to loading of the ALTIMATE_PACKAGES_PATH. To resolve, we are moving it inside the function where the contextmanager loads it. It is wrapped in a try catch block so even if it fails other functionalities are not affected

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
