### PR TITLE
fix: sql formatting

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -76,9 +76,9 @@ export class DbtDocumentFormattingEditProvider
           throw new Error(stderr);
         }
         return [];
-      } catch (diffOutput) {
+      } catch (e) {
         try {
-          return this.processDiffOutput(document, diffOutput as string);
+          return this.processDiffOutput(document, (e as Error).message);
         } catch (error) {
           this.telemetry.sendTelemetryError(
             "formatDbtModelApplyDiffFailed",


### PR DESCRIPTION
## Overview

Earlier error was thrown as `string` which can directly be used as diffOutput. But now since error is thrown as `Error`, need to pass the message.

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
