### PR TITLE
fix: autocomplete

### DIFF
--- a/src/autocompletion_provider/modelAutocompletionProvider.ts
+++ b/src/autocompletion_provider/modelAutocompletionProvider.ts
@@ -21,6 +21,7 @@ import { DBTProject } from "../manifest/dbtProject";
 export class ModelAutocompletionProvider
   implements CompletionItemProvider, Disposable
 {
+  private static readonly JINJA_TEMPLATE_PATTERN = /\{\{\s*\w*$/;
   private static readonly MODEL_PATTERN = /ref\s*\(\s*(['|"])?\s*\w*$/;
   private static readonly PACKAGE_PATTERN =
     /ref\s*\(\s*('[^)']*'|"[^)"]*")\s*,\s*('|")\s*\w*$/;
@@ -56,6 +57,12 @@ export class ModelAutocompletionProvider
     const linePrefix = document
       .lineAt(position)
       .text.substring(0, position.character);
+    // if (linePrefix.match(ModelAutocompletionProvider.JINJA_TEMPLATE_PATTERN)) {
+    //   return [
+    //     { insertText: "ref", label: "ref", additionalTextEdits: [] },
+    //     { insertText: "source", label: "source" },
+    //   ];
+    // }
     if (
       (linePrefix.match(ModelAutocompletionProvider.MODEL_PATTERN) ||
         linePrefix.match(ModelAutocompletionProvider.PACKAGE_PATTERN)) &&

--- a/src/autocompletion_provider/modelAutocompletionProvider.ts
+++ b/src/autocompletion_provider/modelAutocompletionProvider.ts
@@ -57,12 +57,12 @@ export class ModelAutocompletionProvider
     const linePrefix = document
       .lineAt(position)
       .text.substring(0, position.character);
-    // if (linePrefix.match(ModelAutocompletionProvider.JINJA_TEMPLATE_PATTERN)) {
-    //   return [
-    //     { insertText: "ref", label: "ref", additionalTextEdits: [] },
-    //     { insertText: "source", label: "source" },
-    //   ];
-    // }
+    if (linePrefix.match(ModelAutocompletionProvider.JINJA_TEMPLATE_PATTERN)) {
+      return [
+        { insertText: "ref", label: "ref", additionalTextEdits: [] },
+        { insertText: "source", label: "source" },
+      ];
+    }
     if (
       (linePrefix.match(ModelAutocompletionProvider.MODEL_PATTERN) ||
         linePrefix.match(ModelAutocompletionProvider.PACKAGE_PATTERN)) &&

--- a/src/autocompletion_provider/modelAutocompletionProvider.ts
+++ b/src/autocompletion_provider/modelAutocompletionProvider.ts
@@ -93,7 +93,7 @@ export class ModelAutocompletionProvider
               : `"${completionItem.packageName}", "${completionItem.modelName}"`,
         }));
       }
-      // if quotes match insertText ending quote
+      // if quotes then add end quote to match start quote
       const endQuote =
         line[position.character] === modelMatch[1] ? "" : modelMatch[1];
       return autoCompleteItems.map((completionItem) => ({
@@ -121,7 +121,7 @@ export class ModelAutocompletionProvider
           insertText: `"${completionItem.modelName}"`,
         }));
       }
-      // if quotes match insertText ending quote
+      // if quotes then add end quote to match start quote
       const endQuote =
         line[position.character] === packageMatch[2] ? "" : packageMatch[2];
       return autoCompleteItems.map((completionItem) => ({

--- a/src/autocompletion_provider/modelAutocompletionProvider.ts
+++ b/src/autocompletion_provider/modelAutocompletionProvider.ts
@@ -55,7 +55,7 @@ export class ModelAutocompletionProvider
   ): ProviderResult<CompletionItem[] | CompletionList<CompletionItem>> {
     const linePrefix = document
       .lineAt(position)
-      .text.substr(0, position.character);
+      .text.substring(0, position.character);
     if (
       (linePrefix.match(ModelAutocompletionProvider.MODEL_PATTERN) ||
         linePrefix.match(ModelAutocompletionProvider.PACKAGE_PATTERN)) &&

--- a/src/autocompletion_provider/modelAutocompletionProvider.ts
+++ b/src/autocompletion_provider/modelAutocompletionProvider.ts
@@ -103,7 +103,7 @@ export class ModelAutocompletionProvider
         insertText:
           completionItem.projectName === completionItem.packageName
             ? `${completionItem.modelName}${endQuote}`
-            : `${completionItem.packageName}${endQuote}, ${endQuote}${completionItem.modelName}${endQuote}`,
+            : `${completionItem.packageName}${modelMatch[1]}, ${modelMatch[1]}${completionItem.modelName}${endQuote}`,
       }));
     }
     if (packageMatch) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,10 +11,10 @@ import {
 } from "vscode";
 import { EnvironmentVariables } from "./domain";
 
-export const isEnclosedWithinCodeBlock: (
+export const isEnclosedWithinCodeBlock = (
   document: TextDocument,
   rangeOrPosition: Range | Position,
-) => boolean = (document, rangeOrPosition) => {
+): boolean => {
   const isWithinCodeBlock = (
     startPosition: Position,
     direction: "asc" | "desc",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,12 +15,12 @@ export const isEnclosedWithinCodeBlock: (
   document: TextDocument,
   rangeOrPosition: Range | Position,
 ) => boolean = (document, rangeOrPosition) => {
-  const isWithinCodeBlock: (
+  const isWithinCodeBlock = (
     startPosition: Position,
     direction: "asc" | "desc",
     lookupChar: "{" | "}",
     stopChar: "{" | "}",
-  ) => boolean = (startPosition, direction, lookupChar, stopChar) => {
+  ): boolean => {
     const increment = direction === "desc" ? -1 : 1;
     let characterPosition: number | undefined = startPosition.character;
     let lineNumber = startPosition.line;


### PR DESCRIPTION
## Overview

### Problem

https://github.com/AltimateAI/vscode-dbt-power-user/issues/301
https://github.com/AltimateAI/vscode-dbt-power-user/issues/804

Relevant vscode issue: https://github.com/microsoft/vscode/issues/24464
For debugging, might have to add in `.vscode/settings.json`
```
"editor.quickSuggestions": {
    "comments": false,
    "strings": true,
    "other": true,
}
```

### Solution

Cases:
 - type out `{{ ref('` and then autocomplete a model name or package name and model name
 - type out `{{ ref("` and then autocomplete a model name or package name and model name
 - type out `{{ ref(` and then autocomplete a model name or package name and model name
 - type out `{{ ref(some_text` and then autocomplete a model name or package name and model name
 - type out `{{ ref('packageName', '` and then autocomplete a model name for relevant package
 - type out `{{ ref('packageName', "` and then autocomplete a model name for relevant package
 - type out `{{ ref('packageName', ` and then autocomplete a model name for relevant package
 - type out `{{ ref('packageName', some_text` and then autocomplete a model name for relevant package
 - after ref snippet, directly typing should autocomplete 

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
