### PR TITLE
Fix/docs bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
           "dbt.enableCollaboration": {
             "type": "boolean",
             "description": "Enable dbt docs collaboration.",
-            "default": false
+            "default": true
           },
           "dbt.enableNewDocsPanel": {
             "type": "boolean",

--- a/src/altimate.ts
+++ b/src/altimate.ts
@@ -258,6 +258,7 @@ export interface SharedDoc {
   name: string;
   description: string;
   project_name: string;
+  conversation_group: [ConversationGroup];
 }
 
 export interface Conversation {

--- a/src/altimate.ts
+++ b/src/altimate.ts
@@ -730,7 +730,7 @@ export class AltimateRequest {
   }
 
   async getCurrentUser() {
-    return await this.fetch<TenantUser>("/dbt/dbt_docs_share/user/details");
+    return await this.fetch<TenantUser>("dbt/dbt_docs_share/user/details");
   }
 
   async getAllSharedDbtDocs(projectNames: string[]) {

--- a/src/autocompletion_provider/usercompletion_provider.ts
+++ b/src/autocompletion_provider/usercompletion_provider.ts
@@ -30,7 +30,11 @@ export class UserCompletionProvider
     CompletionItem[] | CompletionList<CompletionItem>
   > {
     return this.usersService.users.map((user) => ({
-      label: `${user.display_name}`,
+      label: {
+        label: `${user.display_name}`,
+        // description: "Altimate",
+        detail: " (Altimate)",
+      },
       kind: CompletionItemKind.User,
       keepWhitespace: true,
       insertText: `${user.display_name} `,

--- a/src/comment_provider/conversationProvider.ts
+++ b/src/comment_provider/conversationProvider.ts
@@ -105,7 +105,7 @@ export class ConversationProvider implements Disposable {
     this.disposables.push(
       emitterService.eventEmitter.event((d) => {
         if (
-          d.command === "manifestCacheChanged" ||
+          d.command === "dbtProjectsInitialized" ||
           d.command === "refetchConversations"
         ) {
           this.loadThreads();

--- a/src/comment_provider/conversationProvider.ts
+++ b/src/comment_provider/conversationProvider.ts
@@ -229,7 +229,7 @@ export class ConversationProvider implements Disposable {
       }
 
       pendingConversations.map((conversationGroup) => {
-        const uri = Uri.parse(
+        const uri = Uri.file(
           path.join(
             project.projectRoot.fsPath,
             conversationGroup.meta.filePath,

--- a/src/comment_provider/conversationProvider.ts
+++ b/src/comment_provider/conversationProvider.ts
@@ -167,10 +167,7 @@ export class ConversationProvider implements Disposable {
         "loading conversations",
         dbtDocsShare.share_id,
       );
-      const conversations =
-        await this.conversationService.loadConversationsByShareId(
-          dbtDocsShare.share_id,
-        );
+      const conversations = dbtDocsShare.conversation_group;
       if (!conversations?.length) {
         this.dbtTerminal.debug(
           "ConversationProvider:loadThreads",

--- a/src/manifest/dbtProjectContainer.ts
+++ b/src/manifest/dbtProjectContainer.ts
@@ -35,10 +35,16 @@ export interface ProjectRegisteredUnregisteredEvent {
   registered: boolean;
 }
 
+export interface DBTProjectsInitializationEvent {}
+
 @provideSingleton(DBTProjectContainer)
 export class DBTProjectContainer implements Disposable {
   public onDBTInstallationVerification =
     this.dbtClient.onDBTInstallationVerification;
+  private _onDBTProjectsInitializationEvent =
+    new EventEmitter<DBTProjectsInitializationEvent>();
+  public readonly onDBTProjectsInitialization =
+    this._onDBTProjectsInitializationEvent.event;
   private dbtWorkspaceFolders: DBTWorkspaceFolder[] = [];
   private _onManifestChanged = new EventEmitter<ManifestCacheChangedEvent>();
   private _onProjectRegisteredUnregistered =
@@ -139,6 +145,7 @@ export class DBTProjectContainer implements Disposable {
     await Promise.all(
       folders.map((folder) => this.registerWorkspaceFolder(folder)),
     );
+    this._onDBTProjectsInitializationEvent.fire({});
   }
 
   async showWalkthrough() {

--- a/src/services/conversationService.ts
+++ b/src/services/conversationService.ts
@@ -51,6 +51,10 @@ export class ConversationService {
       const shares =
         await this.altimateRequest.getAllSharedDbtDocs(projectNames);
       this.sharedDocs = shares || [];
+      shares.forEach((share) => {
+        this.conversationsBySharedDoc[share.share_id] =
+          share.conversation_group;
+      });
       return this.sharedDocs;
     } catch (err) {
       this.dbtTerminal.error(

--- a/src/services/queryManifestService.ts
+++ b/src/services/queryManifestService.ts
@@ -18,6 +18,13 @@ export class QueryManifestService {
     private dbtTerminal: DBTTerminal,
     protected emitterService: SharedStateService,
   ) {
+    dbtProjectContainer.onDBTProjectsInitialization(() => {
+      this.emitterService.fire({
+        command: "dbtProjectsInitialized",
+        payload: {},
+      });
+    });
+
     dbtProjectContainer.onManifestChanged((event) =>
       this.onManifestCacheChanged(event),
     );
@@ -29,10 +36,6 @@ export class QueryManifestService {
     });
     event.removed?.forEach((removed) => {
       this.eventMap.delete(removed.projectRoot.fsPath);
-    });
-    this.emitterService.fire({
-      command: "manifestCacheChanged",
-      payload: {},
     });
   }
 

--- a/webview_panels/src/lib/altimate/main.js
+++ b/webview_panels/src/lib/altimate/main.js
@@ -11216,7 +11216,7 @@ const Ec = /* @__PURE__ */ Ve(yc),
                 behavior: "smooth",
                 block: "center",
               });
-            }, 500));
+            }, 1e3));
         },
         [e.conversation_group_id, i],
       );

--- a/webview_panels/src/modules/documentationEditor/styles.module.scss
+++ b/webview_panels/src/modules/documentationEditor/styles.module.scss
@@ -322,5 +322,6 @@
 .conversationInputForm{
   textarea{
     top: 5px !important;
+    height: 80% !important;
   }
 }


### PR DESCRIPTION
## Overview

### Problem
- UI issue in dbt docs share functionality in doc editor: https://altimateai.atlassian.net/browse/AI-1687
- Too many api calls for dbt docs on extension load
- When @ mentioning users, github user names are showing


### Solution
- fixed ui issues in doc editor panel
- added extra text `Altimate` near user names when @ mentioning to indicate altimate users
- Backend api is changed to send conversations with shared docs. Modified extension to handle the new response
- Instead of getting shares after every manifest cache changed event, make it a single call after all projects are initialized

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Load sample_dbt_projects repo in vscode with dbt power user extension
- Single api call `dbt/dbt_docs_share/all?projects=` should be made after all projects are initialized
- While creating new comment, and using @ mention, `ALtimate` text should be visible after user name

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
