### PR TITLE
fix: bigquery sql quick pickl

### DIFF
--- a/src/quickpick/sqlQuickPick.ts
+++ b/src/quickpick/sqlQuickPick.ts
@@ -93,6 +93,7 @@ export class DbtSQLAction {
                 new ThemeIcon("dashboard"),
                 "Estimate cost for BigQuery",
                 "dbtPowerUser.bigqueryCostEstimate",
+                [true],
               ),
             );
           }


### PR DESCRIPTION
## Overview

### Problem

QuickPick for bigquery does not work due to not passing argument

### Solution

By default pass true


### How to test
- Use Cost estimator using quick pick on a  bigquery dbt project

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
