### PR TITLE
fix: for dbt 1.8, capability to use REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES as env

### DIFF
--- a/dbt_core_integration.py
+++ b/dbt_core_integration.py
@@ -93,7 +93,7 @@ COMPILED_CODE = (
 JINJA_CONTROL_SEQS = ["{{", "}}", "{%", "%}", "{#", "#}"]
 
 T = TypeVar("T")
-
+REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES = "REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES"
 
 @contextlib.contextmanager
 def add_path(path):
@@ -361,6 +361,7 @@ class DbtProject:
             self.adapter = self.get_adapter()
             self.adapter.connections.set_connection_name()
             if DBT_MAJOR_VER >= 1 and DBT_MINOR_VER >= 8:
+                self.args.REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES = os.environ.get(REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES, True)
                 from dbt.context.providers import generate_runtime_macro_context
                 self.adapter.set_macro_context_generator(generate_runtime_macro_context)
             self.config.adapter = self.adapter

--- a/package.json
+++ b/package.json
@@ -598,7 +598,7 @@
       },
       {
         "command": "dbtPowerUser.diagnostics",
-        "title": "command to collect diagnostics information for the extension",
+        "title": "Collect diagnostics",
         "category": "dbt Power User",
         "icon": "$(debug-console)"
       }


### PR DESCRIPTION
## Overview

### Problem

dbt core 1.8 requires REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES to be set in the args https://github.com/dbt-labs/dbt-core/blob/v1.8.0rc2/core/dbt/parser/manifest.py#L641. 

### Solution

We are injecting the variable using environment variables and defaulting it to True

### How to test

- Setup project with dbt 1.8
- Extension should work without any proble,,s

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
