### PR TITLE
fix: dbt path from python venv in windows

### DIFF
--- a/src/dbt_client/dbtCloudIntegration.ts
+++ b/src/dbt_client/dbtCloudIntegration.ts
@@ -34,7 +34,7 @@ import { DBTProject } from "../manifest/dbtProject";
 import { TelemetryService } from "../telemetry";
 import { DBTTerminal } from "./dbtTerminal";
 import { PythonEnvironment } from "../manifest/pythonEnvironment";
-import { existsSync } from "fs";
+import { readdirSync } from "fs";
 import { ValidationProvider } from "../validation_provider";
 import { DeferToProdService } from "../services/deferToProdService";
 import { ProjectHealthcheck } from "./dbtCoreIntegration";
@@ -44,8 +44,14 @@ function getDBTPath(
   terminal: DBTTerminal,
 ): string {
   if (pythonEnvironment.pythonPath) {
-    const dbtPythonPath = join(dirname(pythonEnvironment.pythonPath), "dbt");
-    if (existsSync(dbtPythonPath)) {
+    const dbtPath = readdirSync(
+      join(dirname(pythonEnvironment.pythonPath)),
+    ).find((fileName) => fileName === "dbt" || fileName === "dbt.exe");
+    if (dbtPath) {
+      const dbtPythonPath = join(
+        dirname(pythonEnvironment.pythonPath),
+        dbtPath,
+      );
       terminal.debug("Found dbt path in Python bin directory:", dbtPythonPath);
       return dbtPythonPath;
     }

--- a/src/dbt_client/dbtCloudIntegration.ts
+++ b/src/dbt_client/dbtCloudIntegration.ts
@@ -34,7 +34,7 @@ import { DBTProject } from "../manifest/dbtProject";
 import { TelemetryService } from "../telemetry";
 import { DBTTerminal } from "./dbtTerminal";
 import { PythonEnvironment } from "../manifest/pythonEnvironment";
-import { readdirSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { ValidationProvider } from "../validation_provider";
 import { DeferToProdService } from "../services/deferToProdService";
 import { ProjectHealthcheck } from "./dbtCoreIntegration";
@@ -44,9 +44,10 @@ function getDBTPath(
   terminal: DBTTerminal,
 ): string {
   if (pythonEnvironment.pythonPath) {
-    const dbtPath = readdirSync(
-      join(dirname(pythonEnvironment.pythonPath)),
-    ).find((fileName) => fileName === "dbt" || fileName === "dbt.exe");
+    const allowedDbtPaths = ["dbt", "dbt.exe"];
+    const dbtPath = allowedDbtPaths.find((path) =>
+      existsSync(join(dirname(pythonEnvironment.pythonPath), path)),
+    );
     if (dbtPath) {
       const dbtPythonPath = join(
         dirname(pythonEnvironment.pythonPath),

--- a/src/dbt_client/dbtCloudIntegration.ts
+++ b/src/dbt_client/dbtCloudIntegration.ts
@@ -34,7 +34,7 @@ import { DBTProject } from "../manifest/dbtProject";
 import { TelemetryService } from "../telemetry";
 import { DBTTerminal } from "./dbtTerminal";
 import { PythonEnvironment } from "../manifest/pythonEnvironment";
-import { existsSync, readdirSync } from "fs";
+import { existsSync } from "fs";
 import { ValidationProvider } from "../validation_provider";
 import { DeferToProdService } from "../services/deferToProdService";
 import { ProjectHealthcheck } from "./dbtCoreIntegration";


### PR DESCRIPTION
## Overview

### Problem
Not able to setup external executor project in windows

### Solution
dbt path was not found and fix was added to find dbt.exe file in the python venv

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Setup a dbt project with venv in windows
- should be able to run all actions without any issue

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
