### PR TITLE
feat: defer to prod and insights panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,32 @@
             },
             "default": [],
             "description": "Add additional params to `sqlfmt`"
+          },
+          "dbt.deferConfigPerProject": {
+            "type": "object",
+            "description": "Run subset of models without building their parent models",
+            "patternProperties": {
+              ".*": {
+                "type": "object",
+                "properties": {
+                  "deferToProduction": {
+                    "type": "boolean",
+                    "description": "Run subset of models without building their parent models",
+                    "default": false
+                  },
+                  "manifestPathForDeferral": {
+                    "type": "string",
+                    "description": "Manifest path to defer the parent models",
+                    "default": ""
+                  },
+                  "favorState": {
+                    "type": "boolean",
+                    "description": "If a given model exists in both the current environment and the defined defer state, turn this flag on to use the latter always",
+                    "default": false
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -201,6 +227,11 @@
         {
           "id": "docs_edit_view",
           "title": "Documentation Editor",
+          "icon": "./media/images/dbt_icon.svg"
+        },
+        {
+          "id": "insights_view",
+          "title": "Insights",
           "icon": "./media/images/dbt_icon.svg"
         }
       ]
@@ -256,12 +287,23 @@
           "name": "",
           "icon": "./media/images/dbt_icon.svg"
         }
+      ],
+      "insights_view": [
+        {
+          "id": "dbtPowerUser.Insights",
+          "name": "",
+          "type": "webview"
+        }
       ]
     },
     "commands": [
       {
         "command": "dbtPowerUser.puQuickPick",
         "title": "dbt Power User Quick Pick"
+      },
+      {
+        "command": "dbtPowerUser.openInsights",
+        "title": "Open dbt Power User insights panel"
       },
       {
         "command": "dbtPowerUser.sqlQuickPick",

--- a/src/commands/bigQueryCostEstimate.ts
+++ b/src/commands/bigQueryCostEstimate.ts
@@ -14,12 +14,14 @@ export class BigQueryCostEstimate {
     private telemetry: TelemetryService,
   ) {}
 
-  async estimateCost() {
+  async estimateCost({ returnResult }: { returnResult?: boolean }) {
     const modelName = path.basename(
       window.activeTextEditor!.document.fileName,
       ".sql",
     );
-    this.dbtTerminal.show(true);
+    if (!returnResult) {
+      this.dbtTerminal.show(true);
+    }
     try {
       const query = window.activeTextEditor?.document.getText();
       if (!query) {
@@ -42,6 +44,9 @@ export class BigQueryCostEstimate {
       this.dbtTerminal.log(
         `The query for ${modelName} will process ${result.bytes_processed}.\r\n`,
       );
+      if (returnResult) {
+        return { modelName, result };
+      }
     } catch (error) {
       if (error instanceof PythonException) {
         window.showErrorMessage(

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -52,8 +52,10 @@ export class VSCodeCommands implements Disposable {
       commands.registerCommand("dbtPowerUser.compileCurrentModel", () =>
         this.runModel.compileModelOnActiveWindow(),
       ),
-      commands.registerCommand("dbtPowerUser.bigqueryCostEstimate", () =>
-        this.bigQueryCostEstimate.estimateCost(),
+      commands.registerCommand(
+        "dbtPowerUser.bigqueryCostEstimate",
+        ({ returnResult }: { returnResult?: boolean }) =>
+          this.bigQueryCostEstimate.estimateCost({ returnResult }),
       ),
       commands.registerTextEditorCommand(
         "dbtPowerUser.sqlPreview",

--- a/src/dbt_client/dbtCommandUtils.ts
+++ b/src/dbt_client/dbtCommandUtils.ts
@@ -1,0 +1,33 @@
+import { Uri, workspace } from "vscode";
+import { getProjectRelativePath } from "../utils";
+
+interface DeferConfig {
+  deferToProduction: boolean;
+  favorState: boolean;
+  manifestPathForDeferral: string;
+}
+
+export const getDeferParams = async (projectRoot: Uri): Promise<string[]> => {
+  const currentConfig: Record<string, DeferConfig> = await workspace
+    .getConfiguration("dbt")
+    .get("deferConfigPerProject", {});
+  const deferConfigInProject =
+    currentConfig[getProjectRelativePath(projectRoot)];
+  if (!deferConfigInProject) {
+    return [];
+  }
+  const { deferToProduction, manifestPathForDeferral, favorState } =
+    deferConfigInProject;
+  if (!deferToProduction) {
+    return [];
+  }
+  if (!manifestPathForDeferral) {
+    return [];
+  }
+  return [
+    "--defer",
+    "--state",
+    manifestPathForDeferral,
+    favorState ? "--favor-state" : "",
+  ];
+};

--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -37,6 +37,7 @@ import { join } from "path";
 import { TelemetryService } from "../telemetry";
 import { ValidateSqlParseErrorResponse } from "../altimate";
 import { DBTProjectContainer } from "../manifest/dbtProjectContainer";
+import { getDeferParams } from "./dbtCommandUtils";
 
 // TODO: we shouold really get these from manifest directly
 interface ResolveReferenceNodeResult {
@@ -362,19 +363,27 @@ export class DBTCoreProjectIntegration
   }
 
   async runModel(command: DBTCommand) {
-    this.addCommandToQueue(this.dbtCoreCommand(command));
+    this.addCommandToQueue(
+      await this.addDeferParams(this.dbtCoreCommand(command)),
+    );
   }
 
   async buildModel(command: DBTCommand) {
-    this.addCommandToQueue(this.dbtCoreCommand(command));
+    this.addCommandToQueue(
+      await this.addDeferParams(this.dbtCoreCommand(command)),
+    );
   }
 
   async runTest(command: DBTCommand) {
-    this.addCommandToQueue(this.dbtCoreCommand(command));
+    this.addCommandToQueue(
+      await this.addDeferParams(this.dbtCoreCommand(command)),
+    );
   }
 
   async runModelTest(command: DBTCommand) {
-    this.addCommandToQueue(this.dbtCoreCommand(command));
+    this.addCommandToQueue(
+      await this.addDeferParams(this.dbtCoreCommand(command)),
+    );
   }
 
   async compileModel(command: DBTCommand) {
@@ -400,6 +409,12 @@ export class DBTCoreProjectIntegration
       return;
     }
     this.executionInfrastructure.addCommandToQueue(command);
+  }
+
+  private async addDeferParams(command: DBTCommand) {
+    const deferParams = await getDeferParams(this.projectRoot);
+    deferParams.forEach((param) => command.addArgument(param));
+    return command;
   }
 
   private dbtCoreCommand(command: DBTCommand) {

--- a/src/quickpick/index.ts
+++ b/src/quickpick/index.ts
@@ -18,6 +18,9 @@ export class DbtPowerUserActionsCenter implements Disposable {
     commands.registerCommand("dbtPowerUser.puQuickPick", async () => {
       await this.puLaunchQuickPick.openPuQuickPick();
     });
+    commands.registerCommand("dbtPowerUser.openInsights", async () => {
+      await commands.executeCommand("dbtPowerUser.Insights.focus");
+    });
     commands.registerCommand("dbtPowerUser.sqlQuickPick", async () => {
       await this.sqlQuickPick.openQuickPick();
     });

--- a/src/statusbar/deferToProductionStatusBar.ts
+++ b/src/statusbar/deferToProductionStatusBar.ts
@@ -1,0 +1,41 @@
+import {
+  StatusBarItem,
+  StatusBarAlignment,
+  window,
+  Disposable,
+  Command,
+} from "vscode";
+import { provideSingleton } from "../utils";
+
+@provideSingleton(DeferToProductionStatusBar)
+export class DeferToProductionStatusBar implements Disposable {
+  readonly statusBar: StatusBarItem = window.createStatusBarItem(
+    StatusBarAlignment.Left,
+    9,
+  );
+  private defaultColor: string = "statusBarItem.activeBackground";
+  private disposables: Disposable[] = [];
+
+  constructor() {
+    this.showTextInStatusBar("$(sync) Defer");
+  }
+
+  dispose() {
+    while (this.disposables.length) {
+      const x = this.disposables.pop();
+      if (x) {
+        x.dispose();
+      }
+    }
+    this.statusBar.dispose();
+  }
+
+  private showTextInStatusBar(text: string) {
+    this.statusBar.text = text;
+    this.statusBar.command = {
+      title: "Open Insights Panel",
+      command: "dbtPowerUser.openInsights",
+    };
+    this.statusBar.show();
+  }
+}

--- a/src/statusbar/index.ts
+++ b/src/statusbar/index.ts
@@ -1,13 +1,18 @@
 import { Disposable } from "vscode";
 import { provideSingleton } from "../utils";
 import { VersionStatusBar } from "./versionStatusBar";
+import { DeferToProductionStatusBar } from "./deferToProductionStatusBar";
 
 @provideSingleton(StatusBars)
 export class StatusBars implements Disposable {
   private disposables: Disposable[] = [];
 
-  constructor(private dbtStatusBar: VersionStatusBar) {
+  constructor(
+    private dbtStatusBar: VersionStatusBar,
+    private deferToProductionStatusBar: DeferToProductionStatusBar,
+  ) {
     this.disposables.push(this.dbtStatusBar);
+    this.disposables.push(this.deferToProductionStatusBar);
   }
 
   dispose() {

--- a/src/webview_provider/altimateWebviewProvider.ts
+++ b/src/webview_provider/altimateWebviewProvider.ts
@@ -24,7 +24,7 @@ import {
 import { AltimateRequest } from "../altimate";
 import { SharedStateService } from "../services/SharedStateService";
 
-type UpdateConfigProps = {
+export type UpdateConfigProps = {
   key: string;
   value: string | boolean | number;
   isPreviewFeature?: boolean;

--- a/src/webview_provider/index.ts
+++ b/src/webview_provider/index.ts
@@ -4,6 +4,7 @@ import { QueryResultPanel } from "./queryResultPanel";
 import { DocsEditViewPanel } from "./docsEditPanel";
 import { LineagePanel } from "./lineagePanel";
 import { DataPilotPanel } from "./datapilotPanel";
+import { InsightsPanel } from "./insightsPanel";
 
 @provideSingleton(WebviewViewProviders)
 export class WebviewViewProviders implements Disposable {
@@ -14,6 +15,7 @@ export class WebviewViewProviders implements Disposable {
     private docsEditPanel: DocsEditViewPanel,
     private lineagePanel: LineagePanel,
     private dataPilotPanel: DataPilotPanel,
+    private insightsPanel: InsightsPanel,
   ) {
     this.disposables.push(
       window.registerWebviewViewProvider(
@@ -34,6 +36,11 @@ export class WebviewViewProviders implements Disposable {
       window.registerWebviewViewProvider(
         DataPilotPanel.viewType,
         this.dataPilotPanel,
+        { webviewOptions: { retainContextWhenHidden: true } },
+      ),
+      window.registerWebviewViewProvider(
+        InsightsPanel.viewType,
+        this.insightsPanel,
         { webviewOptions: { retainContextWhenHidden: true } },
       ),
     );

--- a/src/webview_provider/insightsPanel.ts
+++ b/src/webview_provider/insightsPanel.ts
@@ -1,0 +1,169 @@
+import { commands, TextEditor, window, workspace } from "vscode";
+import { getProjectRelativePath, provideSingleton } from "../utils";
+import { DBTProjectContainer } from "../manifest/dbtProjectContainer";
+import { DBTProject } from "../manifest/dbtProject";
+import { TelemetryService } from "../telemetry";
+import {
+  AltimateWebviewProvider,
+  HandleCommandProps,
+  UpdateConfigProps,
+} from "./altimateWebviewProvider";
+import { AltimateRequest } from "../altimate";
+import { SharedStateService } from "../services/SharedStateService";
+
+interface DeferConfig {
+  deferToProduction: boolean;
+  favorState: boolean;
+  manifestPathForDeferral: string;
+}
+@provideSingleton(InsightsPanel)
+export class InsightsPanel extends AltimateWebviewProvider {
+  public static readonly viewType = "dbtPowerUser.Insights";
+  protected viewPath = "/insights";
+  protected panelDescription = "Toggle Defer to prod and other features";
+
+  public constructor(
+    dbtProjectContainer: DBTProjectContainer,
+    protected altimateRequest: AltimateRequest,
+    telemetry: TelemetryService,
+    protected emitterService: SharedStateService,
+  ) {
+    super(dbtProjectContainer, altimateRequest, telemetry, emitterService);
+
+    window.onDidChangeActiveTextEditor(
+      async (event: TextEditor | undefined) => {
+        if (event === undefined) {
+          return;
+        }
+
+        if (this._panel) {
+          const currentProjectRoot = await this.getCurrentProjectRoot();
+          const currentConfig: Record<string, DeferConfig> = await workspace
+            .getConfiguration("dbt")
+            .get("deferConfigPerProject", {});
+
+          this._panel!.webview.postMessage({
+            command: "updateDeferConfig",
+            args: currentConfig[currentProjectRoot] || {},
+          });
+        }
+      },
+    );
+  }
+
+  private async getCurrentProjectRoot() {
+    const currentFilePath = window.activeTextEditor?.document.uri;
+    if (!currentFilePath) {
+      throw new Error("Invalid current file");
+    }
+
+    const currentProject =
+      this.dbtProjectContainer.findDBTProject(currentFilePath);
+    if (!currentProject?.projectRoot) {
+      throw new Error("Invalid current project root");
+    }
+
+    return getProjectRelativePath(currentProject.projectRoot);
+  }
+  private async updateDeferConfig(
+    syncRequestId: string | undefined,
+    params: UpdateConfigProps,
+  ) {
+    try {
+      console.log("Updating defer config", params);
+      // defer config is preview feature, then check keys
+      if (!this.altimateRequest.handlePreviewFeatures()) {
+        throw new Error("Invalid credentials");
+      }
+
+      const currentConfig: Record<string, DeferConfig> = await workspace
+        .getConfiguration("dbt")
+        .get("deferConfigPerProject", {});
+      const root = await this.getCurrentProjectRoot();
+      const newConfig = {
+        ...currentConfig,
+        [root]: {
+          ...currentConfig[root],
+          [params.key]: params.value,
+        },
+      };
+      await workspace
+        .getConfiguration("dbt")
+        .update("deferConfigPerProject", newConfig);
+
+      if (syncRequestId) {
+        this._panel!.webview.postMessage({
+          command: "response",
+          args: {
+            syncRequestId,
+            body: {
+              updated: true,
+            },
+            status: true,
+          },
+        });
+      }
+    } catch (err) {
+      console.info("could not update defer config", (err as Error).message);
+      this._panel!.webview.postMessage({
+        command: "response",
+        args: {
+          syncRequestId,
+          body: {
+            updated: false,
+          },
+          status: false,
+        },
+      });
+    }
+  }
+
+  async handleCommand(message: HandleCommandProps): Promise<void> {
+    const { command, syncRequestId, ...params } = message;
+
+    switch (command) {
+      case "updateDeferConfig":
+        await this.updateDeferConfig(
+          syncRequestId,
+          params as UpdateConfigProps,
+        );
+        break;
+      case "bigqueryCostEstimate":
+        console.log("insights_panel:handleCommand -> bigqueryCostEstimate");
+        const result = await commands.executeCommand(
+          "dbtPowerUser.bigqueryCostEstimate",
+          { returnResult: true },
+        );
+
+        this._panel!.webview.postMessage({
+          command: "response",
+          args: { syncRequestId, body: result, status: true },
+        });
+        break;
+      case "altimateScan":
+        commands.executeCommand("dbtPowerUser.altimateScan", {});
+        break;
+      case "clearAltimateScanResults":
+        commands.executeCommand("dbtPowerUser.clearAltimateScanResults", {});
+        break;
+      case "getDeferToProductionConfig":
+        const currentProjectRoot = await this.getCurrentProjectRoot();
+        const currentConfig: Record<string, DeferConfig> = await workspace
+          .getConfiguration("dbt")
+          .get("deferConfigPerProject", {});
+
+        this._panel!.webview.postMessage({
+          command: "response",
+          args: {
+            syncRequestId,
+            body: currentConfig[currentProjectRoot],
+            status: true,
+          },
+        });
+        break;
+      default:
+        super.handleCommand(message);
+        break;
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Original PR: https://github.com/AltimateAI/vscode-dbt-power-user/pull/797/files

Implements defer to prod feature and 2 other modules
- added config `deferConfigPerProject` with 3 sub configs `deferToProduction, favorState, manifestPathForDeferral` for storing the defer state per project and applying the same while running dbt commands listed below
- Bigquery cost estimate module
- Project health checker

#### Defer
- added the extra parameters (if provided by user in insights panel) to the following commands
     - build
     - run
     - test
     - testModel
     
#### Pending 
- [ ] We should also add a new action to "build project" in the run button dropdown. That way they can run the project with defer prod with cost saving
- [ ] verify the defer config save in projects which is added to workspace with multiple projects from different directories
- [ ] if above line item is not working, then we need to add a parameter to dbtProject that refers to the workspace where it has been found in
- [x] Bigquery cost estimate results to show up in right side of insights panel (@saravmajestic have to do this, just need to copy the changes before the refactor PR merge)

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
