### PR TITLE
fix: save documentation in different yml s

### DIFF
--- a/webview_panels/src/modules/documentationEditor/components/saveDocumentation/SaveDocumentation.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/saveDocumentation/SaveDocumentation.tsx
@@ -37,11 +37,7 @@ const SaveDocumentation = (): JSX.Element | null => {
   };
 
   useEffect(() => {
-    if (!currentDocsData?.patchPath) {
-      return;
-    }
-
-    setPatchPath(currentDocsData.patchPath);
+    setPatchPath(currentDocsData?.patchPath ?? "");
   }, [currentDocsData?.patchPath]);
 
   const handleChange = (newValue: string) => {

--- a/webview_panels/src/modules/documentationEditor/components/tests/DisplayTestDetails.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/DisplayTestDetails.tsx
@@ -28,6 +28,7 @@ import classes from "../../styles.module.scss";
 import { DeleteIcon, EditIcon } from "@assets/icons";
 import { findDbtTestType } from "./utils";
 import TestDetails from "./TestDetails";
+import { EntityType } from "@modules/dataPilot/components/docGen/types";
 
 const schema = Yup.object({
   to: Yup.string().optional(),
@@ -39,9 +40,15 @@ interface Props {
   onClose: () => void;
   test: DBTModelTest;
   column: string;
+  type: EntityType;
 }
 
-const DisplayTestDetails = ({ onClose, test, column }: Props): JSX.Element => {
+const DisplayTestDetails = ({
+  onClose,
+  test,
+  column,
+  type,
+}: Props): JSX.Element => {
   const { control, handleSubmit, setValue, watch } = useForm<SaveRequest>({
     resolver: yupResolver(schema),
   });
@@ -55,7 +62,9 @@ const DisplayTestDetails = ({ onClose, test, column }: Props): JSX.Element => {
     test.test_metadata?.name === DbtGenericTests.RELATIONSHIPS;
   const testType = findDbtTestType(test);
   const canDeleteTest =
-    testType !== DbtTestTypes.SINGULAR && testType !== DbtTestTypes.UNKNOWN;
+    testType !== DbtTestTypes.SINGULAR &&
+    testType !== DbtTestTypes.UNKNOWN &&
+    type !== EntityType.MODEL;
 
   const handleDelete = () => {
     panelLogger.info("delete test", test);

--- a/webview_panels/src/modules/documentationEditor/components/tests/EntityWithTests.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/EntityWithTests.tsx
@@ -90,6 +90,7 @@ const EntityWithTests = ({ title, tests, type }: Props): JSX.Element | null => {
             onClose={handleClose}
             test={selectedTest}
             column={title}
+            type={type}
           />
         ) : null}
       </Drawer>


### PR DESCRIPTION
## Overview

### Problem
Issues:
1. 
```
when I am working on a branch and have edited files in multiple folders, each with their own models.yml file I get the following.

1. First file i try to document with the documentation editor, let's say it is in the orders folder, so i try to save its documentation into existing file, select the orders_models.yml file, and that works great
2. i try to document another file, in the customers folder lets say. if i pick existing file, it doesn't ask me to pick a file, it writes it to the order_models.yml file, which is not expected nor something I easily see how to fix without ending up copying and pasting the generated yml to the correct file
```
2. Deleting a custom test in model is not saved

### Solution
- Reason for issue#1 is patch path is not overwritten when user switches models and the model does not have any patch path. So it carried over the previous patch path. Updated code to reset patch path when switching models
- Removed delete option for deleting test in model. Will add a proper fix to delete the test in future PR

### Screenshot/Demo
https://www.awesomescreenshot.com/video/26412512?key=bb5ba9242b57f665e12d471b8076b31b

### How to test
Described in video

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
