### PR TITLE
fix: documentations save flow

### DIFF
--- a/webview_panels/src/modules/documentationEditor/components/saveDocumentation/SaveDocumentation.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/saveDocumentation/SaveDocumentation.tsx
@@ -8,7 +8,7 @@ import classes from "../../styles.module.scss";
 
 const SaveDocumentation = (): JSX.Element | null => {
   const [patchPath, setPatchPath] = useState("");
-  const [dialogType, setDialogType] = useState("");
+  const [dialogType, setDialogType] = useState("Existing file");
   const [openPopover, setOpenPopover] = useState(false);
   const {
     state: { currentDocsData, isDocGeneratedForAnyColumn },
@@ -67,6 +67,7 @@ const SaveDocumentation = (): JSX.Element | null => {
             target="file-path"
             placement="top"
             hideArrow
+            className={classes.popover}
           >
             <PopoverBody className={classes.popoverBody}>
               <List>

--- a/webview_panels/src/modules/documentationEditor/styles.module.scss
+++ b/webview_panels/src/modules/documentationEditor/styles.module.scss
@@ -74,6 +74,7 @@
         }
         & :global #file-path {
           background: var(--background--02);
+          color: #fff;
         }
       }
     }


### PR DESCRIPTION
## Overview
- In new documentation editor, if schema.yml file is missing, file selector icon is not visible
- on clicking save, we show error
- This PR solves the UX issue to show file selector button and set default option as selecting an existing file

![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/0880f346-eed2-489f-9950-68dfc2370c6c)


## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
