### PR TITLE
fix: wrong formatting (#856)

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -110,7 +110,26 @@ export class DbtDocumentFormattingEditProvider
     const textEdits: TextEdit[] = [];
     const diffs = parseDiff(diffOutput);
     diffs.forEach((diff) => {
+      let lastChunk: parseDiff.Chunk;
       diff.chunks.forEach((chunk) => {
+        if (lastChunk) {
+          // Move the lines in-between chunks to their new positions
+          // (The lines after the last chunk don't need to be handled)
+          for (
+            let index = lastChunk.oldStart + lastChunk.oldLines, lineNb = 0;
+            index < chunk.oldStart;
+            index++, lineNb++
+          ) {
+            textEdits.push(
+              ...this.replace(
+                document,
+                index - 1,
+                lastChunk.newStart + lastChunk.newLines - 2 + lineNb,
+                document.lineAt(index - 1).text + "\n",
+              ),
+            );
+          }
+        }
         // Ensure lines added are not out of bounds of chunk
         const oldBoundChunk = chunk.oldLines + chunk.oldStart - 1;
         chunk.changes.forEach((change) => {
@@ -124,18 +143,11 @@ export class DbtDocumentFormattingEditProvider
             );
           }
           if (this.isNormalChange(change)) {
-            // Reflect "replace" edits as delete & insert
-            // First, delete line
             textEdits.push(
-              TextEdit.delete(
-                document.lineAt(change.ln1 - 1).rangeIncludingLineBreak,
-              ),
-            );
-            // Add line
-            textEdits.push(
-              TextEdit.insert(
-                document.lineAt(Math.min(change.ln2, oldBoundChunk) - 1).range
-                  .start,
+              ...this.replace(
+                document,
+                change.ln1 - 1,
+                Math.min(change.ln2, oldBoundChunk) - 1,
                 change.content.slice(1) + "\n",
               ),
             );
@@ -148,9 +160,24 @@ export class DbtDocumentFormattingEditProvider
             );
           }
         });
+        lastChunk = chunk;
       });
     });
     return textEdits;
+  }
+
+  private replace(
+    document: TextDocument,
+    lineToDelete: number,
+    lineToInsert: number,
+    newText: string,
+  ): TextEdit[] {
+    // Reflect "replace" edits as delete & insert
+    // First, delete line, then add line
+    return [
+      TextEdit.delete(document.lineAt(lineToDelete).rangeIncludingLineBreak),
+      TextEdit.insert(document.lineAt(lineToInsert).range.start, newText),
+    ];
   }
 
   private isAddChange(change: parseDiff.Change): change is parseDiff.AddChange {


### PR DESCRIPTION
## Overview

Resolves #856

As (partly) explained in #856, the issue is that, taking any file:
- that is "unformatted enough" i.e. that it has several "chunks" output by sqlfmt
- that "deletes enough lines" (so that the already nicely-formatted text between 2 "chunks" should be moved too)

The file will be formatted wrongly to the extend that the SQL code is not valid anymore.

Example: See related issue for a file that would get corrupted before this PR.

Code walkthrough:

Option 1: Let sqlfmt do the job entirely instead of parsing its results (faster and simpler). https://github.com/AltimateAI/vscode-dbt-power-user/pull/930

Option 2 (this PR): Parse sqlfmt results and create 'TextEdit' changes for each row to change and each row in-between chunks:
- I added a "replace" function since this delete/insert method was already used once and I needed the same logic again.
- I save the "lastChunk" which is the previous chunk before the current one being processed. 
Example of 2 chunks output by sqlfmt (taking the example described in the issue) that are delimited by @@:
While I am in the 2nd chunk (@@ -32,15 +23,9 @@) I still have access to the previous chunk (@@ -13,17 +13,8 @@).
```diff
$ sqlfmt -l 120 --diff debug_project/models/example/my_first_dbt_model.sql      
1 file failed formatting check.
0 files passed formatting check.
debug_project/models/example/my_first_dbt_model.sql failed formatting check.
--- source_query
+++ formatted_query
@@ -13,17 +13,8 @@
 
         select 1 as id
 
-
-
-
-
-
-
-
-
-
-
-        union all select null as id
+        union all
+        select null as id
 
     )
 
@@ -32,15 +23,9 @@
 
 union all
 select *
-from 
+from
 
-
-
-
-
-
-
-source_data
+    source_data
 
     /*
     Uncomment the line below to remove records with null `id` values

```

- In the diff above, you can see that the lines in-between the 2 chunks don't appear in the diff (because they are already correctly formatted - line 30 to 32 in the original file).
- These lines that don't appear in the diff need to be moved from their original location (line 30 to 32) to their new location (just after the end of chunk 1, line 13+8 (as indicated by the @@ delimiter) = 21 so it should be moved to lines 21 to 23)

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
=> No it's a bugfix and thus it was an expected working feature, so no documentation change needed.