### PR TITLE
chore: send response to webview cleanup and make errors to warning

### DIFF
--- a/src/statusbar/deferToProductionStatusBar.ts
+++ b/src/statusbar/deferToProductionStatusBar.ts
@@ -10,6 +10,7 @@ import {
 import { DeferToProdService } from "../services/deferToProdService";
 import { provideSingleton } from "../utils";
 import { DBTProjectContainer } from "../manifest/dbtProjectContainer";
+import { DBTTerminal } from "../dbt_client/dbtTerminal";
 
 @provideSingleton(DeferToProductionStatusBar)
 export class DeferToProductionStatusBar implements Disposable {
@@ -22,6 +23,7 @@ export class DeferToProductionStatusBar implements Disposable {
   constructor(
     private deferToProdService: DeferToProdService,
     private dbtProjectContainer: DBTProjectContainer,
+    private dbtTerminal: DBTTerminal,
   ) {
     this.disposables.push(
       workspace.onDidChangeConfiguration(
@@ -83,7 +85,11 @@ export class DeferToProductionStatusBar implements Disposable {
       this.statusBar.show();
     } catch (err) {
       this.statusBar.hide();
-      console.error("Unable to update defer status bar", err);
+      this.dbtTerminal.debug(
+        "DeferToProductionStatusBar",
+        "Unable to update defer status bar",
+        err,
+      );
     }
   }
 

--- a/src/webview_provider/altimateWebviewProvider.ts
+++ b/src/webview_provider/altimateWebviewProvider.ts
@@ -114,9 +114,10 @@ export class AltimateWebviewProvider implements WebviewViewProvider {
   protected async onEvent({ command, payload }: SharedStateEventEmitterProps) {
     switch (command) {
       case "stream:chunk":
-        this._panel!.webview.postMessage({
+        this.sendResponseToWebview({
           command: "response",
-          args: payload,
+          syncRequestId: payload.syncRequestId as string | undefined,
+          data: payload.body,
         });
         break;
 
@@ -177,14 +178,11 @@ export class AltimateWebviewProvider implements WebviewViewProvider {
           break;
         case "validateCredentials":
           const isValid = await this.altimateRequest.handlePreviewFeatures();
-          this._panel!.webview.postMessage({
+          this.sendResponseToWebview({
             command: "response",
-            args: {
-              syncRequestId,
-              body: {
-                isValid,
-              },
-              status: true,
+            syncRequestId,
+            data: {
+              isValid,
             },
           });
           break;
@@ -221,14 +219,11 @@ export class AltimateWebviewProvider implements WebviewViewProvider {
               .update(params.key, params.value);
           }
           if (syncRequestId) {
-            this._panel!.webview.postMessage({
+            this.sendResponseToWebview({
               command: "response",
-              args: {
-                syncRequestId,
-                body: {
-                  updated: shouldUpdate,
-                },
-                status: true,
+              syncRequestId,
+              data: {
+                updated: shouldUpdate,
               },
             });
           }


### PR DESCRIPTION
## Overview

### Problem
- Logs are polluted with unnecessary error logs
- Sending message to webview panel is not consolidated in insights page

### Solution
- Converted few errors to debug/warn as it is not a real error
- moved all `postMessage` api to `sendResponseToWebview` api

### Screenshot/Demo
NA

### How to test
- Regression for defer to prod feature

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
