### PR TITLE
fix: pricing error handling

### DIFF
--- a/src/exceptions/executionsExhaustedException.ts
+++ b/src/exceptions/executionsExhaustedException.ts
@@ -1,0 +1,7 @@
+export class ExecutionsExhaustedException extends Error {
+  constructor(msg: string) {
+    super(msg);
+
+    Object.setPrototypeOf(this, ExecutionsExhaustedException.prototype);
+  }
+}

--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -1,1 +1,2 @@
 export * from "./rateLimitException";
+export * from "./executionsExhaustedException";


### PR DESCRIPTION
## Overview

### Problem
- If user has exhausted execution limit in backend, 402 payment required error is thrown. Extension is not handling the error.

### Solution
- Update the fetch and fetchAsStream API methods to show right error message

### Screenshot/Demo

![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/ec239124-53f8-49cf-b1fe-188c46e13d45)

### How to test
- exhaust your allowed limit per month
- try to run an execution, for ex: generate a doc
- should see the error with saas ui link

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
