### PR TITLE
fix: query results copy from cell issue

### DIFF
--- a/webview_panels/src/modules/queryPanel/components/perspective/PerspectiveViewer.tsx
+++ b/webview_panels/src/modules/queryPanel/components/perspective/PerspectiveViewer.tsx
@@ -128,13 +128,14 @@ const PerspectiveViewer = ({
     const id = "altimate-styles";
     shadowRoot.getElementById(id)?.remove();
 
-    if (currentTheme === "Vintage") {
-      const style = document.createElement("style");
-      style.textContent = perspectiveStyles;
-      style.id = id;
-      shadowRoot.appendChild(style);
-    }
+    const style = document.createElement("style");
+    style.textContent = perspectiveStyles;
+    style.id = id;
+    shadowRoot.appendChild(style);
     shadowRoot.querySelector("regular-table")?.setAttribute("theme", theme);
+    shadowRoot
+      .querySelector("regular-table")
+      ?.setAttribute("perspective-theme", currentTheme);
   };
 
   const loadPerspectiveData = async () => {

--- a/webview_panels/src/modules/queryPanel/components/perspective/perspective.scss
+++ b/webview_panels/src/modules/queryPanel/components/perspective/perspective.scss
@@ -1,4 +1,11 @@
 regular-table {
+  td, th{
+    user-select: text;
+    cursor: text;
+  }
+}
+
+regular-table[perspective-theme="Vintage"] {
   th {
     font-weight: 800 !important;
     background-color: #222;
@@ -18,7 +25,7 @@ regular-table {
 
   th,
   td {
-    font-size: 13px !important;
+  font-size: 13px !important;
   }
 
   tbody tr::after,
@@ -70,7 +77,7 @@ regular-table {
   }
 }
 
-regular-table[theme="dark"] {
+regular-table[theme="dark"][perspective-theme="Vintage"] {
   tbody {
     tr:nth-child(even) {
       background-color: var(--background--03);


### PR DESCRIPTION
## Overview

### Problem
New query results view does not allow user to select contents of cells in table

### Solution
Enabled text select for cells

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Run a query and open query results panel
- try to select the text in the gird
- user should be able to select the text

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
