### PR TITLE
fix: add telemetry attribute for dbt-loom

### DIFF
--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -285,6 +285,22 @@ export class DBTCoreProjectIntegration
       this.rebuildManifestDiagnostics,
       this.pythonBridgeDiagnostics,
     );
+
+    this.isDbtLoomInstalled().then((isInstalled) => {
+      this.telemetry.setTelemetryCustomAttribute(
+        "dbtLoomInstalled",
+        `${isInstalled}`,
+      );
+    });
+  }
+
+  private async isDbtLoomInstalled(): Promise<boolean> {
+    try {
+      await this.python.ex`from dbt_loom import *`;
+      return true;
+    } catch (error) {
+      return false;
+    }
   }
 
   // remove the trailing slashes if they exists,

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -4,9 +4,14 @@ import { provideSingleton } from "../utils";
 
 @provideSingleton(TelemetryService)
 export class TelemetryService implements vscode.Disposable {
+  private customAttributes: { [key: string]: string } = {};
   private telemetryReporter: TelemetryReporter = new TelemetryReporter(
     "50598369-dd83-4f9a-9a65-ca1fa6f1785c",
   );
+
+  setTelemetryCustomAttribute(key: string, value: string) {
+    this.customAttributes[key] = value;
+  }
 
   sendTelemetryEvent(
     eventName: string,
@@ -28,6 +33,7 @@ export class TelemetryService implements vscode.Disposable {
           .get<boolean>("isLocalMode", false)
           ? "true"
           : "false",
+        ...this.customAttributes,
       },
       measurements,
     );
@@ -58,6 +64,7 @@ export class TelemetryService implements vscode.Disposable {
           error !== undefined && error instanceof Error
             ? error.stack
             : JSON.stringify(error),
+        ...this.customAttributes,
       },
       measurements,
     );


### PR DESCRIPTION
## Overview

### Problem
Need an attribute for all telemetry events when dbt-loom is installed for dbt core project

### Solution
Added custom attributes in telemetry service

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Setup [dbt-loom-example](https://github.com/Bl3f/dbt-loom-example) project
- Any telemetry event sent after project initialization should have `dbtLoomInstalled` attribute as `true`

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
