### PR TITLE
fix: add guards for doc editor

### DIFF
--- a/src/services/dbtTestService.ts
+++ b/src/services/dbtTestService.ts
@@ -217,7 +217,7 @@ export class DbtTestService {
     }
 
     const adapter = dbtProject.getAdapterType();
-    const documentation = await this.docGenService.getDocumentation(
+    const { documentation } = await this.docGenService.getDocumentation(
       params.filePath,
     );
     if (!documentation) {

--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -1,6 +1,7 @@
 import path = require("path");
 import {
   ProgressLocation,
+  Uri,
   WebviewPanel,
   WebviewView,
   window,
@@ -171,45 +172,74 @@ export class DocGenService {
     return this.getDocumentation(window.activeTextEditor?.document?.uri.fsPath);
   }
 
-  public async getDocumentation(
-    filePath?: string,
-  ): Promise<DBTDocumentation | undefined> {
+  private getMissingDocumentationMessage(filePath?: string) {
+    const message =
+      "Documentation could be viewed for valid models only. Please open a valid model.";
+    if (!filePath) {
+      return { message, type: "warning" };
+    }
+    try {
+      this.queryManifestService
+        .getProjectByUri(Uri.file(filePath))
+        ?.throwDiagnosticsErrorIfAvailable();
+    } catch (err) {
+      return { message: (err as Error).message, type: "error" };
+    }
+
+    return { message, type: "warning" };
+  }
+
+  public async getDocumentation(filePath?: string): Promise<{
+    documentation: DBTDocumentation | undefined;
+    message?: { message: string; type: string };
+  }> {
     const eventResult = this.queryManifestService.getEventByCurrentProject();
     if (!eventResult) {
-      return undefined;
+      return {
+        documentation: undefined,
+        message: this.getMissingDocumentationMessage(filePath),
+      };
     }
     const { event } = eventResult;
 
     if (!event || !filePath) {
-      return undefined;
+      return {
+        documentation: undefined,
+        message: this.getMissingDocumentationMessage(filePath),
+      };
     }
 
     const modelName = path.basename(filePath, ".sql");
     const currentNode = event.nodeMetaMap.get(modelName);
     if (currentNode === undefined) {
-      return undefined;
+      return {
+        documentation: undefined,
+        message: this.getMissingDocumentationMessage(filePath),
+      };
     }
 
     const docColumns = currentNode.columns;
     return {
-      aiEnabled: this.altimateRequest.enabled(),
-      name: modelName,
-      patchPath: currentNode.patch_path,
-      description: currentNode.description,
-      generated: false,
-      resource_type: currentNode.resource_type,
-      uniqueId: currentNode.uniqueId,
-      filePath,
-      columns: Object.values(docColumns).map((column) => {
-        return {
-          name: column.name,
-          description: column.description,
-          generated: false,
-          source: Source.YAML,
-          type: column.data_type?.toLowerCase(),
-        };
-      }),
-    } as DBTDocumentation;
+      documentation: {
+        aiEnabled: this.altimateRequest.enabled(),
+        name: modelName,
+        patchPath: currentNode.patch_path,
+        description: currentNode.description,
+        generated: false,
+        resource_type: currentNode.resource_type,
+        uniqueId: currentNode.uniqueId,
+        filePath,
+        columns: Object.values(docColumns).map((column) => {
+          return {
+            name: column.name,
+            description: column.description,
+            generated: false,
+            source: Source.YAML,
+            type: column.data_type?.toLowerCase(),
+          };
+        }),
+      } as DBTDocumentation,
+    };
   }
 
   private chunk(a: string[], n: number) {
@@ -455,7 +485,7 @@ export class DocGenService {
           if (!project) {
             throw new Error("Unable to find project");
           }
-          const documentation = await this.getDocumentation();
+          const { documentation } = await this.getDocumentation();
           const compiledSql = await project.unsafeCompileQuery(queryText);
           const request = message.data;
           request["feedback_text"] = message.comment;

--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -174,7 +174,7 @@ export class DocGenService {
 
   private getMissingDocumentationMessage(filePath?: string) {
     const message =
-      "Documentation could be viewed for valid models only. Please open a valid model.";
+      "A valid dbt model file needs to be open and active in the editor area above to view documentation for that model.";
     if (!filePath) {
       return { message, type: "warning" };
     }

--- a/src/services/queryAnalysisService.ts
+++ b/src/services/queryAnalysisService.ts
@@ -189,7 +189,7 @@ export class QueryAnalysisService {
     }
 
     const adapter = dbtProject.getAdapterType() || "unknown";
-    const documentation = await this.docGenService.getDocumentation(
+    const { documentation } = await this.docGenService.getDocumentation(
       params.filePath,
     );
     if (!documentation) {
@@ -245,7 +245,8 @@ export class QueryAnalysisService {
     }
 
     const adapter = dbtProject.getAdapterType() || "unknown";
-    const documentation = await this.docGenService.getDocumentation(filePath);
+    const { documentation } =
+      await this.docGenService.getDocumentation(filePath);
 
     if (!documentation) {
       const error = new Error(

--- a/src/webview_provider/altimateWebviewProvider.ts
+++ b/src/webview_provider/altimateWebviewProvider.ts
@@ -1,5 +1,6 @@
 import {
   CancellationToken,
+  commands,
   Disposable,
   env,
   Uri,
@@ -215,6 +216,10 @@ export class AltimateWebviewProvider implements WebviewViewProvider {
 
     try {
       switch (command) {
+        case "openProblemsTab":
+          commands.executeCommand("workbench.action.problems.focus");
+
+          break;
         case "dbtdocsview:render":
           this.emitterService.fire({
             command: "dbtdocsview:render",

--- a/src/webview_provider/datapilotPanel.ts
+++ b/src/webview_provider/datapilotPanel.ts
@@ -86,8 +86,9 @@ export class DataPilotPanel extends AltimateWebviewProvider {
 
         this.docGenService.generateDocsForModel({
           queryText,
-          documentation:
-            await this.docGenService.getDocumentationForCurrentActiveFile(),
+          documentation: (
+            await this.docGenService.getDocumentationForCurrentActiveFile()
+          ).documentation,
           message,
           panel: this._panel,
           project: this.queryManifestService.getProject(),
@@ -96,8 +97,9 @@ export class DataPilotPanel extends AltimateWebviewProvider {
 
       case "generateDocsForColumn":
         await this.docGenService.generateDocsForColumns({
-          documentation:
-            await this.docGenService.getDocumentationForCurrentActiveFile(),
+          documentation: (
+            await this.docGenService.getDocumentationForCurrentActiveFile()
+          ).documentation,
           panel: this._panel,
           message,
           project: this.queryManifestService.getProject(),

--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -121,8 +121,6 @@ export class DocsEditViewPanel implements WebviewViewProvider {
         if (event === undefined) {
           return;
         }
-        this.documentation =
-          await this.docGenService.getDocumentationForCurrentActiveFile();
         if (this._panel) {
           this.transmitData();
           this.updateGraphStyle();
@@ -148,10 +146,14 @@ export class DocsEditViewPanel implements WebviewViewProvider {
   }
 
   private async transmitData() {
+    const { documentation, message } =
+      await this.docGenService.getDocumentationForCurrentActiveFile();
+    this.documentation = documentation;
     if (this._panel) {
       await this._panel.webview.postMessage({
         command: "renderDocumentation",
         docs: this.documentation,
+        missingDocumentationMessage: message,
         tests: await this.dbtTestService.getTestsForCurrentModel(),
         project: this.getProject()?.getProjectName(),
         collaborationEnabled: workspace
@@ -206,8 +208,6 @@ export class DocsEditViewPanel implements WebviewViewProvider {
     this.newDocsPanel.resolveWebview(panel, context, token);
     this.setupWebviewHooks(context);
     this.transmitConfig();
-    this.documentation =
-      await this.docGenService.getDocumentationForCurrentActiveFile();
     this.transmitData();
   }
 
@@ -751,8 +751,9 @@ export class DocsEditViewPanel implements WebviewViewProvider {
                   // Force reload from manifest after manifest refresh
                   this.loadedFromManifest = false;
                   writeFileSync(patchPath, stringify(parsedDocFile));
-                  this.documentation =
-                    await this.docGenService.getDocumentationForCurrentActiveFile();
+                  this.documentation = (
+                    await this.docGenService.getDocumentationForCurrentActiveFile()
+                  ).documentation;
                   const tests =
                     await this.dbtTestService.getTestsForCurrentModel();
                   if (syncRequestId) {
@@ -821,8 +822,6 @@ export class DocsEditViewPanel implements WebviewViewProvider {
       //  documentation will be overwritten by the one coming from the manifest
       return;
     }
-    this.documentation =
-      await this.docGenService.getDocumentationForCurrentActiveFile();
     this.loadedFromManifest = true;
     if (this._panel) {
       this.transmitData();

--- a/src/webview_provider/newDocsGenPanel.ts
+++ b/src/webview_provider/newDocsGenPanel.ts
@@ -195,11 +195,12 @@ export class NewDocsGenPanel
           return;
         }
 
-        const documentation =
+        const { documentation, message: missingDocumentationMessage } =
           await this.docGenService.getDocumentationForCurrentActiveFile();
         this.sendResponseToWebview({
           command: "renderDocumentation",
           docs: documentation,
+          missingDocumentationMessage,
           tests: await this.dbtTestService.getTestsForCurrentModel(),
           project: this.queryManifestService.getProject()?.getProjectName(),
           collaborationEnabled: workspace

--- a/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
+++ b/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
@@ -113,7 +113,7 @@ const DocumentationEditor = (): JSX.Element => {
     return (
       <div className={classes.docGenerator}>
         <h2>Documentation Help</h2>
-        <DocumentationHelpContent />
+        <DocumentationHelpContent showMissingDocumentationMessage />
       </div>
     );
   }

--- a/webview_panels/src/modules/documentationEditor/DocumentationProvider.tsx
+++ b/webview_panels/src/modules/documentationEditor/DocumentationProvider.tsx
@@ -13,6 +13,7 @@ import documentationSlice, {
   setGenerationsHistory,
   setIncomingDocsData,
   setInsertedEntityName,
+  setMissingDocumentationMessage,
   setProject,
   updatConversations,
   updateCollaborationEnabled,
@@ -93,6 +94,7 @@ const DocumentationProvider = (): JSX.Element => {
           name?: string;
           description?: string;
           collaborationEnabled?: boolean;
+          missingDocumentationMessage?: string;
         }
       >,
     ) => {
@@ -121,6 +123,11 @@ const DocumentationProvider = (): JSX.Element => {
           dispatch(
             updateCollaborationEnabled(
               Boolean(event.data.collaborationEnabled),
+            ),
+          );
+          dispatch(
+            setMissingDocumentationMessage(
+              event.data.missingDocumentationMessage,
             ),
           );
           break;

--- a/webview_panels/src/modules/documentationEditor/components/help/DocumentationHelpContent.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/help/DocumentationHelpContent.tsx
@@ -1,8 +1,40 @@
-import { Stack } from "@uicore";
+import { executeRequestInAsync } from "@modules/app/requestExecutor";
+import useDocumentationContext from "@modules/documentationEditor/state/useDocumentationContext";
+import { Alert, Button, Stack } from "@uicore";
 
-const DocumentationHelpContent = (): JSX.Element => {
+const DocumentationHelpContent = ({
+  showMissingDocumentationMessage,
+}: {
+  showMissingDocumentationMessage?: boolean;
+}): JSX.Element => {
+  const {
+    state: { missingDocumentationMessage },
+  } = useDocumentationContext();
+
+  const openProblemsTab = () => {
+    executeRequestInAsync("openProblemsTab", {});
+  };
   return (
     <Stack direction="column">
+      {missingDocumentationMessage && showMissingDocumentationMessage ? (
+        <Alert color="warning" className="mt-2 mb-1">
+          {missingDocumentationMessage.message}
+          {missingDocumentationMessage.type === "error" ? (
+            <>
+              <Button
+                color="link"
+                style={{ marginTop: -5 }}
+                onClick={openProblemsTab}
+              >
+                Click here
+              </Button>{" "}
+              to view Problems tab
+            </>
+          ) : (
+            ""
+          )}
+        </Alert>
+      ) : null}
       <p>
         You can write, update, and generate descriptions for your dbt models and
         columns, and save them in YAML files with a click of a button.{" "}

--- a/webview_panels/src/modules/documentationEditor/state/documentationSlice.ts
+++ b/webview_panels/src/modules/documentationEditor/state/documentationSlice.ts
@@ -27,6 +27,7 @@ export const initialState = {
   conversations: {},
   showConversationsRightPanel: false,
   collaborationEnabled: false,
+  missingDocumentationMessage: undefined,
 } as DocumentationStateProps;
 
 const documentationSlice = createSlice({
@@ -43,6 +44,14 @@ const documentationSlice = createSlice({
     },
     addToSelectedPage: (state, action: PayloadAction<Pages>) => {
       state.selectedPages.push(action.payload);
+    },
+    setMissingDocumentationMessage: (
+      state,
+      action: PayloadAction<
+        DocumentationStateProps["missingDocumentationMessage"]
+      >,
+    ) => {
+      state.missingDocumentationMessage = action.payload;
     },
     updateConversationsRightPanelState: (
       state,
@@ -256,5 +265,6 @@ export const {
   updateConversationsRightPanelState,
   updateSelectedConversationGroup,
   updateCollaborationEnabled,
+  setMissingDocumentationMessage,
 } = documentationSlice.actions;
 export default documentationSlice;

--- a/webview_panels/src/modules/documentationEditor/state/types.ts
+++ b/webview_panels/src/modules/documentationEditor/state/types.ts
@@ -82,6 +82,7 @@ export interface DocumentationStateProps {
     conversationGroupId: ConversationGroup["conversation_group_id"];
   };
   collaborationEnabled: boolean;
+  missingDocumentationMessage?: { message: string; type: "warning" | "error" };
 }
 
 export interface DBTModelTest {


### PR DESCRIPTION
## Overview

### Problem
- We cannot display documentation editor if there is any error in project or active open file is not a model. So it is confusing for the user to know what is the reason for not showing documentation of model

### Solution
- Show warning message if the open file is not valid model
- show error message if there is any error in project and a button to view problems tab

### Screenshot/Demo
https://www.loom.com/share/b8f5ca6ac24a460690af485830c50723?sid=03fb89e1-9b7a-4601-8f3e-e075fb19c746

### How to test
- open a schema.yml file
- should see warning message
- delete the profile for the project, delete the target directory
- on refresh should see the error message with button

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
