### PR TITLE
Support metrics

### DIFF
--- a/new_lineage_panel/src/CustomNodes.tsx
+++ b/new_lineage_panel/src/CustomNodes.tsx
@@ -171,7 +171,10 @@ export const TableNode: FunctionComponent<NodeProps> = ({ data }) => {
     if (!selected) return;
     e.stopPropagation();
     setShowSidebar(true);
-    if (flow.getNode(selectedTable)?.data?.nodeType === "exposure") {
+    if (nodeType === "metrics") {
+      return;
+    }
+    if (nodeType === "exposure") {
       setSidebarScreen(EXPOSURE_SIDEBAR);
       return;
     }
@@ -273,7 +276,7 @@ export const TableNode: FunctionComponent<NodeProps> = ({ data }) => {
               <div
                 className={classNames(
                   "nodrag",
-                  selected ? "text-blue" : "text-grey"
+                  selected && nodeType !== "metrics" ? "text-blue" : "text-grey"
                 )}
                 onClick={onDetailsClick}
                 data-testid={"view-details-btn-" + table}

--- a/new_lineage_panel/src/CustomNodes.tsx
+++ b/new_lineage_panel/src/CustomNodes.tsx
@@ -168,12 +168,12 @@ export const TableNode: FunctionComponent<NodeProps> = ({ data }) => {
   const expandLeft = () => expand(false);
 
   const onDetailsClick = (e: React.MouseEvent) => {
-    if (!selected) return;
     e.stopPropagation();
-    setShowSidebar(true);
-    if (nodeType === "metrics") {
+    if (!selected) return;
+    if (nodeType === "semantic_model") {
       return;
     }
+    setShowSidebar(true);
     if (nodeType === "exposure") {
       setSidebarScreen(EXPOSURE_SIDEBAR);
       return;
@@ -276,7 +276,7 @@ export const TableNode: FunctionComponent<NodeProps> = ({ data }) => {
               <div
                 className={classNames(
                   "nodrag",
-                  selected && nodeType !== "metrics" ? "text-blue" : "text-grey"
+                  selected && nodeType !== "semantic_model" ? "text-blue" : "text-grey"
                 )}
                 onClick={onDetailsClick}
                 data-testid={"view-details-btn-" + table}

--- a/new_lineage_panel/src/components/Column.tsx
+++ b/new_lineage_panel/src/components/Column.tsx
@@ -68,7 +68,7 @@ export const NodeTypeIcon: FunctionComponent<{ nodeType: string }> = ({
     {nodeType === "exposure" && <ExposureIcon />}
     {nodeType === "analysis" && <AnalysisIcon />}
     {nodeType === "snapshot" && <SnapshotIcon />}
-    {nodeType === "metrics" && <MetricsIcon />}
+    {nodeType === "semantic_model" && <MetricsIcon />}
     {nodeType === "macros" && <MacrosIcon />}
   </div>
 );
@@ -94,7 +94,7 @@ export const NODE_TYPE_STYLES = {
   source: styles.source,
   exposure: styles.exposure,
   snapshot: styles.snapshot,
-  metrics: styles.metrics,
+  semantic_model: styles.metrics,
   macros: styles.macros,
   analysis: styles.analysis,
 };
@@ -105,7 +105,7 @@ export const NODE_TYPE_SHORTHAND = {
   source: "SRC",
   exposure: "EXP",
   snapshot: "SNP",
-  metrics: "MET",
+  semantic_model: "MET",
   macros: "SEM",
   analysis: "ANY",
 };

--- a/src/commands/runModel.ts
+++ b/src/commands/runModel.ts
@@ -84,6 +84,9 @@ export class RunModel {
         this.runModelOnActiveWindow(type);
         return;
       }
+      if (!model.url) {
+        return;
+      }
       switch (type) {
         case RunModelType.TEST: {
           if (model.label) {

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -189,7 +189,7 @@ export class Exposure extends Node {
   displayInModelTree = true;
 }
 export class Metric extends Node {
-  displayInModelTree = true;
+  displayInModelTree = false;
 }
 export class Snapshot extends Node {}
 export class Source extends Node {

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 
 export type NodeMetaMap = Map<string, NodeMetaData>;
 export type MacroMetaMap = Map<string, MacroMetaData>;
+export type MetricMetaMap = Map<string, MetricMetaData>;
 export type SourceMetaMap = Map<string, SourceMetaData>;
 export type TestMetaMap = Map<string, TestMetaData>;
 export type ExposureMetaMap = Map<string, ExposureMetaData>;
@@ -13,6 +14,10 @@ interface MacroMetaData {
   path: string;
   line: number;
   character: number;
+}
+
+interface MetricMetaData {
+  name: string;
 }
 
 export interface NodeMetaData {
@@ -129,6 +134,7 @@ export interface GraphMetaMap {
   parents: NodeGraphMap;
   children: NodeGraphMap;
   tests: NodeGraphMap;
+  metrics: NodeGraphMap;
 }
 
 interface IconPath {
@@ -139,7 +145,7 @@ interface IconPath {
 export abstract class Node {
   label: string;
   key: string;
-  url: string;
+  url: string | undefined;
   iconPath: IconPath = {
     light: path.join(
       path.resolve(__dirname),
@@ -149,7 +155,7 @@ export abstract class Node {
   };
   displayInModelTree: boolean = true;
 
-  constructor(label: string, key: string, url: string) {
+  constructor(label: string, key: string, url?: string) {
     this.label = label;
     this.key = key;
     this.url = url;
@@ -173,6 +179,9 @@ export class Analysis extends Node {
   displayInModelTree = true;
 }
 export class Exposure extends Node {
+  displayInModelTree = true;
+}
+export class Metric extends Node {
   displayInModelTree = true;
 }
 export class Snapshot extends Node {}

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -71,7 +71,7 @@ export class DBTProject implements Disposable {
   static RESOURCE_TYPE_SEED = "seed";
   static RESOURCE_TYPE_SNAPSHOT = "snapshot";
   static RESOURCE_TYPE_TEST = "test";
-  static RESOURCE_TYPE_METRIC = "metric";
+  static RESOURCE_TYPE_METRIC = "metrics";
 
   readonly projectRoot: Uri;
   private projectConfig: any; // TODO: typing

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -71,6 +71,7 @@ export class DBTProject implements Disposable {
   static RESOURCE_TYPE_SEED = "seed";
   static RESOURCE_TYPE_SNAPSHOT = "snapshot";
   static RESOURCE_TYPE_TEST = "test";
+  static RESOURCE_TYPE_METRIC = "metric";
 
   readonly projectRoot: Uri;
   private projectConfig: any; // TODO: typing

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -71,7 +71,7 @@ export class DBTProject implements Disposable {
   static RESOURCE_TYPE_SEED = "seed";
   static RESOURCE_TYPE_SNAPSHOT = "snapshot";
   static RESOURCE_TYPE_TEST = "test";
-  static RESOURCE_TYPE_METRIC = "metrics";
+  static RESOURCE_TYPE_METRIC = "semantic_model";
 
   readonly projectRoot: Uri;
   private projectConfig: any; // TODO: typing

--- a/src/manifest/event/manifestCacheChangedEvent.ts
+++ b/src/manifest/event/manifestCacheChangedEvent.ts
@@ -4,6 +4,7 @@ import {
   ExposureMetaMap,
   GraphMetaMap,
   MacroMetaMap,
+  MetricMetaMap,
   NodeMetaMap,
   SourceMetaMap,
   TestMetaMap,
@@ -14,6 +15,7 @@ export interface ManifestCacheProjectAddedEvent {
   project: DBTProject;
   nodeMetaMap: NodeMetaMap;
   macroMetaMap: MacroMetaMap;
+  metricMetaMap: MetricMetaMap;
   sourceMetaMap: SourceMetaMap;
   graphMetaMap: GraphMetaMap;
   testMetaMap: TestMetaMap;

--- a/src/manifest/parsers/graphParser.ts
+++ b/src/manifest/parsers/graphParser.ts
@@ -112,7 +112,7 @@ export class GraphParser {
               metricMetaMap,
             ),
           )
-          .filter((n) => n instanceof Test)
+          .filter((n) => n instanceof Metric)
           .filter(notEmpty);
         map.set(nodeName, { nodes: currentNodes });
         return map;

--- a/src/manifest/parsers/index.ts
+++ b/src/manifest/parsers/index.ts
@@ -13,6 +13,7 @@ import { SourceParser } from "./sourceParser";
 import { TestParser } from "./testParser";
 import { TelemetryService } from "../../telemetry";
 import { ExposureParser } from "./exposureParser";
+import { MetricParser } from "./metricParser";
 
 @provide(ManifestParser)
 export class ManifestParser {
@@ -21,6 +22,7 @@ export class ManifestParser {
   constructor(
     private nodeParser: NodeParser,
     private macroParser: MacroParser,
+    private metricParser: MetricParser,
     private graphParser: GraphParser,
     private sourceParser: SourceParser,
     private testParser: TestParser,
@@ -55,12 +57,14 @@ export class ManifestParser {
             project,
             nodeMetaMap: new Map(),
             macroMetaMap: new Map(),
+            metricMetaMap: new Map(),
             sourceMetaMap: new Map(),
             testMetaMap: new Map(),
             graphMetaMap: {
               parents: new Map(),
               children: new Map(),
               tests: new Map(),
+              metrics: new Map(),
             },
             docMetaMap: new Map(),
             exposureMetaMap: new Map(),
@@ -70,8 +74,16 @@ export class ManifestParser {
       return event;
     }
 
-    const { nodes, sources, macros, parent_map, child_map, docs, exposures } =
-      manifest;
+    const {
+      nodes,
+      sources,
+      macros,
+      semantic_models,
+      parent_map,
+      child_map,
+      docs,
+      exposures,
+    } = manifest;
 
     const nodeMetaMapPromise = this.nodeParser.createNodeMetaMap(
       nodes,
@@ -79,6 +91,10 @@ export class ManifestParser {
     );
     const macroMetaMapPromise = this.macroParser.createMacroMetaMap(
       macros,
+      project,
+    );
+    const metricMetaMapPromise = this.metricParser.createMetricMetaMap(
+      semantic_models,
       project,
     );
     const sourceMetaMapPromise = this.sourceParser.createSourceMetaMap(
@@ -99,6 +115,7 @@ export class ManifestParser {
     const [
       nodeMetaMap,
       macroMetaMap,
+      metricMetaMap,
       sourceMetaMap,
       testMetaMap,
       docMetaMap,
@@ -106,6 +123,7 @@ export class ManifestParser {
     ] = await Promise.all([
       nodeMetaMapPromise,
       macroMetaMapPromise,
+      metricMetaMapPromise,
       sourceMetaMapPromise,
       testMetaMapPromise,
       docMetaMapPromise,
@@ -119,6 +137,7 @@ export class ManifestParser {
       nodeMetaMap,
       sourceMetaMap,
       testMetaMap,
+      metricMetaMap,
     );
 
     const nodeCounts = Object.values(nodes as any[]).reduce((map, node) => {
@@ -156,6 +175,7 @@ export class ManifestParser {
           project,
           nodeMetaMap: nodeMetaMap,
           macroMetaMap: macroMetaMap,
+          metricMetaMap: metricMetaMap,
           sourceMetaMap: sourceMetaMap,
           graphMetaMap: graphMetaMap,
           testMetaMap: testMetaMap,

--- a/src/manifest/parsers/metricParser.ts
+++ b/src/manifest/parsers/metricParser.ts
@@ -1,0 +1,39 @@
+import { provide } from "inversify-binding-decorators";
+import { DBTTerminal } from "../../dbt_client/dbtTerminal";
+import { DBTProject } from "../dbtProject";
+import { MetricMetaMap } from "../../domain";
+
+@provide(MetricParser)
+export class MetricParser {
+  constructor(private terminal: DBTTerminal) {}
+
+  createMetricMetaMap(
+    metrics: any[],
+    project: DBTProject,
+  ): Promise<MetricMetaMap> {
+    return new Promise(async (resolve) => {
+      this.terminal.debug(
+        "MetricParser",
+        `Parsing metrics for "${project.getProjectName()}" at ${
+          project.projectRoot
+        }`,
+      );
+      const metricMetaMap: MetricMetaMap = new Map();
+      if (metrics === null || metrics === undefined) {
+        resolve(metricMetaMap);
+      }
+      for (const key in metrics) {
+        const metric = metrics[key];
+        metricMetaMap.set(metric.name, { name: metric.name });
+      }
+      this.terminal.debug(
+        "MetricParser",
+        `Returning metrics for "${project.getProjectName()}" at ${
+          project.projectRoot
+        }`,
+        metricMetaMap,
+      );
+      resolve(metricMetaMap);
+    });
+  }
+}

--- a/src/treeview_provider/modelTreeviewProvider.ts
+++ b/src/treeview_provider/modelTreeviewProvider.ts
@@ -290,12 +290,13 @@ class DocTreeItem extends TreeItem {
     super(node.label, TreeItemCollapsibleState.Collapsed);
     this.description = node.description !== undefined ? node.description : " ";
     // this. tooltip = "test tooltip" // node.description !== undefined ? node.description : " ";
-    this.command = {
-      command: "vscode.open",
-      title: "Open YML",
-      arguments: [Uri.file(node.url)],
-    };
-
+    if (node.url) {
+      this.command = {
+        command: "vscode.open",
+        title: "Open YML",
+        arguments: [Uri.file(node.url)],
+      };
+    }
     if (node.iconPath !== undefined) {
       this.iconPath = node.iconPath;
     }
@@ -314,7 +315,7 @@ export class DocNode extends Node {
 export class NodeTreeItem extends TreeItem {
   collapsibleState = TreeItemCollapsibleState.Collapsed;
   key: string;
-  url: string;
+  url: string | undefined;
 
   constructor(node: Node) {
     super(node.label);

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -12,11 +12,7 @@ import {
   WebviewViewResolveContext,
   window,
 } from "vscode";
-import {
-  AltimateRequest,
-  DBTColumnLineageResponse,
-  ModelNode,
-} from "../altimate";
+import { AltimateRequest, ModelNode } from "../altimate";
 import {
   ExposureMetaData,
   GraphMetaMap,
@@ -37,7 +33,7 @@ import { DBTTerminal } from "../dbt_client/dbtTerminal";
 type Table = {
   label: string;
   table: string;
-  url: string;
+  url: string | undefined;
   downstreamCount: number;
   upstreamCount: number;
   nodeType: string;
@@ -671,7 +667,7 @@ export class NewLineagePanel implements LineagePanelView {
 
   private createTable(
     event: ManifestCacheProjectAddedEvent,
-    tableUrl: string,
+    tableUrl: string | undefined,
     key: string,
   ): Table | undefined {
     const nodeType = key.split(".")[0];
@@ -704,6 +700,21 @@ export class NewLineagePanel implements LineagePanelView {
         upstreamCount,
         downstreamCount,
         nodeType,
+        tests: (graphMetaMap["tests"].get(key)?.nodes || []).map((n) => {
+          const testKey = n.label.split(".")[0];
+          return { ...testMetaMap.get(testKey), key: testKey };
+        }),
+      };
+    }
+    if (nodeType === DBTProject.RESOURCE_TYPE_METRIC) {
+      return {
+        table: key,
+        label: key,
+        url: tableUrl,
+        upstreamCount,
+        downstreamCount,
+        nodeType,
+        materialization: undefined,
         tests: (graphMetaMap["tests"].get(key)?.nodes || []).map((n) => {
           const testKey = n.label.split(".")[0];
           return { ...testMetaMap.get(testKey), key: testKey };

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -670,7 +670,8 @@ export class NewLineagePanel implements LineagePanelView {
     tableUrl: string | undefined,
     key: string,
   ): Table | undefined {
-    const nodeType = key.split(".")[0];
+    const splits = key.split(".");
+    const nodeType = splits[0];
     const { graphMetaMap, testMetaMap } = event;
     const upstreamCount = this.getConnectedNodeCount(
       graphMetaMap["children"],
@@ -682,7 +683,6 @@ export class NewLineagePanel implements LineagePanelView {
     );
     if (nodeType === DBTProject.RESOURCE_TYPE_SOURCE) {
       const { sourceMetaMap } = event;
-      const splits = key.split(".");
       const schema = splits[2];
       const table = splits[3];
       const _node = sourceMetaMap.get(schema);
@@ -709,7 +709,7 @@ export class NewLineagePanel implements LineagePanelView {
     if (nodeType === DBTProject.RESOURCE_TYPE_METRIC) {
       return {
         table: key,
-        label: key,
+        label: splits[2],
         url: tableUrl,
         upstreamCount,
         downstreamCount,
@@ -723,9 +723,7 @@ export class NewLineagePanel implements LineagePanelView {
     }
     const { nodeMetaMap } = event;
 
-    const splits = key.split(".");
     const table = splits[2];
-
     if (nodeType === DBTProject.RESOURCE_TYPE_EXPOSURE) {
       return {
         table: key,

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -715,10 +715,7 @@ export class NewLineagePanel implements LineagePanelView {
         downstreamCount,
         nodeType,
         materialization: undefined,
-        tests: (graphMetaMap["tests"].get(key)?.nodes || []).map((n) => {
-          const testKey = n.label.split(".")[0];
-          return { ...testMetaMap.get(testKey), key: testKey };
-        }),
+        tests: [],
       };
     }
     const { nodeMetaMap } = event;
@@ -733,10 +730,7 @@ export class NewLineagePanel implements LineagePanelView {
         downstreamCount,
         nodeType,
         materialization: undefined,
-        tests: (graphMetaMap["tests"].get(key)?.nodes || []).map((n) => {
-          const testKey = n.label.split(".")[0];
-          return { ...testMetaMap.get(testKey), key: testKey };
-        }),
+        tests: [],
       };
     }
 


### PR DESCRIPTION
## Overview

### Problem

Support metrics in lineage panel and tree view

### Solution

Only semantic_model is supported

### Screenshot/Demo

<img width="907" alt="image" src="https://github.com/AltimateAI/vscode-dbt-power-user/assets/9265503/4aff20f2-a51b-4d85-b203-0b499c847f9c">

Currently incorrectly shown as view @AdiGajbhiye 

### How to test

Add metrics to your project for example:

```
semantic_models:
  #The name of the semantic model.
  - name: orders
    defaults:
      agg_time_dimension: ordered_at
    description: |
      Order fact table. This table is at the order grain with one row per order. 
    #The name of the dbt model and schema
    model: ref('orders')
```

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
