### PR TITLE
fix: debug launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,15 @@
       "runtimeExecutable": "${execPath}",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "npm: webpack"
+    },
+    {
+      "name": "Debug Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "preLaunchTask": "debug-task",
       "postDebugTask": "terminate debug-task"
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ We warmly welcome contributions from our active community! If you're interested 
       ```
 
    1. **Start Debugging:** In the Visual Studio Code interface, navigate to the "Run and Debug" sidebar. Click on "Launch Extension" to start the debugging process. This will open a new window with the dbt Power User extension installed. During this debug session, the existing installation of dbt-power-user will be overridden, allowing you to test your changes without affecting the installed extension.
-      - **Note:** If you're running the dbt Power User extension in debug mode and you make changes to the extension's code, you can see those changes take effect immediately by reloading the VS Code instance where the extension is running.
+      - **Note:** If you're running the dbt Power User extension in debug mode using `Debug Extension` and you make changes to the extension's code, you can see those changes take effect immediately by reloading the VS Code instance where the extension is running.
       - To reload the VS Code instance in debug mode, you can either:
         - Use the command "Developer: Reload Window" from the command palette by pressing Ctrl + Shift + P and typing "Developer: Reload Window".
         - Simply press Ctrl/Cmd + R to reload the VS Code instance.

--- a/webview_panels/package.json
+++ b/webview_panels/package.json
@@ -10,8 +10,8 @@
   "packageManager": "npm@9.6.7",
   "scripts": {
     "dev": "vite",
-    "watch": "rm -Rf ./dist; tsc && vite build --watch && cp -r ./node_modules/@vscode/codicons/dist ./dist/assets/codicons/",
-    "build": "rm -Rf ./dist; tsc && vite build && cp -r ./node_modules/@vscode/codicons/dist ./dist/assets/codicons/",
+    "watch": "rm -Rf ./dist; tsc && vite build --watch",
+    "build": "rm -Rf ./dist; tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 5",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",

--- a/webview_panels/vite.config.ts
+++ b/webview_panels/vite.config.ts
@@ -2,10 +2,24 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 import path from "path";
+import { cpSync } from "fs";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svgr(), react()],
+  plugins: [
+    svgr(),
+    react(),
+    {
+      name: "copy-codicons",
+      renderStart: () => {
+        cpSync(
+          "./node_modules/@vscode/codicons/dist",
+          "./dist/assets/codicons/",
+          { recursive: true },
+        );
+      },
+    },
+  ],
   build: {
     rollupOptions: {
       input: "./src/main.tsx",


### PR DESCRIPTION
## Overview

### Problem
- recently added [debug](https://github.com/AltimateAI/vscode-dbt-power-user/issues/946) config for development is not working reliable. It stops watch command abruptly
- also, the debug source code is not reflecting the updated code
- icons from codicons are not showing up

### Solution
- update `launch` config to use `webpack` as before
- added new `debug extension` config to use this new flow.

### Screenshot/Demo
NA

### How to test
- Click `Launch extension` / `debug extension` 

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
