### PR TITLE
chore: remove legacy documentation editor support

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,11 +76,6 @@
             "description": "Enable dbt docs collaboration.",
             "default": false
           },
-          "dbt.enableNewDocsPanel": {
-            "type": "boolean",
-            "description": "Enable the new docs panel in dbt.",
-            "default": true
-          },
           "dbt.enableNewQueryPanel": {
             "type": "boolean",
             "description": "Enable the new query panel in dbt.",

--- a/src/altimate.ts
+++ b/src/altimate.ts
@@ -168,24 +168,7 @@ interface DocsGenerateModelRequestV2 {
   follow_up_instructions?: {
     instruction: string;
   };
-
-  gen_model_description: boolean;
-}
-
-export interface DocsGenerateModelRequest {
-  columns: string[];
-  dbt_model: {
-    model_name: string;
-    model_description?: string;
-    compiled_sql?: string;
-    columns: {
-      column_name: string;
-      description?: string;
-      data_type?: string;
-    }[];
-    adapter?: string;
-  };
-  prompt_hint: string;
+  prompt_hint?: string;
   gen_model_description: boolean;
 }
 
@@ -670,13 +653,6 @@ export class AltimateRequest {
       return false;
     }
     return true;
-  }
-
-  async generateModelDocs(docsGenerate: DocsGenerateModelRequest) {
-    return this.fetch<DocsGenerateResponse>("dbt/v1", {
-      method: "POST",
-      body: JSON.stringify(docsGenerate),
-    });
   }
 
   async generateModelDocsV2(docsGenerate: DocsGenerateModelRequestV2) {

--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -69,9 +69,6 @@ export class DocGenService {
       if (!documentation) {
         return resolve(undefined);
       }
-      const enableNewDocsPanel = workspace
-        .getConfiguration("dbt")
-        .get<boolean>("enableNewDocsPanel", true);
 
       const baseRequest = {
         columns,
@@ -92,13 +89,11 @@ export class DocGenService {
       >["0"];
 
       try {
-        const result = enableNewDocsPanel
-          ? await this.altimateRequest.generateModelDocsV2({
-              ...baseRequest,
-              user_instructions: message.user_instructions,
-              follow_up_instructions: message.follow_up_instructions,
-            })
-          : await this.altimateRequest.generateModelDocs(baseRequest);
+        const result = await this.altimateRequest.generateModelDocsV2({
+          ...baseRequest,
+          user_instructions: message.user_instructions,
+          follow_up_instructions: message.follow_up_instructions,
+        });
 
         return resolve(result);
       } catch (err) {
@@ -390,9 +385,6 @@ export class DocGenService {
         try {
           const startTime = Date.now();
           const compiledSql = await project.unsafeCompileQuery(queryText);
-          const enableNewDocsPanel = workspace
-            .getConfiguration("dbt")
-            .get<boolean>("enableNewDocsPanel", true);
 
           const baseRequest = {
             columns: [],
@@ -411,17 +403,16 @@ export class DocGenService {
             prompt_hint: message.promptHint || "generate",
             gen_model_description: true,
           } as unknown as DocsGenerateModelRequest;
-          const generateDocsForModel = enableNewDocsPanel
-            ? await this.altimateRequest.generateModelDocsV2({
-                ...baseRequest,
-                user_instructions: {
-                  ...message.user_instructions,
-                  prompt_hint:
-                    message.user_instructions.prompt_hint || "generate",
-                },
-                follow_up_instructions: message.follow_up_instructions,
-              })
-            : await this.altimateRequest.generateModelDocs(baseRequest);
+          const generateDocsForModel =
+            await this.altimateRequest.generateModelDocsV2({
+              ...baseRequest,
+              user_instructions: {
+                ...message.user_instructions,
+                prompt_hint:
+                  message.user_instructions.prompt_hint || "generate",
+              },
+              follow_up_instructions: message.follow_up_instructions,
+            });
 
           if (
             !generateDocsForModel ||

--- a/src/webview_provider/datapilotPanel.ts
+++ b/src/webview_provider/datapilotPanel.ts
@@ -67,27 +67,6 @@ export class DataPilotPanel extends AltimateWebviewProvider {
     const queryText = window.activeTextEditor?.document.getText();
 
     switch (command) {
-      case "getNewDocsPanelState":
-        const newDocsPanelState = workspace
-          .getConfiguration("dbt")
-          .get<boolean>("enableNewDocsPanel", true);
-
-        this.sendResponseToWebview({
-          command: "response",
-          data: {
-            enabled: newDocsPanelState,
-          },
-          syncRequestId,
-        });
-        break;
-
-      case "enableNewDocsPanel":
-        this.emitterService.fire({
-          command: "enableNewDocsPanel",
-          payload: params,
-        });
-        break;
-
       case "sendFeedback":
         if (!queryText) {
           return;

--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -124,32 +124,6 @@ export class DocsEditViewPanel implements WebviewViewProvider {
         }
       },
     );
-
-    this._disposables.push(
-      workspace.onDidChangeConfiguration(
-        (e) => {
-          if (!e.affectsConfiguration("dbt.enableNewDocsPanel")) {
-            return;
-          }
-          if (this._panel && this.context && this.token) {
-            this.getPanel().resolveWebview(
-              this._panel,
-              this.context,
-              this.token,
-            );
-          }
-        },
-        this,
-        this._disposables,
-      ),
-    );
-  }
-
-  private getPanel() {
-    const enableNewDocsPanel = workspace
-      .getConfiguration("dbt")
-      .get<boolean>("enableNewDocsPanel", true);
-    return enableNewDocsPanel ? this.newDocsPanel : this.legacyDocsPanel;
   }
 
   private getProject(): DBTProject | undefined {
@@ -223,7 +197,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
     this.context = context;
     this.token = token;
     this._panel = panel;
-    this.getPanel().resolveWebview(panel, context, token);
+    this.newDocsPanel.resolveWebview(panel, context, token);
     this.setupWebviewHooks(context);
     this.transmitConfig();
     this.documentation =
@@ -448,15 +422,6 @@ export class DocsEditViewPanel implements WebviewViewProvider {
 
         const { command, syncRequestId, args } = message;
         switch (command) {
-          case "enableNewDocsPanel":
-            await workspace
-              .getConfiguration("dbt")
-              .update("enableNewDocsPanel", message.enable);
-            this.init();
-            this.telemetry.sendTelemetryEvent(
-              message.enable ? "NewDocsPanelEnabled" : "NewDocsPanelDisabled",
-            );
-            break;
           case "fetchMetadataFromDatabase":
             this.telemetry.sendTelemetryEvent("syncColumnsFromDatabaseForDocs");
             window.withProgress(

--- a/src/webview_provider/newDocsGenPanel.ts
+++ b/src/webview_provider/newDocsGenPanel.ts
@@ -224,10 +224,6 @@ export class NewDocsGenPanel
 
         break;
 
-      case "enableNewDocsPanel":
-        this.toggleDocsPanel(args);
-        break;
-
       case "getCurrentModelDocumentation":
         if (!this._panel) {
           return;
@@ -333,19 +329,8 @@ export class NewDocsGenPanel
           ...payload,
         });
         break;
-      case "enableNewDocsPanel":
-        this.toggleDocsPanel(payload);
       default:
         break;
     }
-  }
-
-  private async toggleDocsPanel({ enable }: Record<string, unknown>) {
-    await workspace
-      .getConfiguration("dbt")
-      .update("enableNewDocsPanel", enable);
-    this.telemetry.sendTelemetryEvent(
-      enable ? "NewDocsPanelEnabled" : "NewDocsPanelDisabled",
-    );
   }
 }

--- a/webview_panels/src/modules/dataPilot/components/common/DatapilotChatFollowup.tsx
+++ b/webview_panels/src/modules/dataPilot/components/common/DatapilotChatFollowup.tsx
@@ -169,7 +169,7 @@ const DatapilotChatFollowupComponent = ({
               <AltimateIcon /> {datapilotTitle}
             </CardTitle>
             <CardBody>
-              <div className={classes.response}>
+              <div className={classes.response} title="Datapilot response">
                 {response ? <MarkdownRenderer response={response} /> : null}
                 {component ? (
                   <>{DatapilotResponseComponents[component]}</>

--- a/webview_panels/src/modules/dataPilot/components/docGen/NewGenerationResults.tsx
+++ b/webview_panels/src/modules/dataPilot/components/docGen/NewGenerationResults.tsx
@@ -71,7 +71,7 @@ const NewGenerationResults = ({
                 <AltimateIcon /> {result.datapilotTitle}
               </CardTitle>
               <CardBody>
-                {result.description}
+                <span title="Datapilot response">{result.description}</span>
                 <Stack className={classes.actionButtons}>
                   <Stack>
                     <Button

--- a/webview_panels/src/modules/defer/ManifestSelection.tsx
+++ b/webview_panels/src/modules/defer/ManifestSelection.tsx
@@ -128,7 +128,6 @@ export const ManifestSelection = ({
         <Label
           check
           for="localManifestPathRadio"
-          sm={2}
           className={classes.title}
           style={{ whiteSpace: "nowrap" }}
         >
@@ -158,7 +157,6 @@ export const ManifestSelection = ({
         <Label
           check
           for="manifestPathRadio"
-          sm={2}
           className={classes.title}
           style={{ whiteSpace: "nowrap" }}
           onClick={() => handleManifestPathTypeChange(ManifestPathType.REMOTE)}

--- a/webview_panels/src/modules/defer/defer.module.scss
+++ b/webview_panels/src/modules/defer/defer.module.scss
@@ -39,10 +39,11 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+      gap:10px;
     }
 
     .path-input{
-      width: 70%;
+      max-width: 70%;
       cursor: pointer;
     }
 

--- a/webview_panels/src/modules/insights/Insights.tsx
+++ b/webview_panels/src/modules/insights/Insights.tsx
@@ -1,10 +1,10 @@
 import FeedbackButton from "@modules/commonActionButtons/FeedbackButton";
-import HelpButton from "@modules/commonActionButtons/HelpButton";
 import { Container, Stack, Tabs } from "@uicore";
 // import BigQueryCostEstimator from "../bigQuery/CostEstimator";
 import DeferToProduction from "../defer/DeferToProduction";
 import ProjectHealthChecker from "../healthCheck/ProjectHealthChecker";
 import classes from "./insights.module.scss";
+import HelpButton from "./components/help/HelpButton";
 
 const Insights = (): JSX.Element => (
   <Container className={classes.insightsContainer}>


### PR DESCRIPTION
## Overview

### Problem
Legacy documentation editor is not supported anymore

### Solution
Remove the option to switch between legacy and new documentation editor

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Open a model in dbt project
- should be able to see only new documentation editor with bulk generate options
- in vscode settings also, user should not be able to switch to legacy doc editor panel

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
