### PR TITLE
fix: have to print env vars twice to display anything

### DIFF
--- a/src/commands/bigQueryCostEstimate.ts
+++ b/src/commands/bigQueryCostEstimate.ts
@@ -20,7 +20,7 @@ export class BigQueryCostEstimate {
       ".sql",
     );
     if (!returnResult) {
-      this.dbtTerminal.show(true);
+      await this.dbtTerminal.show(true);
     }
     try {
       const query = window.activeTextEditor?.document.getText();

--- a/src/dbt_client/dbtIntegration.ts
+++ b/src/dbt_client/dbtIntegration.ts
@@ -63,17 +63,17 @@ export class CLIDBTCommandExecutionStrategy
   ): Promise<CommandProcessResult> {
     const commandExecution = this.executeCommand(command, token);
     const executionPromise = command.logToTerminal
-      ? commandExecution.completeWithTerminalOutput(this.terminal)
-      : commandExecution.complete();
+      ? (await commandExecution).completeWithTerminalOutput(this.terminal)
+      : (await commandExecution).complete();
     return executionPromise;
   }
 
-  protected executeCommand(
+  protected async executeCommand(
     command: DBTCommand,
     token?: CancellationToken,
-  ): CommandProcessExecution {
+  ): Promise<CommandProcessExecution> {
     if (command.logToTerminal && command.focus) {
-      this.terminal.show(true);
+      await this.terminal.show(true);
     }
     this.telemetry.sendTelemetryEvent("dbtCommand", {
       command: command.getCommandAsString(),
@@ -124,21 +124,21 @@ export class PythonDBTCommandExecutionStrategy
     command: DBTCommand,
     token?: CancellationToken,
   ): Promise<CommandProcessResult> {
-    return this.executeCommand(command, token).completeWithTerminalOutput(
-      this.terminal,
-    );
+    return (
+      await this.executeCommand(command, token)
+    ).completeWithTerminalOutput(this.terminal);
   }
 
-  private executeCommand(
+  private async executeCommand(
     command: DBTCommand,
     token?: CancellationToken,
-  ): CommandProcessExecution {
+  ): Promise<CommandProcessExecution> {
     this.terminal.log(`> Executing task: ${command.getCommandAsString()}\n\r`);
     this.telemetry.sendTelemetryEvent("dbtCommand", {
       command: command.getCommandAsString(),
     });
     if (command.focus) {
-      this.terminal.show(true);
+      await this.terminal.show(true);
     }
 
     const { args } = command!;

--- a/src/dbt_client/dbtTerminal.ts
+++ b/src/dbt_client/dbtTerminal.ts
@@ -14,9 +14,9 @@ export class DBTTerminal {
 
   constructor(private telemetry: TelemetryService) {}
 
-  show(status: boolean) {
+  async show(status: boolean) {
     if (status) {
-      this.requireTerminal();
+      await this.requireTerminal();
       this.terminal!.show(!status);
     }
   }
@@ -93,7 +93,7 @@ export class DBTTerminal {
     }
   }
 
-  private requireTerminal() {
+  private async requireTerminal() {
     if (this.terminal === undefined) {
       this.terminal = window.createTerminal({
         name: "Tasks - dbt",
@@ -106,6 +106,7 @@ export class DBTTerminal {
           },
         },
       });
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
   }
 }

--- a/src/manifest/pythonEnvironment.ts
+++ b/src/manifest/pythonEnvironment.ts
@@ -32,10 +32,11 @@ export class PythonEnvironment implements Disposable {
     }
   }
 
-  printEnvVars() {
+  async printEnvVars() {
+    this.dbtTerminal.show(true);
+    await new Promise((resolve) => setTimeout(resolve, 100));
     const envVars = this.environmentVariables;
     this.dbtTerminal.log("Printing environment variables...\r\n");
-    this.dbtTerminal.show(true);
     for (const key in envVars) {
       this.dbtTerminal.log(
         `${key}=${envVars[key]}\t\tsource:${this.environmentVariableSource[key]}\r\n`,

--- a/src/manifest/pythonEnvironment.ts
+++ b/src/manifest/pythonEnvironment.ts
@@ -33,8 +33,7 @@ export class PythonEnvironment implements Disposable {
   }
 
   async printEnvVars() {
-    this.dbtTerminal.show(true);
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await this.dbtTerminal.show(true);
     const envVars = this.environmentVariables;
     this.dbtTerminal.log("Printing environment variables...\r\n");
     for (const key in envVars) {


### PR DESCRIPTION
## Overview

### Problem

have to print env vars twice to display 

### Solution

adding delay between showing and writing to terminal

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
