### PR TITLE
fix: defer to prod event logging

### DIFF
--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -691,7 +691,6 @@ export class DBTCoreProjectIntegration
           this.projectRoot,
         );
         console.log(`Set remote manifest path: ${manifestPath}`);
-        this.altimateRequest.sendDeferToProdEvent(ManifestPathType.REMOTE);
         return manifestPath;
       } catch (error) {
         if (error instanceof NotFoundError) {
@@ -741,6 +740,10 @@ export class DBTCoreProjectIntegration
       true,
       args,
     );
+
+    if (manifestPathType === ManifestPathType.REMOTE) {
+      this.altimateRequest.sendDeferToProdEvent(ManifestPathType.REMOTE);
+    }
     return args;
   }
 


### PR DESCRIPTION
## Overview

### Problem

Too many api to calls to `defer_to_prod_event`

### Solution

Reposition event logging within a function dedicated exclusively to command execution.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
