### PR TITLE
fix: cancel state not resetting

### DIFF
--- a/new_lineage_panel/src/service_utils.ts
+++ b/new_lineage_panel/src/service_utils.ts
@@ -82,6 +82,7 @@ export class CLL {
 
   static start() {
     CLL.inProgress = true;
+    CLL.isCancelled = false;
     CLL.linkCount = 0;
     vscode.postMessage({
       command: "columnLineage",


### PR DESCRIPTION
## Overview

### Problem

After cancelling column lineage once, unable to perform column lineage at all.

### Solution

cancel state was not getting reset. Fix it

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
