### PR TITLE
fix: show test macro code in tests editor

### DIFF
--- a/src/dbt_client/dbtCloudIntegration.ts
+++ b/src/dbt_client/dbtCloudIntegration.ts
@@ -410,7 +410,7 @@ export class DBTCloudProjectIntegration
   async compileModel(command: DBTCommand) {
     this.addCommandToQueue(
       DBTCloudProjectIntegration.QUEUE_ALL,
-      this.dbtCloudCommand(command),
+      await this.addDeferParams(this.dbtCloudCommand(command)),
     );
   }
 

--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -558,7 +558,9 @@ export class DBTCoreProjectIntegration
   }
 
   async compileModel(command: DBTCommand) {
-    this.addCommandToQueue(this.dbtCoreCommand(command));
+    this.addCommandToQueue(
+      await this.addDeferParams(this.dbtCoreCommand(command)),
+    );
   }
 
   async generateDocs(command: DBTCommand) {

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -78,6 +78,12 @@ export interface TestMetadataRelationships extends TestMetadataSpecification {
   to?: string;
 }
 
+interface DependsOnSpec {
+  macros: [string];
+  nodes: [string];
+  sources: [string];
+}
+
 export interface TestMetaData {
   path: string;
   database: string;
@@ -91,11 +97,12 @@ export interface TestMetaData {
     namespace?: string;
   };
   attached_node?: string;
+  depends_on: DependsOnSpec;
 }
 
 export interface ExposureMetaData {
   description?: string;
-  depends_on: { macros: [string]; nodes: [string]; sources: [string] };
+  depends_on: DependsOnSpec;
   label?: string;
   maturity?: string;
   name: string;

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -78,7 +78,7 @@ export interface TestMetadataRelationships extends TestMetadataSpecification {
   to?: string;
 }
 
-interface DependsOnSpec {
+interface DependsOn {
   macros: [string];
   nodes: [string];
   sources: [string];
@@ -97,12 +97,12 @@ export interface TestMetaData {
     namespace?: string;
   };
   attached_node?: string;
-  depends_on: DependsOnSpec;
+  depends_on: DependsOn;
 }
 
 export interface ExposureMetaData {
   description?: string;
-  depends_on: DependsOnSpec;
+  depends_on: DependsOn;
   label?: string;
   maturity?: string;
   name: string;

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -590,7 +590,7 @@ export class DBTProject implements Disposable {
       true,
       { model, column },
     );
-    const query = `select ${column} as values from ${model} group by ${column}`;
+    const query = `select ${column} from ${model} group by ${column}`;
     const queryExecution = await this.dbtProjectIntegration.executeSQL(
       query,
       100, // setting this 100 as executeSql needs a limit and distinct values will be usually less in number

--- a/src/manifest/parsers/macroParser.ts
+++ b/src/manifest/parsers/macroParser.ts
@@ -55,7 +55,12 @@ export class MacroParser {
 
           for (let index = 0; index < macroFileLines.length; index++) {
             const currentLine = macroFileLines[index];
-            if (currentLine.match(new RegExp(`macro\\s${name}\\(`))) {
+            if (
+              currentLine.match(new RegExp(`macro\\s${name}\\(`)) ||
+              currentLine.match(
+                new RegExp(`test\\s${name.replace("test_", "")}\\(`),
+              )
+            ) {
               macroMetaMap.set(macroName, {
                 path: fullPath,
                 line: index,

--- a/src/manifest/parsers/testParser.ts
+++ b/src/manifest/parsers/testParser.ts
@@ -37,6 +37,7 @@ export class TestParser {
             column_name,
             test_metadata,
             attached_node,
+            depends_on,
           }) => {
             const fullPath = path.join(rootPath, original_file_path);
             testMetaMap.set(name, {
@@ -48,6 +49,7 @@ export class TestParser {
               column_name,
               test_metadata,
               attached_node,
+              depends_on,
             });
           },
         );

--- a/src/services/dbtTestsService.ts
+++ b/src/services/dbtTestsService.ts
@@ -1,13 +1,9 @@
-import { AltimateRequest } from "../altimate";
 import { provideSingleton } from "../utils";
-import { DocGenService } from "./docGenService";
-import { StreamingService } from "./streamingService";
-import { QueryManifestService } from "./queryManifestService";
-import { DBTTerminal } from "../dbt_client/dbtTerminal";
 import { MacroMetaMap } from "../domain";
 
 @provideSingleton(DbtTestService)
 export class DbtTestService {
+  // Find the file path of test macro
   public getMacroFilePath = (
     macros: [string],
     projectName: string,
@@ -17,10 +13,14 @@ export class DbtTestService {
     if (!testName) {
       return;
     }
+
+    // Find if current test depends on test macro in current project
     const macro = macros.find(
       (m) => m === `macro.${projectName}.test_${testName}`,
     );
+
     if (macro) {
+      // return the file path if it ends with sql
       const macroData = macroMetaMap.get(`test_${testName}`);
       return macroData?.path.endsWith(".sql") ? macroData?.path : undefined;
     }

--- a/src/services/dbtTestsService.ts
+++ b/src/services/dbtTestsService.ts
@@ -13,7 +13,7 @@ export class DbtTestService {
     private queryManifestService: QueryManifestService,
   ) {}
 
-  private stringifyTest = (
+  private filterAndStringifyTest = (
     tests: Record<string, Record<string, unknown>>[],
     test: TestMetaData,
   ) => {
@@ -47,6 +47,7 @@ export class DbtTestService {
       selectedTest,
     );
 
+    // Remove fields which are already handled in UI
     const filteredConfig = Object.entries(selectedTest[fullName]).reduce(
       (acc: Record<string, unknown>, [key, value]) => {
         if (ignoredFields.includes(key)) {
@@ -58,7 +59,7 @@ export class DbtTestService {
       },
       {},
     );
-    // If test is from external package, show the package namespace as well
+    // If test is from external package ex: dbt_utils, show the package namespace as well
     const refinedTestConfig = namespace
       ? {
           [fullName]: filteredConfig,
@@ -67,6 +68,9 @@ export class DbtTestService {
     return stringify(refinedTestConfig);
   };
 
+  /**
+   * Find the extra config for test from schema.yml, if available
+   */
   public getConfigByTest(
     test: TestMetaData,
     modelName: string,
@@ -125,7 +129,7 @@ export class DbtTestService {
         parsedDocFile,
         model,
       );
-      return this.stringifyTest(model?.tests, test);
+      return this.filterAndStringifyTest(model?.tests, test);
     }
 
     const column =
@@ -139,7 +143,7 @@ export class DbtTestService {
       column,
     );
 
-    return this.stringifyTest(column?.tests, test);
+    return this.filterAndStringifyTest(column?.tests, test);
   }
 
   // Find the file path of test macro

--- a/src/services/dbtTestsService.ts
+++ b/src/services/dbtTestsService.ts
@@ -1,0 +1,28 @@
+import { AltimateRequest } from "../altimate";
+import { provideSingleton } from "../utils";
+import { DocGenService } from "./docGenService";
+import { StreamingService } from "./streamingService";
+import { QueryManifestService } from "./queryManifestService";
+import { DBTTerminal } from "../dbt_client/dbtTerminal";
+import { MacroMetaMap } from "../domain";
+
+@provideSingleton(DbtTestService)
+export class DbtTestService {
+  public getMacroFilePath = (
+    macros: [string],
+    projectName: string,
+    macroMetaMap: MacroMetaMap,
+    testName: string | undefined,
+  ) => {
+    if (!testName) {
+      return;
+    }
+    const macro = macros.find(
+      (m) => m === `macro.${projectName}.test_${testName}`,
+    );
+    if (macro) {
+      const macroData = macroMetaMap.get(`test_${testName}`);
+      return macroData?.path.endsWith(".sql") ? macroData?.path : undefined;
+    }
+  };
+}

--- a/src/services/dbtTestsService.ts
+++ b/src/services/dbtTestsService.ts
@@ -1,8 +1,147 @@
 import { provideSingleton } from "../utils";
-import { MacroMetaMap } from "../domain";
+import { MacroMetaMap, TestMetaData } from "../domain";
+import { DBTTerminal } from "../dbt_client/dbtTerminal";
+import { QueryManifestService } from "./queryManifestService";
+import path = require("path");
+import { readFileSync } from "fs";
+import { parse, stringify } from "yaml";
 
 @provideSingleton(DbtTestService)
 export class DbtTestService {
+  constructor(
+    private dbtTerminal: DBTTerminal,
+    private queryManifestService: QueryManifestService,
+  ) {}
+
+  private stringifyTest = (
+    tests: Record<string, Record<string, unknown>>[],
+    test: TestMetaData,
+  ) => {
+    if (!tests?.length) {
+      return;
+    }
+
+    // Ignore these generic fields, as we handle these fields differently in UI
+    const ignoredFields = ["model", "column_name", "field", "to", "values"];
+
+    if (!test.test_metadata) {
+      return;
+    }
+    const { name, namespace } = test.test_metadata;
+    const fullName = namespace ? `${namespace}.${name}` : name;
+
+    const selectedTest = tests.find(
+      (t: Record<string, Record<string, unknown>>) => {
+        return Boolean(t[fullName]);
+      },
+    );
+
+    if (!selectedTest) {
+      this.dbtTerminal.debug("getDbtTestCode", "no test available in yml");
+      return;
+    }
+
+    this.dbtTerminal.debug(
+      "getDbtTestCode",
+      "sending selected test from yml",
+      selectedTest,
+    );
+
+    const filteredConfig = Object.entries(selectedTest[fullName]).reduce(
+      (acc: Record<string, unknown>, [key, value]) => {
+        if (ignoredFields.includes(key)) {
+          return acc;
+        }
+
+        acc[key] = value;
+        return acc;
+      },
+      {},
+    );
+    // If test is from external package, show the package namespace as well
+    const refinedTestConfig = namespace
+      ? {
+          [fullName]: filteredConfig,
+        }
+      : filteredConfig;
+    return stringify(refinedTestConfig);
+  };
+
+  public getConfigByTest(
+    test: TestMetaData,
+    modelName: string,
+    column_name?: string,
+  ) {
+    const eventResult = this.queryManifestService.getEventByCurrentProject();
+    if (!eventResult) {
+      return;
+    }
+    const {
+      event: { nodeMetaMap },
+    } = eventResult;
+    const node = nodeMetaMap.get(modelName);
+    if (!node) {
+      return;
+    }
+    const project = this.queryManifestService.getProject();
+    if (!project) {
+      return;
+    }
+
+    const patchPath = node?.patch_path.includes("://")
+      ? path.join(project.projectRoot.fsPath, node.patch_path.split("://")[1])
+      : node.patch_path;
+
+    this.dbtTerminal.debug(
+      "getDbtTestCode",
+      "finding test from yaml",
+      patchPath,
+    );
+    const parsedDocFile = parse(
+      readFileSync(patchPath, { encoding: "utf-8" }),
+      {
+        strict: false,
+        uniqueKeys: false,
+        maxAliasCount: -1,
+      },
+    );
+
+    if (!parsedDocFile) {
+      this.dbtTerminal.debug(
+        "getDbtTestCode",
+        "yml file does not have any content",
+        patchPath,
+      );
+      return null;
+    }
+
+    const model = parsedDocFile.models?.find((m: any) => m.name === modelName);
+
+    // model test
+    if (!column_name) {
+      this.dbtTerminal.debug(
+        "getDbtTestCode",
+        "finding model test from yml",
+        parsedDocFile,
+        model,
+      );
+      return this.stringifyTest(model?.tests, test);
+    }
+
+    const column =
+      model.columns &&
+      model.columns.find((yamlColumn: any) => yamlColumn.name === column_name);
+    this.dbtTerminal.debug(
+      "getDbtTestCode",
+      "finding column test from yml",
+      parsedDocFile,
+      model,
+      column,
+    );
+
+    return this.stringifyTest(column?.tests, test);
+  }
+
   // Find the file path of test macro
   public getMacroFilePath = (
     macros: [string],

--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -16,6 +16,7 @@ import {
   DBTDocumentation,
   Source,
 } from "../webview_provider/docsEditPanel";
+import { DbtTestService } from "./dbtTestsService";
 import { QueryManifestService } from "./queryManifestService";
 
 interface GenerateDocsForColumnsProps {
@@ -50,6 +51,7 @@ export class DocGenService {
     protected telemetry: TelemetryService,
     private queryManifestService: QueryManifestService,
     private dbtTerminal: DBTTerminal,
+    private dbtTestService: DbtTestService,
   ) {}
 
   private async generateDocsForColumn(
@@ -440,14 +442,14 @@ export class DocGenService {
     );
   }
 
-  public async getTestsForCurrentModel() {
+  public async getTestsForCurrentModel(projectName: string) {
     const eventResult = this.queryManifestService.getEventByCurrentProject();
     if (!eventResult?.event || !eventResult?.currentDocument) {
       return undefined;
     }
 
     const {
-      event: { nodeMetaMap, graphMetaMap, testMetaMap },
+      event: { nodeMetaMap, graphMetaMap, testMetaMap, macroMetaMap },
       currentDocument,
     } = eventResult;
     const modelName = path.basename(currentDocument.uri.fsPath, ".sql");
@@ -484,7 +486,23 @@ export class DocGenService {
           return null;
         }
 
-        return { ...testData, key: testKey };
+        const {
+          depends_on: { macros },
+          test_metadata,
+        } = testData;
+
+        const macroFilepath = this.dbtTestService.getMacroFilePath(
+          macros,
+          projectName,
+          macroMetaMap,
+          test_metadata?.name,
+        );
+
+        return {
+          ...testData,
+          path: macroFilepath || testData.path,
+          key: testKey,
+        };
       })
       .filter((t) => Boolean(t));
   }

--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -442,7 +442,7 @@ export class DocGenService {
     );
   }
 
-  public async getTestsForCurrentModel(projectName: string) {
+  public async getTestsForCurrentModel() {
     const eventResult = this.queryManifestService.getEventByCurrentProject();
     if (!eventResult?.event || !eventResult?.currentDocument) {
       return undefined;
@@ -452,6 +452,12 @@ export class DocGenService {
       event: { nodeMetaMap, graphMetaMap, testMetaMap, macroMetaMap },
       currentDocument,
     } = eventResult;
+    const project = this.queryManifestService.getProject();
+    if (!project) {
+      return undefined;
+    }
+    const projectName = project?.getProjectName();
+
     const modelName = path.basename(currentDocument.uri.fsPath, ".sql");
     this.dbtTerminal.debug(
       "dbtTests",

--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -598,7 +598,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                   this.documentation =
                     await this.docGenService.getDocumentation();
                   const tests =
-                    await this.docGenService.getTestsForCurrentModel();
+                    await this.docGenService.getTestsForCurrentModel("");
                   if (syncRequestId) {
                     this._panel!.webview.postMessage({
                       command: "response",

--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -598,7 +598,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                   this.documentation =
                     await this.docGenService.getDocumentation();
                   const tests =
-                    await this.docGenService.getTestsForCurrentModel("");
+                    await this.docGenService.getTestsForCurrentModel();
                   if (syncRequestId) {
                     this._panel!.webview.postMessage({
                       command: "response",

--- a/src/webview_provider/newDocsGenPanel.ts
+++ b/src/webview_provider/newDocsGenPanel.ts
@@ -91,12 +91,14 @@ export class NewDocsGenPanel
       return;
     }
 
-    const project = this.queryManifestService.getProject()?.getProjectName();
+    const projectName = this.queryManifestService
+      .getProject()
+      ?.getProjectName();
     const tests = await this.docGenService.getTestsForCurrentModel();
     this.sendResponseToWebview({
       command: "renderTests",
       tests,
-      project,
+      project: projectName,
     });
   }
 

--- a/src/webview_provider/newDocsGenPanel.ts
+++ b/src/webview_provider/newDocsGenPanel.ts
@@ -91,11 +91,12 @@ export class NewDocsGenPanel
       return;
     }
 
-    const tests = await this.docGenService.getTestsForCurrentModel();
+    const project = this.queryManifestService.getProject()?.getProjectName();
+    const tests = await this.docGenService.getTestsForCurrentModel(project);
     this.sendResponseToWebview({
       command: "renderTests",
       tests,
-      project: this.queryManifestService.getProject()?.getProjectName(),
+      project,
     });
   }
 

--- a/src/webview_provider/newDocsGenPanel.ts
+++ b/src/webview_provider/newDocsGenPanel.ts
@@ -92,7 +92,7 @@ export class NewDocsGenPanel
     }
 
     const project = this.queryManifestService.getProject()?.getProjectName();
-    const tests = await this.docGenService.getTestsForCurrentModel(project);
+    const tests = await this.docGenService.getTestsForCurrentModel();
     this.sendResponseToWebview({
       command: "renderTests",
       tests,

--- a/src/webview_provider/newDocsGenPanel.ts
+++ b/src/webview_provider/newDocsGenPanel.ts
@@ -24,7 +24,7 @@ import {
 import { DocsGenPanelView } from "./docsEditPanel";
 import { PythonException } from "python-bridge";
 import { TestMetaData } from "../domain";
-import { parse, stringify } from "yaml";
+import { DbtTestService } from "../services/dbtTestsService";
 
 @provideSingleton(NewDocsGenPanel)
 export class NewDocsGenPanel
@@ -43,6 +43,7 @@ export class NewDocsGenPanel
     protected emitterService: SharedStateService,
     protected queryManifestService: QueryManifestService,
     protected dbtTerminal: DBTTerminal,
+    private dbtTestsService: DbtTestService,
   ) {
     super(
       dbtProjectContainer,
@@ -102,92 +103,26 @@ export class NewDocsGenPanel
     });
   }
 
-  private stringifyTest = (
-    tests: Record<string, unknown>[],
-    test: TestMetaData,
-  ) => {
-    if (!tests?.length) {
-      return null;
-    }
-
-    const selectedTest = tests.find((t: Record<string, unknown>) => {
-      if (!test.test_metadata) {
-        return false;
-      }
-      const { name, namespace } = test.test_metadata;
-      const fullName = namespace ? `${namespace}.${name}` : name;
-      return Boolean(t[fullName]);
-    });
-
-    if (!selectedTest) {
-      this.dbtTerminal.debug("getDbtTestCode", "no test available in yml");
-      return null;
-    }
-
+  private getDbtTestCode(test: TestMetaData, modelName: string) {
+    const { path: testPath, column_name } = test;
     this.dbtTerminal.debug(
       "getDbtTestCode",
-      "sending selected test from yml",
-      selectedTest,
+      "getting sql and config",
+      testPath,
+      column_name,
+      modelName,
     );
-    return stringify(selectedTest);
-  };
 
-  private getDbtTestCode(test: TestMetaData, modelName: string) {
-    const { path, column_name } = test;
-    if (path.endsWith(".sql")) {
-      this.dbtTerminal.debug("getDbtTestCode", "reading sql test", path);
-      return readFileSync(path, { encoding: "utf-8" });
-    }
-
-    if (path.endsWith(".yml")) {
-      this.dbtTerminal.debug("getDbtTestCode", "finding test from yaml", path);
-      const parsedDocFile = parse(readFileSync(path, { encoding: "utf-8" }), {
-        strict: false,
-        uniqueKeys: false,
-        maxAliasCount: -1,
-      });
-
-      if (!parsedDocFile) {
-        this.dbtTerminal.debug(
-          "getDbtTestCode",
-          "yml file does not have any content",
-          path,
-        );
-        return null;
-      }
-
-      const model = parsedDocFile.models?.find(
-        (m: any) => m.name === modelName,
-      );
-
-      // model test
-      if (!column_name) {
-        this.dbtTerminal.debug(
-          "getDbtTestCode",
-          "finding model test from yml",
-          parsedDocFile,
-          model,
-        );
-        return this.stringifyTest(model?.tests, test);
-      }
-
-      const column =
-        model.columns &&
-        model.columns.find(
-          (yamlColumn: any) => yamlColumn.name === column_name,
-        );
-      this.dbtTerminal.debug(
-        "getDbtTestCode",
-        "finding column test from yml",
-        parsedDocFile,
-        model,
-        column,
-      );
-
-      return this.stringifyTest(column?.tests, test);
-    }
-
-    return null;
+    return {
+      sql: testPath.endsWith(".sql")
+        ? readFileSync(testPath, { encoding: "utf-8" })
+        : undefined,
+      config: this.dbtTestsService.getConfigByTest(
+        test,
+        modelName,
+        column_name,
+      ),
+    };
   }
 
   async handleCommand(message: HandleCommandProps): Promise<void> {
@@ -197,12 +132,10 @@ export class NewDocsGenPanel
       case "getTestCode":
         this.sendResponseToWebview({
           command: "response",
-          data: {
-            code: this.getDbtTestCode(
-              args.test as TestMetaData,
-              args.model as string,
-            ),
-          },
+          data: this.getDbtTestCode(
+            args.test as TestMetaData,
+            args.model as string,
+          ),
           syncRequestId,
         });
         break;

--- a/webview_panels/src/modules/documentationEditor/components/tests/DbtTestCode.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/DbtTestCode.tsx
@@ -5,11 +5,15 @@ import { panelLogger } from "@modules/logger";
 import { CodeBlock } from "@uicore";
 import { useEffect, useState } from "react";
 
+interface GetTestCodeResponse {
+  sql?: string;
+  config?: string;
+}
 const DbtTestCode = ({ test }: { test: DBTModelTest }): JSX.Element | null => {
   const {
     state: { currentDocsData },
   } = useDocumentationContext();
-  const [testCode, setTestCode] = useState("");
+  const [testCode, setTestCode] = useState<GetTestCodeResponse | null>(null);
 
   panelLogger.info(testCode);
   const loadTestCode = async () => {
@@ -19,8 +23,8 @@ const DbtTestCode = ({ test }: { test: DBTModelTest }): JSX.Element | null => {
     const result = (await executeRequestInSync("getTestCode", {
       test,
       model: currentDocsData.name,
-    })) as { code: string };
-    setTestCode(result.code);
+    })) as GetTestCodeResponse;
+    setTestCode(result);
   };
 
   useEffect(() => {
@@ -37,7 +41,16 @@ const DbtTestCode = ({ test }: { test: DBTModelTest }): JSX.Element | null => {
     return null;
   }
 
-  return <CodeBlock code={testCode} language="sql" fileName="Details" />;
+  return (
+    <>
+      {testCode.config ? (
+        <CodeBlock code={testCode.config} language="yaml" fileName="Config" />
+      ) : null}
+      {testCode.sql ? (
+        <CodeBlock code={testCode.sql} language="sql" fileName="Source" />
+      ) : null}
+    </>
+  );
 };
 
 export default DbtTestCode;

--- a/webview_panels/src/modules/documentationEditor/components/tests/DisplayTestDetails.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/DisplayTestDetails.tsx
@@ -16,8 +16,6 @@ import {
   CardFooter,
   CardTitle,
   IconButton,
-  ListGroup,
-  ListGroupItem,
   Stack,
   Tag,
 } from "@uicore";
@@ -29,7 +27,7 @@ import useTestFormSave, { TestOperation } from "./hooks/useTestFormSave";
 import classes from "../../styles.module.scss";
 import { DeleteIcon, EditIcon } from "@assets/icons";
 import { findDbtTestType } from "./utils";
-import DbtTestCode from "./DbtTestCode";
+import TestDetails from "./TestDetails";
 
 const schema = Yup.object({
   to: Yup.string().optional(),
@@ -197,76 +195,6 @@ const DisplayTestDetails = ({ onClose, test, column }: Props): JSX.Element => {
     }
   };
 
-  const getDisplayContent = () => {
-    switch (testType) {
-      case DbtTestTypes.GENERIC:
-        switch (test.test_metadata?.name) {
-          case DbtGenericTests.UNIQUE:
-          case DbtGenericTests.NOT_NULL:
-            return null;
-          case DbtGenericTests.ACCEPTED_VALUES:
-            return (
-              <Card>
-                <CardBody>
-                  <CardTitle className="d-flex justify-content-between">
-                    Values
-                  </CardTitle>
-                  <ListGroup className={classes.testListGroup}>
-                    {(
-                      test.test_metadata
-                        .kwargs as TestMetadataAcceptedValuesKwArgs
-                    ).values?.map((value) => (
-                      <ListGroupItem key={value} tag="div">
-                        {value}
-                      </ListGroupItem>
-                    ))}
-                  </ListGroup>
-                </CardBody>
-              </Card>
-            );
-          case DbtGenericTests.RELATIONSHIPS:
-            return (
-              <Card>
-                <CardBody>
-                  <CardTitle className="d-flex justify-content-between">
-                    Values
-                  </CardTitle>
-                  <ListGroup className={classes.testListGroup}>
-                    <ListGroupItem action tag="div">
-                      <caption>To:</caption>{" "}
-                      {
-                        (
-                          test.test_metadata
-                            .kwargs as TestMetadataRelationshipsKwArgs
-                        ).to
-                      }
-                    </ListGroupItem>
-
-                    <ListGroupItem action tag="div">
-                      <caption>Field:</caption>{" "}
-                      {
-                        (
-                          test.test_metadata
-                            .kwargs as TestMetadataRelationshipsKwArgs
-                        ).field
-                      }
-                    </ListGroupItem>
-                  </ListGroup>
-                </CardBody>
-              </Card>
-            );
-
-          default:
-            return null;
-        }
-      case DbtTestTypes.MACRO:
-      case DbtTestTypes.SINGULAR:
-      case DbtTestTypes.EXTERNAL_PACKAGE:
-        return <DbtTestCode test={test} />;
-      default:
-        return null;
-    }
-  };
   return (
     <Stack direction="column" className={classes.addTest}>
       <Card>
@@ -300,7 +228,11 @@ const DisplayTestDetails = ({ onClose, test, column }: Props): JSX.Element => {
       </Card>
 
       <form onSubmit={handleSubmit(onSubmit)}>
-        {isInEditMode ? getEditableContent() : getDisplayContent()}
+        {isInEditMode ? (
+          getEditableContent()
+        ) : (
+          <TestDetails test={test} testType={testType} />
+        )}
       </form>
     </Stack>
   );

--- a/webview_panels/src/modules/documentationEditor/components/tests/TestDetails.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/TestDetails.tsx
@@ -1,0 +1,101 @@
+import {
+  DbtGenericTests,
+  DBTModelTest,
+  DbtTestTypes,
+  TestMetadataAcceptedValuesKwArgs,
+  TestMetadataRelationshipsKwArgs,
+} from "@modules/documentationEditor/state/types";
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  ListGroup,
+  ListGroupItem,
+  Stack,
+} from "@uicore";
+import { useMemo } from "react";
+import classes from "../../styles.module.scss";
+import DbtTestCode from "./DbtTestCode";
+
+interface Props {
+  testType: DbtTestTypes;
+  test: DBTModelTest;
+}
+
+const TestDetails = ({ testType, test }: Props): JSX.Element => {
+  const testConfig = useMemo(() => {
+    switch (testType) {
+      case DbtTestTypes.GENERIC:
+        switch (test.test_metadata?.name) {
+          case DbtGenericTests.UNIQUE:
+          case DbtGenericTests.NOT_NULL:
+            return null;
+          case DbtGenericTests.ACCEPTED_VALUES:
+            return (
+              <Card>
+                <CardBody>
+                  <CardTitle className="d-flex justify-content-between">
+                    Values
+                  </CardTitle>
+                  <ListGroup className={classes.testListGroup}>
+                    {(
+                      test.test_metadata
+                        .kwargs as TestMetadataAcceptedValuesKwArgs
+                    ).values?.map((value) => (
+                      <ListGroupItem key={value} tag="div">
+                        {value}
+                      </ListGroupItem>
+                    ))}
+                  </ListGroup>
+                </CardBody>
+              </Card>
+            );
+          case DbtGenericTests.RELATIONSHIPS:
+            return (
+              <Card>
+                <CardBody>
+                  <CardTitle className="d-flex justify-content-between">
+                    Values
+                  </CardTitle>
+                  <ListGroup className={classes.testListGroup}>
+                    <ListGroupItem action tag="div">
+                      <caption>To:</caption>{" "}
+                      {
+                        (
+                          test.test_metadata
+                            .kwargs as TestMetadataRelationshipsKwArgs
+                        ).to
+                      }
+                    </ListGroupItem>
+
+                    <ListGroupItem action tag="div">
+                      <caption>Field:</caption>{" "}
+                      {
+                        (
+                          test.test_metadata
+                            .kwargs as TestMetadataRelationshipsKwArgs
+                        ).field
+                      }
+                    </ListGroupItem>
+                  </ListGroup>
+                </CardBody>
+              </Card>
+            );
+
+          default:
+            return null;
+        }
+      default:
+        return null;
+    }
+  }, []);
+
+  return (
+    <Stack direction="column">
+      {testConfig}
+      <DbtTestCode test={test} />
+    </Stack>
+  );
+};
+
+export default TestDetails;

--- a/webview_panels/src/modules/documentationEditor/components/tests/TestDetails.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/TestDetails.tsx
@@ -9,6 +9,7 @@ import {
   Card,
   CardBody,
   CardTitle,
+  Label,
   ListGroup,
   ListGroupItem,
   Stack,
@@ -57,27 +58,36 @@ const TestDetails = ({ testType, test }: Props): JSX.Element => {
                   <CardTitle className="d-flex justify-content-between">
                     Values
                   </CardTitle>
-                  <ListGroup className={classes.testListGroup}>
-                    <ListGroupItem action tag="div">
-                      <caption>To:</caption>{" "}
-                      {
-                        (
-                          test.test_metadata
-                            .kwargs as TestMetadataRelationshipsKwArgs
-                        ).to
-                      }
-                    </ListGroupItem>
-
-                    <ListGroupItem action tag="div">
-                      <caption>Field:</caption>{" "}
-                      {
-                        (
-                          test.test_metadata
-                            .kwargs as TestMetadataRelationshipsKwArgs
-                        ).field
-                      }
-                    </ListGroupItem>
-                  </ListGroup>
+                  <Stack direction="column">
+                    <div>
+                      <Label>To:</Label>
+                      <div
+                        className="p-2 px-3 rounded"
+                        style={{ background: "var(--background--02)" }}
+                      >
+                        {
+                          (
+                            test.test_metadata
+                              .kwargs as TestMetadataRelationshipsKwArgs
+                          ).to
+                        }
+                      </div>
+                    </div>
+                    <div>
+                      <Label>Field:</Label>
+                      <div
+                        className="p-2 px-3 rounded"
+                        style={{ background: "var(--background--02)" }}
+                      >
+                        {
+                          (
+                            test.test_metadata
+                              .kwargs as TestMetadataRelationshipsKwArgs
+                          ).field
+                        }
+                      </div>
+                    </div>
+                  </Stack>
                 </CardBody>
               </Card>
             );

--- a/webview_panels/src/modules/documentationEditor/components/tests/TestDetails.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/TestDetails.tsx
@@ -28,9 +28,6 @@ const TestDetails = ({ testType, test }: Props): JSX.Element => {
     switch (testType) {
       case DbtTestTypes.GENERIC:
         switch (test.test_metadata?.name) {
-          case DbtGenericTests.UNIQUE:
-          case DbtGenericTests.NOT_NULL:
-            return null;
           case DbtGenericTests.ACCEPTED_VALUES:
             return (
               <Card>
@@ -93,12 +90,14 @@ const TestDetails = ({ testType, test }: Props): JSX.Element => {
             );
 
           default:
-            return null;
+            break;
         }
+        break;
       default:
-        return null;
+        break;
     }
-  }, []);
+    return null;
+  }, [testType, test.test_metadata]);
 
   return (
     <Stack direction="column">

--- a/webview_panels/src/modules/documentationEditor/styles.module.scss
+++ b/webview_panels/src/modules/documentationEditor/styles.module.scss
@@ -227,6 +227,7 @@
     margin: 0;
     font-weight: 400;
     margin-bottom: 1rem;
+    padding-bottom: 0;
   }
 
   :global .card-body {

--- a/webview_panels/src/uiCore/components/codeblock/index.tsx
+++ b/webview_panels/src/uiCore/components/codeblock/index.tsx
@@ -6,7 +6,7 @@ import { Themes } from "@modules/app/types";
 
 interface Props {
   code: string;
-  language: "sql";
+  language: "sql" | "yaml";
   fileName?: string;
 }
 const CodeBlockComponent = ({


### PR DESCRIPTION
## Overview

### Problem
1. In the new tests section in documentation editor, if a model/column has manually created macro test with below sample code in `macros` directory, the sql code is not display in right side panel, when clicking the macro name.
```
{% test positive_value(model, column_name) %}
SELECT
    *
FROM
    {{ model }}
WHERE
    {{ column_name}} < 1
{% endtest %}
```
2. If a test for column/model has extra config like [this example ](https://docs.getdbt.com/reference/resource-configs/where#examples), show these extra config in right side panel

### Solution
1. Modified the code to add the test macros also from `macros` directory into `macroMetamap` and use the information to find the file path for generating tests data
2. Modified `getTestCode` command to get sql source and also extra configs from schema.yml


### Screenshot/Demo:
Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/02b14850-9021-4c91-a440-2924e934b79c)  | ![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/344c0e35-ab0d-4523-8187-c8f5077d7527)

![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/bd872a0a-189a-4671-b600-5150630fe5d0) ![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/cfb82f21-44fd-4a90-9e39-a3fbe67d2b78) ![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/560d9590-23ae-4f4b-a795-0c476e3771d6)


### How to test
- Add a test macro with above sample code in dbt project/macros directory
- Apply the test to a column in schema file like below
```
    - name: minimum_nights
        tests:
          - positive_value
```
- Open documentation editor and select tests
- Click `positive_value` test from the column
- Right side panel should show the sql code from macros directory
- Add extra configs for generic tests ex: 
```
- unique:
              where: "minimum_nights < 10"
```
- Add tests from external packages like dbt utils or expectations. Ex:
```
- dbt_expectations.expect_column_quantile_values_to_be_between:
              quantile: .99
              min_value: 50
              max_value: 500
```
- Right side panel for each test should show the extra config as in screenshots

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
