### PR TITLE
Fix terminal integrated env

### DIFF
--- a/src/manifest/pythonEnvironment.ts
+++ b/src/manifest/pythonEnvironment.ts
@@ -129,11 +129,28 @@ export class PythonEnvironment implements Disposable {
           const env = config.terminal.integrated.env;
           // parse vs code environment variables
           for (const prop in env) {
+            // Ignore any settings not supported by the terminal
+            // We don't know which os is used in terminal unfortunately, so we just merge all of them.
+            if (!["osx", "windows", "linux"].includes(prop)) {
+              this.dbtTerminal.debug(
+                "pythonEnvironment",
+                "Loading env vars from config.terminal.integrated.env",
+                "Ignoring invalid property  " + prop,
+              );
+              continue;
+            }
             const vsCodeEnv = env[prop];
+            const newEnvVars = this.parseEnvVarsFromUserSettings(vsCodeEnv);
+            this.dbtTerminal.debug(
+              "pythonEnvironment",
+              "Loading env vars from config.terminal.integrated.env",
+              "Merging from " + prop,
+              newEnvVars,
+            );
             envVars = {
               ...process.env,
               ...envVars,
-              ...this.parseEnvVarsFromUserSettings(vsCodeEnv),
+              ...newEnvVars,
             };
           }
         }


### PR DESCRIPTION
## Overview

This fix ensures invalid config are not used by the extension resulting in inconsistent behaviour in the terminal vs the extension.

Can be simulated by putting this in .vscode/settings.json

```
  "terminal.integrated.env.tst": {
    "DBT_PROFILES_DIR": "~/.dbt/profiles.yml"
  } 

```
## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
