### PR TITLE
fix: show save on first generation in doc editor

### DIFF
--- a/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
+++ b/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
@@ -65,6 +65,7 @@ const DocumentationEditor = (): JSX.Element => {
         updateCurrentDocsData({
           name: currentDocsData.name,
           description: result.description,
+          isNewGeneration: true,
         }),
       );
     } catch (error) {

--- a/webview_panels/src/modules/documentationEditor/components/docGenerator/DocGeneratorColumn.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/docGenerator/DocGeneratorColumn.tsx
@@ -63,7 +63,9 @@ const DocGeneratorColumn = ({ column }: Props): JSX.Element => {
         "generateDocsForColumn",
         requestData,
       )) as { columns: Partial<DBTDocumentationColumn>[] };
-      dispatch(updateColumnsInCurrentDocsData(result));
+      dispatch(
+        updateColumnsInCurrentDocsData({ ...result, isNewGeneration: true }),
+      );
 
       await addDocGeneration(
         project,


### PR DESCRIPTION
## Overview

### Problem
- In new doc gen editor, when a column/model does not have any description and user generates documentation, save button is not showing

### Solution
- fixed the state update dispatch to show save button in these cases

### Screenshot/Demo

NA

### How to test
- Open a model without description for model and column
- Use new doc editor version
- Generate desc for column/model
- Save should show and on save, should save to yaml

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
