### PR TITLE
chore: make dbt docs collaboration enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
           "dbt.enableCollaboration": {
             "type": "boolean",
             "description": "Enable dbt docs collaboration.",
-            "default": false
+            "default": true
           },
           "dbt.enableNewDocsPanel": {
             "type": "boolean",

--- a/src/altimate.ts
+++ b/src/altimate.ts
@@ -730,7 +730,7 @@ export class AltimateRequest {
   }
 
   async getCurrentUser() {
-    return await this.fetch<TenantUser>("/dbt/dbt_docs_share/user/details");
+    return await this.fetch<TenantUser>("dbt/dbt_docs_share/user/details");
   }
 
   async getAllSharedDbtDocs(projectNames: string[]) {


### PR DESCRIPTION
## Overview

### Problem
To release dbt docs collaboration, enable the feature flag by default

### Solution

Updated the defauly config value

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Load the extension
- should be able to see the comments panel and should be able to add comments without enabling collaboration

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
