### PR TITLE
improve: sort translate options and debug log

### DIFF
--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -931,7 +931,12 @@ select * from renamed
   }
 
   public findPackageVersion(packageName: string) {
-    return this.dbtProjectIntegration.findPackageVersion(packageName);
+    const version = this.dbtProjectIntegration.findPackageVersion(packageName);
+    this.terminal.debug(
+      "dbtProject:findPackageVersion",
+      `found ${packageName} version: ${version}`,
+    );
+    return version;
   }
 
   async getNodesWithDBColumns(

--- a/webview_panels/src/modules/dataPilot/components/queryAnalysis/components/QueryTranslateDialectSelects.tsx
+++ b/webview_panels/src/modules/dataPilot/components/queryAnalysis/components/QueryTranslateDialectSelects.tsx
@@ -43,7 +43,7 @@ const QueryTranslateDialectSelects = (): JSX.Element => {
   const { chat, onNewGeneration, history } = useQueryAnalysisContext();
   const { dispatch } = useDataPilotContext();
 
-  const dialectOptions: OptionType[] = SqlDialects.map((d) => ({
+  const dialectOptions: OptionType[] = SqlDialects.sort().map((d) => ({
     label: d,
     value: d,
   }));


### PR DESCRIPTION
## Overview

### Problem
- While trying to translate query, it was difficult to find right adapter
- Add debug log for package version for debugging

### Solution
- sorted the translate dialect options
- debug log for package version

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- In query translation, check the options shown in translate dropdowns. Should be sorted in alphabetical order
- If dbt utils or expectations is installed in the project, while making translate api call, this should show in debug log

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
