### PR TITLE
fix: query explain unnecessary errors

### DIFF
--- a/src/webview_provider/datapilotPanel.ts
+++ b/src/webview_provider/datapilotPanel.ts
@@ -244,7 +244,7 @@ export class DataPilotPanel extends AltimateWebviewProvider {
               await this.queryAnalysisService.getFollowupQuestions(
                 params as { query: string; user_request: string },
               );
-            return { response };
+            return response;
           },
           command,
           true,

--- a/webview_panels/src/modules/dataPilot/components/queryAnalysis/useQueryAnalysisAction.ts
+++ b/webview_panels/src/modules/dataPilot/components/queryAnalysis/useQueryAnalysisAction.ts
@@ -102,6 +102,7 @@ const useQueryAnalysisAction = (): {
           ? undefined
           : (executeRequestInSync("queryanalysis:followup", {
               user_request,
+              filePath: chat?.filePath,
               query: chat?.query,
             }) as Promise<string[] | null>),
       ]);


### PR DESCRIPTION
## Overview

### Problem
- DataPilot explain functionality is not giving text box to ask additional questions.
(Also for a few seconds) - valid SQL model needs to be open in editor message flashes. Also, the text shows for this SQL query instead of dbt model when explanation is printed. 


### Solution
- get follow up questions api was expecting a valid file path which was not passed from webview properly. Added the file path from where the conversation is initiated


### Screenshot/Demo
NA


### How to test
- Open a valid model
- right click -> datapilot -> explain
- Should see valid explanation and follow up questions if available

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
