### PR TITLE
fix: render tests for quoted column names

### DIFF
--- a/src/manifest/parsers/testParser.ts
+++ b/src/manifest/parsers/testParser.ts
@@ -47,7 +47,10 @@ export class TestParser {
               database,
               schema,
               alias,
-              column_name,
+              // for quoted column names, remove the quotes
+              // ex: in manifest, it will be stored as "column_name": "\"Customer ID\"" for tests
+              // here we remove the extra quotes
+              column_name: column_name?.replace(/^"(.*)"$/, "$1"),
               test_metadata,
               attached_node,
               depends_on,

--- a/src/manifest/parsers/testParser.ts
+++ b/src/manifest/parsers/testParser.ts
@@ -8,6 +8,17 @@ import { DBTTerminal } from "../../dbt_client/dbtTerminal";
 export class TestParser {
   constructor(private terminal: DBTTerminal) {}
 
+  private getColumnNameWithoutQuotes(columnName: string): string | undefined {
+    if (!columnName) {
+      return undefined;
+    }
+
+    if (columnName.startsWith('"') && columnName.endsWith('"')) {
+      return columnName.slice(1, -1);
+    }
+
+    return columnName;
+  }
   createTestMetaMap(
     testsMap: any[],
     project: DBTProject,
@@ -49,8 +60,8 @@ export class TestParser {
               alias,
               // for quoted column names, remove the quotes
               // ex: in manifest, it will be stored as "column_name": "\"Customer ID\"" for tests
-              // here we remove the extra quotes
-              column_name: column_name?.replace(/^"(.*)"$/, "$1"),
+              // here we remove the enclosing quotes
+              column_name: this.getColumnNameWithoutQuotes(column_name),
               test_metadata,
               attached_node,
               depends_on,


### PR DESCRIPTION
## Overview

### Problem
Doc editor does not display tests for quoted columns

### Solution
In manifest, quoted column name are stored with extra quotes for tests. So, modified testParser to remove extra quotes
![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/4da4e017-e719-46d8-8127-0746fde9bd9c)


### Screenshot/Demo
![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/695f4216-085c-43b0-817d-ea6a3532bb03)


### How to test
- create quoted column
- add tests in schema.yml
- doc editor should show the tests

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
