### PR TITLE
fix: run all scan in project healthcheck

### DIFF
--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -216,11 +216,14 @@ export class DBTProject implements Disposable {
       );
     }
     const healthcheckArgs: HealthcheckArgs = { manifestPath };
-    if ("configPath" in args) {
+    if (args.configType === "Manual") {
       healthcheckArgs.configPath = args.configPath;
     } else {
-      healthcheckArgs.config = args.config;
+      if (args.configType === "Saas") {
+        healthcheckArgs.config = args.config;
+      }
       if (
+        args.configType === "All" ||
         args.config_schema.some((i) => i.files_required.includes("Catalog"))
       ) {
         const docsGenerateCommand =

--- a/src/webview_provider/insightsPanel.ts
+++ b/src/webview_provider/insightsPanel.ts
@@ -34,8 +34,13 @@ type UpdateConfigPropsArray = {
   projectRoot: string;
 };
 type ConfigOption =
-  | { configPath: string }
-  | { config: unknown; config_schema: { files_required: string }[] };
+  | { configPath: string; configType: "Manual" }
+  | {
+      config: unknown;
+      config_schema: { files_required: string }[];
+      configType: "Saas";
+    }
+  | { configType: "All" };
 
 export type AltimateConfigProps = { projectRoot: string } & ConfigOption;
 

--- a/webview_panels/src/modules/healthCheck/ProjectHealthChecker.tsx
+++ b/webview_panels/src/modules/healthCheck/ProjectHealthChecker.tsx
@@ -42,7 +42,10 @@ type ConfigOption =
   | { configPath: string }
   | { config: unknown; config_schema: unknown[] };
 
-type AltimateConfigProps = { projectRoot: string } & ConfigOption;
+type AltimateConfigProps = {
+  projectRoot: string;
+  configType: string;
+} & ConfigOption;
 
 enum ConfigType {
   Manual,
@@ -182,7 +185,7 @@ const SaasConfigSelector = (props: SaasConfigSelectorProps) => {
             checked={props.configType === ConfigType.All}
             onClick={() => props.setConfigType(ConfigType.All)}
           />
-          Scan everything
+          Run all checks
         </Label>
       </div>
     </div>
@@ -318,6 +321,7 @@ const ProjectHealthcheckInput = ({
                 }
                 const args = {
                   projectRoot: selectedProject,
+                  configType: ConfigType[configType],
                   ...(configType === ConfigType.Manual
                     ? { configPath }
                     : selectedConfig!),


### PR DESCRIPTION
## Overview

### Problem

 in project healthcheck, run all scan errors out at the start. 

### Solution

file required was not properly handled for run all scan. now in case of run all checks, assuming manifest and catalog both are required.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
