### PR TITLE
fix: add logging with extra args

### DIFF
--- a/src/dbt_client/dbtTerminal.ts
+++ b/src/dbt_client/dbtTerminal.ts
@@ -21,8 +21,8 @@ export class DBTTerminal {
     }
   }
 
-  log(message: string) {
-    this.outputChannel.info(stripANSI(message));
+  log(message: string, ...args: any[]) {
+    this.outputChannel.info(stripANSI(message), args);
     if (this.terminal !== undefined) {
       this.writeEmitter.fire(message);
     }
@@ -33,32 +33,37 @@ export class DBTTerminal {
     console.log(message);
   }
 
-  debug(message: string) {
-    this.outputChannel?.debug(stripANSI(message));
-    console.debug(message);
+  debug(message: string, ...args: any[]) {
+    this.outputChannel?.debug(stripANSI(message), args);
+    console.debug(message, args);
   }
 
-  info(name: string, message: string, sendTelemetry: boolean = true) {
-    this.outputChannel?.info(stripANSI(message));
-    console.info(`${name}:${message}`);
+  info(
+    name: string,
+    message: string,
+    sendTelemetry: boolean = true,
+    ...args: any[]
+  ) {
+    this.outputChannel?.info(stripANSI(message), args);
+    console.info(`${name}:${message}`, args);
     if (sendTelemetry) {
       this.telemetry.sendTelemetryEvent(name, { message });
     }
   }
 
-  warn(e: CustomException, sendTelemetry: boolean = true) {
+  warn(e: CustomException, sendTelemetry: boolean = true, ...args: any[]) {
     const message = e.getMessage();
-    this.outputChannel?.warn(stripANSI(message));
-    console.warn(`${e.name}:${message}`);
+    this.outputChannel?.warn(stripANSI(message), args);
+    console.warn(`${e.name}:${message}`, args);
     if (sendTelemetry) {
       this.telemetry.sendTelemetryError(e.name, e.error, { message });
     }
   }
 
-  error(e: CustomException, sendTelemetry = true) {
+  error(e: CustomException, sendTelemetry = true, ...args: any[]) {
     const message = e.getMessage();
-    this.outputChannel?.error(stripANSI(message));
-    console.error(`${e.name}:${message}`);
+    this.outputChannel?.error(stripANSI(message), args);
+    console.error(`${e.name}:${message}`, args);
     if (sendTelemetry) {
       this.telemetry.sendTelemetryError(e.name, e.error, { message });
     }


### PR DESCRIPTION
## Overview
Problem: In the current logging service, if we need to pass extra arguments/meta data for logs, use JSON.stringify and add to the log message. This will be difficult to read and parse later.

Solution: Use the same parameters as outputChannel to accept arbitrary array of data and write to channel.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
