### PR TITLE
fix: defer for windows

### DIFF
--- a/src/services/deferToProdService.ts
+++ b/src/services/deferToProdService.ts
@@ -12,7 +12,7 @@ export class DeferToProdService {
   }
 
   public getDeferConfigByProjectRoot(projectRoot: string): DeferConfig {
-    const relativePath = getProjectRelativePath(Uri.parse(projectRoot));
+    const relativePath = getProjectRelativePath(Uri.file(projectRoot));
     const currentConfig: Record<string, DeferConfig> =
       this.getDeferConfigByWorkspace();
 

--- a/src/webview_provider/insightsPanel.ts
+++ b/src/webview_provider/insightsPanel.ts
@@ -158,7 +158,7 @@ export class InsightsPanel extends AltimateWebviewProvider {
 
       const currentConfig: Record<string, DeferConfig> =
         this.deferToProdService.getDeferConfigByWorkspace();
-      const root = getProjectRelativePath(Uri.parse(params.projectRoot));
+      const root = getProjectRelativePath(Uri.file(params.projectRoot));
 
       this.dbtTerminal.info(
         "Defer config",
@@ -180,7 +180,7 @@ export class InsightsPanel extends AltimateWebviewProvider {
       };
 
       const workspaceFolder = workspace.getWorkspaceFolder(
-        Uri.parse(params.projectRoot),
+        Uri.file(params.projectRoot),
       );
       await workspace
         .getConfiguration("dbt", workspaceFolder)


### PR DESCRIPTION
## Overview

### Problem
Defer to prod settings is not saved properly in windows machine

### Solution
Uri.parse does not resolve the projectRoot to right project, because of this the right project is not found to save the config. Updated to use Uri.file which can resolve to right project and config is saved

### Screenshot/Demo
NA

### How to test
- Enable/disable defer for a project in actions panel in windows and mac machine
- should be able to save the config

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
