### PR TITLE
fix: use float instead of int in query results to avoid overflow

### DIFF
--- a/query_panel/main.js
+++ b/query_panel/main.js
@@ -69,7 +69,7 @@ class Grid {
     await this.elem.load(table);
     await this.elem.restore({
       columns: [], // reset columns
-      settings: false,
+      settings: true,
       title: "query result",
       plugin_config: { editable: false },
     });

--- a/query_panel/main.js
+++ b/query_panel/main.js
@@ -30,6 +30,8 @@ class Grid {
         float: {
           format: {
             maximumFractionDigits: 20,
+            minimumFractionDigits: 0,
+            useGrouping: false,
           },
         },
       },
@@ -42,7 +44,7 @@ class Grid {
       case "Text":
         return "string";
       case "Integer":
-        return "integer";
+        return "float";
       // case "Boolean":
       //   return "boolean"; // TODO: uncomment when material icons are added
       // case "Date":
@@ -67,7 +69,7 @@ class Grid {
     await this.elem.load(table);
     await this.elem.restore({
       columns: [], // reset columns
-      settings: true,
+      settings: false,
       title: "query result",
       plugin_config: { editable: false },
     });


### PR DESCRIPTION
## Overview
- Fixes integer overflow in query results panel new UI
- perspective.js does not handle int64 and workaround suggested is to convert the int to float and use without precision. https://github.com/finos/perspective/issues/1346
- So for any integer type in schema, we will use float type with 0 precision digits and without grouping to avoid thousands separator

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
