### PR TITLE
fix: send defer event to backend only for remote

### DIFF
--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -620,7 +620,12 @@ export class DBTCoreProjectIntegration
         "localManifest",
         `local defer params: ${args.join(" ")}`,
       );
-      this.altimateRequest.sendDeferToProdEvent(ManifestPathType.LOCAL);
+      this.dbtTerminal.info(
+        "deferToProd",
+        "executing dbt command with defer params local mode",
+        true,
+        args,
+      );
       return args;
     }
     if (manifestPathType === ManifestPathType.REMOTE) {
@@ -651,6 +656,12 @@ export class DBTCoreProjectIntegration
           args.push("--favor-state");
         }
         this.altimateRequest.sendDeferToProdEvent(ManifestPathType.REMOTE);
+        this.dbtTerminal.info(
+          "deferToProd",
+          "executing dbt command with defer params remote mode",
+          true,
+          args,
+        );
         return args;
       } catch (error) {
         if (error instanceof NotFoundError) {

--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -617,10 +617,6 @@ export class DBTCoreProjectIntegration
         args.push("--favor-state");
       }
       this.dbtTerminal.debug(
-        "localManifest",
-        `local defer params: ${args.join(" ")}`,
-      );
-      this.dbtTerminal.info(
         "deferToProd",
         "executing dbt command with defer params local mode",
         true,
@@ -656,7 +652,7 @@ export class DBTCoreProjectIntegration
           args.push("--favor-state");
         }
         this.altimateRequest.sendDeferToProdEvent(ManifestPathType.REMOTE);
-        this.dbtTerminal.info(
+        this.dbtTerminal.debug(
           "deferToProd",
           "executing dbt command with defer params remote mode",
           true,


### PR DESCRIPTION
## Overview

### Problem

For local mode in defer to prod feature, dont send event to backend to track the run

### Solution

Removed tracking event and added telemetry event

### Screenshot/Demo

NA

### How to test

- Enable defer to prod with local integration
- Run a dbt command like run,test,build
- Should not send event to backend but to telemetry

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
