### PR TITLE
fix: show warning message if query change has more than 10 lines

### DIFF
--- a/webview_panels/src/modules/dataPilot/components/queryAnalysis/QueryAnalysis.tsx
+++ b/webview_panels/src/modules/dataPilot/components/queryAnalysis/QueryAnalysis.tsx
@@ -1,4 +1,4 @@
-import { Alert, CodeBlock, Stack } from "@uicore";
+import { Alert, Card, CardBody, CardTitle, CodeBlock, Stack } from "@uicore";
 import QueryAnalysisActionButton from "./QueryAnalysisActionButton";
 import QueryAnalysisResultComponent from "./QueryAnalysisResult";
 import useQueryAnalysisContext, {
@@ -7,7 +7,10 @@ import useQueryAnalysisContext, {
 import DatapilotHeader from "../common/Header";
 import { DataPilotChatAction } from "@modules/dataPilot/types";
 import { QueryAnalysisCommands } from "./commands";
+import { AltimateIcon } from "@assets/icons";
+import { QueryAnalysisType } from "./types";
 
+const QUERY_HAPPY_LIMIT = 10;
 const DefaultActions = [
   {
     title: "Query explanation",
@@ -27,12 +30,28 @@ const QueryAnalysis = (): JSX.Element | null => {
   }
 
   const actions = chat.actions?.length ? chat.actions : DefaultActions;
+  const showLineLimitWarning =
+    chat.query.split("\n").length > QUERY_HAPPY_LIMIT &&
+    chat.analysisType === QueryAnalysisType.MODIFY;
 
   return (
     <Stack direction="column">
       <DatapilotHeader />
 
       <CodeBlock code={chat.query} language="sql" fileName={chat.fileName} />
+      {showLineLimitWarning ? (
+        <Card>
+          <CardTitle>
+            <AltimateIcon /> Datapilot
+          </CardTitle>
+          <CardBody>
+            Warning: this functionality works better for small code blocks, as
+            DataPilot may end up rewriting the entire code that is displayed
+            above.
+          </CardBody>
+        </Card>
+      ) : null}
+
       {/* show actions only if this is start of chat */}
       {results.length > 0 ? null : (
         <Stack style={{ flexWrap: "wrap" }}>


### PR DESCRIPTION
## Overview
- Shows warning message in datapilot if selected code is more than 10 lines in query change feature
- resolves https://altimateai.atlassian.net/browse/AI-1533

### Screenshot
![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/46d27710-3c04-471a-b7d2-57c9372f66e7)

## Checklist
- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
