### PR TITLE
fix: sync columns before generate all in new doc editor

### DIFF
--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -300,6 +300,18 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                     };
                   });
                   this.transmitColumns(columns);
+                  if (syncRequestId) {
+                    this._panel!.webview.postMessage({
+                      command: "response",
+                      args: {
+                        syncRequestId,
+                        body: {
+                          columns,
+                        },
+                        status: true,
+                      },
+                    });
+                  }
                 } catch (exc) {
                   this.transmitError();
                   if (exc instanceof PythonException) {
@@ -321,6 +333,16 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                     "docsEditPanelLoadError",
                     exc,
                   );
+                  if (syncRequestId) {
+                    this._panel!.webview.postMessage({
+                      command: "response",
+                      args: {
+                        syncRequestId,
+                        body: {},
+                        status: false,
+                      },
+                    });
+                  }
                 }
               },
             );

--- a/webview_panels/src/modules/dataPilot/components/NewGenerationResults.tsx
+++ b/webview_panels/src/modules/dataPilot/components/NewGenerationResults.tsx
@@ -92,9 +92,7 @@ const NewGenerationResults = ({
                 <AltimateIcon /> {result.datapilot_title}
               </CardTitle>
               <CardBody>
-                <Stack data-testid="generated-description">
-                  {result.description}
-                </Stack>
+                {result.description}
                 <Stack className={classes.actionButtons}>
                   <Stack>
                     <Button

--- a/webview_panels/src/modules/dataPilot/components/NewGenerationResults.tsx
+++ b/webview_panels/src/modules/dataPilot/components/NewGenerationResults.tsx
@@ -92,7 +92,9 @@ const NewGenerationResults = ({
                 <AltimateIcon /> {result.datapilot_title}
               </CardTitle>
               <CardBody>
-                {result.description}
+                <Stack data-testid="generated-description">
+                  {result.description}
+                </Stack>
                 <Stack className={classes.actionButtons}>
                   <Stack>
                     <Button

--- a/webview_panels/src/modules/documentationEditor/components/docGenerator/BulkGenerateButton.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/docGenerator/BulkGenerateButton.tsx
@@ -65,7 +65,6 @@ const BulkGenerateButton = () => {
     } catch (err) {
       panelLogger.error("Unable to generate docs for all columns");
     }
-    return null;
   };
 
   const sendTelemetryEvent = (

--- a/webview_panels/src/modules/documentationEditor/components/docGenerator/BulkGenerateButton.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/docGenerator/BulkGenerateButton.tsx
@@ -55,10 +55,17 @@ const BulkGenerateButton = () => {
     return bulkGenerateDocs(columnsWithoutDescription);
   };
   const generateForAll = async () => {
-    if (!currentDocsData) {
-      return;
+    try {
+      const { columns } = (await executeRequestInSync(
+        "fetchMetadataFromDatabase",
+        {},
+      )) as { columns: DBTDocumentationColumn[] };
+
+      return await bulkGenerateDocs(columns);
+    } catch (err) {
+      panelLogger.error("Unable to generate docs for all columns");
     }
-    return bulkGenerateDocs(currentDocsData.columns);
+    return null;
   };
 
   const sendTelemetryEvent = (

--- a/webview_panels/src/uiCore/theme.scss
+++ b/webview_panels/src/uiCore/theme.scss
@@ -72,6 +72,10 @@ html {
     color: var(--text-color--title);
     box-shadow: none;
   }
+
+  &::placeholder{
+    color: var(--text-color--caption);
+  }
 }
 
 input.form-control {


### PR DESCRIPTION
## Overview
Fix for: https://altimateai.atlassian.net/browse/AI-1514
- When user requests to generate docs for all columns, sync with db first and then generate with new columns
- also fixed minor css issue to show proper color for input/textarea placeholder text

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
