### PR TITLE
fix: defer to prod notification issues

### DIFF
--- a/src/altimate.ts
+++ b/src/altimate.ts
@@ -163,7 +163,7 @@ export interface DocsGenerateResponse {
   model_description?: string;
 }
 
-interface DBTCoreIntegration {
+export interface DBTCoreIntegration {
   id: number;
   name: string;
   created_at: string;

--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -624,7 +624,13 @@ export class DBTCoreProjectIntegration
       return args;
     }
     if (manifestPathType === ManifestPathType.REMOTE) {
-      this.validationProvider.throwIfNotAuthenticated();
+      try {
+        this.validationProvider.throwIfNotAuthenticated();
+      } catch (err) {
+        throw new Error(
+          "Defer to production is currently enabled, it requires a valid Altimate API key and instance. In order to run dbt commands you will need to disable the feature or enter a valid Altimate API key.",
+        );
+      }
       if (dbtCoreIntegrationId! <= 0) {
         this.dbtTerminal.debug(
           "DBTCoreProjectIntegration",

--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -628,7 +628,7 @@ export class DBTCoreProjectIntegration
         this.validationProvider.throwIfNotAuthenticated();
       } catch (err) {
         throw new Error(
-          "Defer to production is currently enabled, it requires a valid Altimate API key and instance. In order to run dbt commands you will need to disable the feature or enter a valid Altimate API key.",
+          "Defer to production is currently enabled with 'DataPilot dbt integration' mode. It requires a valid Altimate AI API key and instance name in the settings. In order to run dbt commands, please either switch to Local Path mode or disable the feature or add an API key / instance name.",
         );
       }
 

--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -631,13 +631,6 @@ export class DBTCoreProjectIntegration
           "Defer to production is currently enabled, it requires a valid Altimate API key and instance. In order to run dbt commands you will need to disable the feature or enter a valid Altimate API key.",
         );
       }
-      if (dbtCoreIntegrationId! <= 0) {
-        this.dbtTerminal.debug(
-          "DBTCoreProjectIntegration",
-          "No dbtCoreIntegrationId for defer remote config",
-        );
-        return [];
-      }
 
       this.dbtTerminal.debug(
         "remoteManifest",

--- a/webview_panels/src/modules/defer/DeferToProduction.tsx
+++ b/webview_panels/src/modules/defer/DeferToProduction.tsx
@@ -45,7 +45,8 @@ const DeferToProduction = (): JSX.Element => {
     },
     setDeferState,
   ] = useState<DeferToProductionProps>(DefaultDeferState);
-
+  const [fetchingProjectIntegrations, setFetchingProjectIntegrations] =
+    useState(false);
   const [dbtProjects, setDbtProjects] = useState<DbtProject[]>([]);
   const [dbtProjectRoot, setDbtProjectRoot] = useState("");
   const [dbtIntegrationMode, setDbtIntegrationMode] = useState(
@@ -165,8 +166,11 @@ const DeferToProduction = (): JSX.Element => {
     }
   };
 
-  const setProjectIntegrations = async () => {
-    const response = await executeRequestInSync("fetchProjectIntegrations", {});
+  const setProjectIntegrations = async (clearCache?: boolean) => {
+    setFetchingProjectIntegrations(true);
+    const response = await executeRequestInSync("fetchProjectIntegrations", {
+      clearCache,
+    });
     if (Array.isArray(response)) {
       setDeferState((prevState) => ({
         ...prevState,
@@ -178,8 +182,8 @@ const DeferToProduction = (): JSX.Element => {
         ),
         manifestPathType: ManifestPathType.REMOTE,
       }));
-      return;
     }
+    setFetchingProjectIntegrations(false);
   };
 
   const handleProjectSelect = (selectedOption: {
@@ -259,6 +263,7 @@ const DeferToProduction = (): JSX.Element => {
                 {dbtIntegrationMode !== DbtIntegrationMode.CLOUD ? (
                   <>
                     <ManifestSelection
+                      fetchingProjectIntegrations={fetchingProjectIntegrations}
                       dbtProjectRoot={dbtProjectRoot}
                       manifestPathForDeferral={manifestPathForDeferral}
                       manifestPathType={manifestPathType}

--- a/webview_panels/src/modules/defer/DeferToProduction.tsx
+++ b/webview_panels/src/modules/defer/DeferToProduction.tsx
@@ -30,7 +30,7 @@ const DefaultDeferState = {
   manifestPathForDeferral: "",
   manifestPathType: ManifestPathType.EMPTY,
   projectIntegrations: [],
-  dbtCoreIntegrationId: -1,
+  dbtCoreIntegrationId: undefined,
 };
 
 const DeferToProduction = (): JSX.Element => {

--- a/webview_panels/src/modules/defer/ManifestSelection.tsx
+++ b/webview_panels/src/modules/defer/ManifestSelection.tsx
@@ -47,7 +47,7 @@ export const ManifestSelection = ({
   const handleManifestPathTypeChange = async (option: ManifestPathType) => {
     if (option === ManifestPathType.REMOTE) {
       await setProjectIntegrations();
-      if (dbtCoreIntegrationId > 0) {
+      if (dbtCoreIntegrationId) {
         await executeRequestInSync("updateDeferConfig", {
           config: [
             {

--- a/webview_panels/src/modules/defer/ManifestSelection.tsx
+++ b/webview_panels/src/modules/defer/ManifestSelection.tsx
@@ -1,4 +1,4 @@
-import { FormGroup, Input, Label, Select } from "@uicore";
+import { FormGroup, IconButton, Input, Label, Select, Spinner } from "@uicore";
 import {
   executeRequestInAsync,
   executeRequestInSync,
@@ -7,6 +7,7 @@ import classes from "./defer.module.scss";
 import { ManifestPathType } from "./constants";
 import { ManifestSelectionProps } from "./types";
 import { panelLogger } from "@modules/logger";
+import { RefreshIcon } from "@assets/icons";
 
 export const ManifestSelection = ({
   dbtProjectRoot,
@@ -16,6 +17,7 @@ export const ManifestSelection = ({
   dbtCoreIntegrationId,
   setDeferState,
   setProjectIntegrations,
+  fetchingProjectIntegrations,
 }: ManifestSelectionProps): JSX.Element => {
   const updateConfigWithManifestPath = async (path: string) => {
     panelLogger.info("updating defer config for manifest path", path);
@@ -118,6 +120,8 @@ export const ManifestSelection = ({
     await updateConfigWithManifestPath(path);
   };
 
+  const handleRefresh = () => setProjectIntegrations(true);
+
   return (
     <FormGroup check className={classes.pathSelection}>
       <div className={classes.pathSelectionRow}>
@@ -168,18 +172,29 @@ export const ManifestSelection = ({
         </Label>
         {manifestPathType === ManifestPathType.REMOTE &&
           projectIntegrations && (
-            <Select
-              options={projectIntegrations}
-              className={classes.pathInput}
-              value={projectIntegrations.find(
-                (i) => i.value === dbtCoreIntegrationId,
-              )}
-              onChange={(newValue) =>
-                handleIntegrationSelect(
-                  newValue as { label: string; value: number },
-                )
-              }
-            />
+            <>
+              <Select
+                options={projectIntegrations}
+                className={classes.pathInput}
+                value={projectIntegrations.find(
+                  (i) => i.value === dbtCoreIntegrationId,
+                )}
+                onChange={(newValue) =>
+                  handleIntegrationSelect(
+                    newValue as { label: string; value: number },
+                  )
+                }
+              />
+              <IconButton
+                title="Refetch Project Integrations"
+                onClick={handleRefresh}
+                color="outline"
+                className={classes.refreshBtn}
+                disabled={fetchingProjectIntegrations}
+              >
+                {!fetchingProjectIntegrations ? <RefreshIcon /> : <Spinner />}
+              </IconButton>
+            </>
           )}
       </div>
     </FormGroup>

--- a/webview_panels/src/modules/defer/defer.module.scss
+++ b/webview_panels/src/modules/defer/defer.module.scss
@@ -45,6 +45,22 @@
       width: 70%;
       cursor: pointer;
     }
+
+    .refresh-btn{
+      color: #fff;
+      margin-left: -5rem;
+      margin-top: 0.15rem;
+
+      :global .codicon{
+        font-size: 1.1rem;
+      }
+      :global .spinner-border{
+        width: 1rem;
+      height: 1rem;
+      margin-top: 0.15rem;
+      border-width: 2px;
+      }
+    }
   }
 }
 

--- a/webview_panels/src/modules/defer/types.ts
+++ b/webview_panels/src/modules/defer/types.ts
@@ -20,13 +20,14 @@ export interface DeferToProductionProps {
 }
 
 export interface ManifestSelectionProps {
+  fetchingProjectIntegrations: boolean;
   dbtProjectRoot: string;
   manifestPathForDeferral: string;
   manifestPathType: ManifestPathType;
   projectIntegrations: DropdownOptions[];
   dbtCoreIntegrationId: number;
   setDeferState: React.Dispatch<React.SetStateAction<DeferToProductionProps>>;
-  setProjectIntegrations: () => Promise<void>;
+  setProjectIntegrations: (clearCache?: boolean) => Promise<void>;
 }
 
 export interface DbtProject {

--- a/webview_panels/src/modules/defer/types.ts
+++ b/webview_panels/src/modules/defer/types.ts
@@ -16,7 +16,7 @@ export interface DeferToProductionProps {
   manifestPathForDeferral: string;
   manifestPathType: ManifestPathType;
   projectIntegrations: DropdownOptions[];
-  dbtCoreIntegrationId: number;
+  dbtCoreIntegrationId?: number;
 }
 
 export interface ManifestSelectionProps {
@@ -25,7 +25,7 @@ export interface ManifestSelectionProps {
   manifestPathForDeferral: string;
   manifestPathType: ManifestPathType;
   projectIntegrations: DropdownOptions[];
-  dbtCoreIntegrationId: number;
+  dbtCoreIntegrationId?: number;
   setDeferState: React.Dispatch<React.SetStateAction<DeferToProductionProps>>;
   setProjectIntegrations: (clearCache?: boolean) => Promise<void>;
 }

--- a/webview_panels/src/uiCore/components/iconButton/IconButton.tsx
+++ b/webview_panels/src/uiCore/components/iconButton/IconButton.tsx
@@ -20,6 +20,7 @@ const IconButton = (props: Props): JSX.Element => {
         className={`btn ${props.color ? `btn-${props.color}` : ""} ${
           props.className ?? ""
         } ${classes.iconButton}`}
+        type={props.type ?? "button"}
       >
         {props.children}
       </button>

--- a/webview_panels/src/uiCore/index.ts
+++ b/webview_panels/src/uiCore/index.ts
@@ -21,6 +21,7 @@ export {
   Offcanvas,
   OffcanvasHeader,
   OffcanvasBody,
+  Spinner,
 } from "reactstrap";
 
 export { default as Tag } from "./components/tag/Tag";


### PR DESCRIPTION
## Overview

### Problem
- If user removes the altimate key, on every build action he’s getting a notification “To use this feature …”, this is confusing the user might not know this is because defer to prod is enabled.
- If user removes the altimate key, he keeps getting multiple notifications, I think it is because of us fetching the integrations. I think we should only fetch them once and provide a refresh button.

### Solution
- updated error message
- added caching for project integrations and introduced refresh button

### Screenshot/Demo
https://www.awesomescreenshot.com/video/25630595?key=79d8573f2fa0544b7ef418d80de83eaa

### How to test
- In a multi project workspace, enable defer to prod feature
- Add a project integration
- Remove the alimate key/instance name from settings
- Switch between different models in different projects
- Verify the notification does not show
- Run a dbt model
- Updated error message should show
- Add altimate key and instance name again in settings
- Click refresh button near project integration dropdown
- Should see all project integrations

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
