### PR TITLE
fix: windows file uri for query translate

### DIFF
--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -12,7 +12,7 @@ export class FileService {
         reject(new Error("Invalid file path"));
         return;
       }
-      workspace.openTextDocument(Uri.parse(path)).then(
+      workspace.openTextDocument(Uri.file(path)).then(
         (file: TextDocument) => {
           window.showTextDocument(file, 1, false).then(
             (e) => {


### PR DESCRIPTION
## Overview

### Problem
Query translate is not working in windows

### Solution
Use Uri.file instead of Uri.parse

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Open a model and select piece of code 
- right click -> datapilot -> query translate
- select dialects
- click translate
- should not throw error and should be able to translate

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
