### PR TITLE
fix: make horizontal scrollbar visible in query panel

### DIFF
--- a/query_panel/style.css
+++ b/query_panel/style.css
@@ -143,3 +143,7 @@ th {
 .flex-column {
   flex-direction: column;
 }
+
+regular-table::-webkit-scrollbar-thumb {
+  border-width: 2px;
+}


### PR DESCRIPTION
## Overview
### Problem
Horizontal scrollbar in query results panel is not visible and make it harder to see the columns out of viewport

### Solution
Horizontal scrollbar is already available in perspective viewer table but the height is limited by the border. In this PR, border width is reduced to make the scrollbar more prominent

### How to verify
- open query results panel and run a query which can return more columns in result
- horizontal scrollbar should be visible as in screenshot and user should be able to scroll

### Screenshot/demo
![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/c44a68b4-e829-4afd-974e-ad7b46df8ef0)

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
