### PR TITLE
fix: save alert when switching in multi project

### DIFF
--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -199,6 +199,7 @@ export class DocGenService {
       generated: false,
       resource_type: currentNode.resource_type,
       uniqueId: currentNode.uniqueId,
+      filePath,
       columns: Object.values(docColumns).map((column) => {
         return {
           name: column.name,

--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -602,6 +602,16 @@ export class DocsEditViewPanel implements WebviewViewProvider {
               },
               async () => {
                 try {
+                  const projectByFilePath =
+                    this.dbtProjectContainer.findDBTProject(
+                      Uri.file(message.filePath),
+                    );
+                  if (!projectByFilePath) {
+                    throw new Error(
+                      "Unable to find project for saving documentation",
+                    );
+                  }
+
                   if (!patchPath) {
                     switch (message.dialogType) {
                       case "Existing file":
@@ -630,7 +640,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                   } else {
                     // the location comes from the manifest, parse it
                     patchPath = path.join(
-                      project.projectRoot.fsPath,
+                      projectByFilePath.projectRoot.fsPath,
                       patchPath.split("://")[1],
                     );
                   }
@@ -663,7 +673,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                       columns: message.columns.map((column: any) => {
                         const name = getColumnNameByCase(
                           column.name,
-                          project.getAdapterType(),
+                          projectByFilePath.getAdapterType(),
                         );
                         return {
                           name,
@@ -672,7 +682,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                           ...this.getTestDataByColumn(message, column.name),
                           ...(isQuotedIdentifier(
                             column.name,
-                            project.getAdapterType(),
+                            projectByFilePath.getAdapterType(),
                           )
                             ? { quote: true }
                             : undefined),
@@ -714,7 +724,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                             } else {
                               const name = getColumnNameByCase(
                                 column.name,
-                                project.getAdapterType(),
+                                projectByFilePath.getAdapterType(),
                               );
                               return {
                                 name,
@@ -726,7 +736,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                                 ),
                                 ...(isQuotedIdentifier(
                                   column.name,
-                                  project.getAdapterType(),
+                                  projectByFilePath.getAdapterType(),
                                 )
                                   ? { quote: true }
                                   : undefined),
@@ -767,6 +777,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                     "saveDocumentationError",
                     `Could not save documentation to ${patchPath}`,
                     error,
+                    true,
                   );
                   if (syncRequestId) {
                     this._panel!.webview.postMessage({


### PR DESCRIPTION
## Overview

### Problem
If vscode workspace contains multiple projects, and if user modifies documentation of a model in a project and switched to another model in another project, the save alert warning message shows up. but the save is not working

### Solution
- This is mainly because of getting project by current active open file.
- Modified code to send filePath along with documentation data and use that to find project and save the data

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Open a workspace with multi project setup
- modify documentation of a model in a project
- without saving, open another file from another project
- in the warning message, click save changes
- modified documentation should be saved to right model in right project

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
