### PR TITLE
chore: add telemetry events for tests

### DIFF
--- a/src/webview_provider/newDocsGenPanel.ts
+++ b/src/webview_provider/newDocsGenPanel.ts
@@ -250,6 +250,11 @@ export class NewDocsGenPanel
         });
       case "getColumnsOfSources":
         try {
+          this.telemetry.sendTelemetryEvent("getColumnsOfSources", {
+            source: args.source as string,
+            table: args.table as string,
+          });
+
           const columnsFromSources = await this.queryManifestService
             .getProject()
             ?.getColumnsOfSource(args.source as string, args.table as string);
@@ -282,6 +287,9 @@ export class NewDocsGenPanel
         break;
       case "getColumnsOfModel":
         try {
+          this.telemetry.sendTelemetryEvent("getColumnsOfModel", {
+            source: args.model as string,
+          });
           const columns = await this.queryManifestService
             .getProject()
             ?.getColumnsOfModel(args.model as string);

--- a/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
+++ b/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
@@ -1,5 +1,8 @@
 import { CheckedSquareIcon, EmptySquareIcon } from "@assets/icons";
-import { executeRequestInSync } from "@modules/app/requestExecutor";
+import {
+  executeRequestInAsync,
+  executeRequestInSync,
+} from "@modules/app/requestExecutor";
 import useAppContext from "@modules/app/useAppContext";
 import CommonActionButtons from "@modules/commonActionButtons/CommonActionButtons";
 import { EntityType } from "@modules/dataPilot/components/docGen/types";
@@ -34,6 +37,12 @@ const DocumentationEditor = (): JSX.Element => {
       dispatch(removeFromSelectedPage(page));
       return;
     }
+    executeRequestInAsync("sendTelemetryEvent", {
+      eventName: `${page}-opened`,
+      properties: {
+        model: currentDocsData?.name,
+      },
+    });
     dispatch(addToSelectedPage(page));
   };
 

--- a/webview_panels/src/modules/documentationEditor/components/tests/AddTest.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/AddTest.tsx
@@ -16,6 +16,7 @@ import { useRef, useState } from "react";
 import TestForm from "./forms/TestForm";
 import classes from "../../styles.module.scss";
 import useTestFormSave, { TestOperation } from "./hooks/useTestFormSave";
+import { executeRequestInAsync } from "@modules/app/requestExecutor";
 
 interface Props {
   title: string;
@@ -29,6 +30,12 @@ const AddTest = ({ title, currentTests }: Props): JSX.Element => {
   const { handleSave } = useTestFormSave();
 
   const handleNewTestClick = (test: DbtGenericTests) => {
+    executeRequestInAsync("sendTelemetryEvent", {
+      eventName: `addNewTest`,
+      properties: {
+        test,
+      },
+    });
     if (test === DbtGenericTests.NOT_NULL || test === DbtGenericTests.UNIQUE) {
       handleSave({ test }, title, TestOperation.CREATE);
       setShowButtons(false);

--- a/webview_panels/src/modules/documentationEditor/components/tests/DisplayTestDetails.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/DisplayTestDetails.tsx
@@ -30,6 +30,8 @@ import classes from "../../styles.module.scss";
 import { DeleteIcon, EditIcon } from "@assets/icons";
 import { findDbtTestType } from "./utils";
 import DbtTestCode from "./DbtTestCode";
+import { executeRequestInAsync } from "@modules/app/requestExecutor";
+import useDocumentationContext from "@modules/documentationEditor/state/useDocumentationContext";
 
 const schema = Yup.object({
   to: Yup.string().optional(),
@@ -47,6 +49,9 @@ const DisplayTestDetails = ({ onClose, test, column }: Props): JSX.Element => {
   const { control, handleSubmit, setValue, watch } = useForm<SaveRequest>({
     resolver: yupResolver(schema),
   });
+  const {
+    state: { currentDocsData },
+  } = useDocumentationContext();
 
   const { isSaving, handleSave } = useTestFormSave();
 
@@ -61,6 +66,13 @@ const DisplayTestDetails = ({ onClose, test, column }: Props): JSX.Element => {
 
   const handleDelete = () => {
     panelLogger.info("delete test", test);
+    executeRequestInAsync("sendTelemetryEvent", {
+      eventName: `deleteTest`,
+      properties: {
+        column,
+        model: currentDocsData?.name,
+      },
+    });
     handleSave(
       { test: test.test_metadata?.name as DbtGenericTests },
       column,
@@ -70,6 +82,13 @@ const DisplayTestDetails = ({ onClose, test, column }: Props): JSX.Element => {
   };
 
   const handleEdit = () => {
+    executeRequestInAsync("sendTelemetryEvent", {
+      eventName: `editTest`,
+      properties: {
+        column,
+        model: currentDocsData?.name,
+      },
+    });
     setIsInEditMode(true);
     if (test.test_metadata?.name === DbtGenericTests.ACCEPTED_VALUES) {
       setValue(
@@ -93,6 +112,13 @@ const DisplayTestDetails = ({ onClose, test, column }: Props): JSX.Element => {
   };
 
   const handleCancel = () => {
+    executeRequestInAsync("sendTelemetryEvent", {
+      eventName: `editTestCancel`,
+      properties: {
+        column,
+        model: currentDocsData?.name,
+      },
+    });
     setIsInEditMode(false);
   };
 

--- a/webview_panels/src/modules/documentationEditor/components/tests/EntityWithTests.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/EntityWithTests.tsx
@@ -8,6 +8,7 @@ import DisplayTestDetails from "./DisplayTestDetails";
 import classes from "../../styles.module.scss";
 import useDocumentationContext from "@modules/documentationEditor/state/useDocumentationContext";
 import { TestsIcon } from "@assets/icons";
+import { executeRequestInAsync } from "@modules/app/requestExecutor";
 
 interface Props {
   title: string;
@@ -19,7 +20,7 @@ const MaxVisibleTests = 3;
 
 const EntityWithTests = ({ title, tests, type }: Props): JSX.Element | null => {
   const {
-    state: { selectedPages },
+    state: { selectedPages, currentDocsData },
   } = useDocumentationContext();
   const [selectedTest, setSelectedTest] = useState<DBTModelTest | null>(null);
   const [showAllTests, setshowAllTests] = useState(false);
@@ -32,6 +33,13 @@ const EntityWithTests = ({ title, tests, type }: Props): JSX.Element | null => {
   const handleShowAllTests = () => setshowAllTests(true);
 
   const onSelect = (test: DBTModelTest) => {
+    executeRequestInAsync("sendTelemetryEvent", {
+      eventName: `showTestDetails`,
+      properties: {
+        column: EntityType.COLUMN === type ? title : undefined,
+        model: currentDocsData?.name,
+      },
+    });
     setSelectedTest(test);
     drawerRef.current?.open();
   };

--- a/webview_panels/src/modules/documentationEditor/components/tests/forms/TestForm.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/forms/TestForm.tsx
@@ -16,6 +16,7 @@ import Relationships from "./Relationships";
 import { useEffect, useMemo } from "react";
 import useTestFormSave, { TestOperation } from "../hooks/useTestFormSave";
 import { SaveRequest } from "../types";
+import { executeRequestInAsync } from "@modules/app/requestExecutor";
 
 interface Props {
   formType: DbtGenericTests;
@@ -57,6 +58,12 @@ const TestForm = ({ formType, onClose, column }: Props): JSX.Element | null => {
 
   const handleCancel = () => {
     reset();
+    executeRequestInAsync("sendTelemetryEvent", {
+      eventName: `addTestCancelled`,
+      properties: {
+        column,
+      },
+    });
     if (!isSaving) {
       onClose();
     }

--- a/webview_panels/src/modules/documentationEditor/components/tests/hooks/useTestFormSave.ts
+++ b/webview_panels/src/modules/documentationEditor/components/tests/hooks/useTestFormSave.ts
@@ -12,6 +12,7 @@ import {
   TestMetadataRelationshipsKwArgs,
   TestMetadataAcceptedValuesKwArgs,
 } from "@modules/documentationEditor/state/types";
+import { executeRequestInAsync } from "@modules/app/requestExecutor";
 
 export enum TestOperation {
   CREATE,
@@ -136,6 +137,15 @@ const useTestFormSave = (): {
       return;
     }
 
+    executeRequestInAsync("sendTelemetryEvent", {
+      eventName: `saveTest`,
+      properties: {
+        column,
+        model: currentDocsData?.name,
+        data,
+        operation,
+      },
+    });
     const testsData = getUpdatedTestsData(data, column, operation);
     panelLogger.info("add/update test data", testsData);
     dispatch(updateCurrentDocsTests(testsData));

--- a/webview_panels/src/modules/documentationEditor/state/types.ts
+++ b/webview_panels/src/modules/documentationEditor/state/types.ts
@@ -6,9 +6,9 @@ export enum Source {
 }
 
 export enum Pages {
-  DOCUMENTATION,
-  TESTS,
-  TAGS,
+  DOCUMENTATION = "Documentation",
+  TAGS = "Tags",
+  TESTS = "Tests",
 }
 export interface MetadataColumn {
   name: string;


### PR DESCRIPTION
## Overview

### Problem
Telemetry events are missing for new tests feature

### Solution
Add telemetry events for following actions:
- [x] checking tests in header to see tests
- [x] adding dbt generic test
- [x] for accepted_values, getting values of columns
- [x] for relationships getting columns of models/sources
- [x] cancelling add test form
- [x] click on a test to see details in right panel
- [x] click edit
- [x] click delete
- [x] click update

### Screenshot/Demo
NA

### How to test
- Perform the above listed actions in vscode extension
- Telemetry events should be logged

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
