### PR TITLE
fix: find right config if same dbt test is added with diff configs in yml

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -274,11 +274,11 @@ export const isAcceptedValues = (
 };
 
 export const getColumnTestConfigFromYml = (
-  tests: any[] | undefined,
+  allTests: any[] | undefined,
   kwargs: TestMetadataAcceptedValues | TestMetadataRelationships,
   testName: string,
 ) => {
-  const existingConfigs = tests?.filter((t: any) => {
+  const testsByTestName = allTests?.filter((t: any) => {
     if (typeof t === "string") {
       return t === testName;
     }
@@ -286,7 +286,7 @@ export const getColumnTestConfigFromYml = (
     return key === testName;
   });
 
-  return existingConfigs?.find((t: any) => {
+  const testWithRightConfigValues = testsByTestName?.find((t: any) => {
     if (typeof t === "string") {
       return t === testName;
     }
@@ -307,4 +307,26 @@ export const getColumnTestConfigFromYml = (
 
     return true;
   });
+
+  if (isRelationship(kwargs)) {
+    return (
+      testWithRightConfigValues as
+        | { relationships: TestMetadataAcceptedValues }
+        | undefined
+    )?.["relationships"];
+  }
+
+  if (isAcceptedValues(kwargs)) {
+    return (
+      testWithRightConfigValues as
+        | { accepted_values: TestMetadataAcceptedValues }
+        | undefined
+    )?.["accepted_values"];
+  }
+
+  if (testWithRightConfigValues?.[testName]) {
+    return {
+      [testName]: testWithRightConfigValues?.[testName],
+    };
+  }
 };

--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -11,7 +11,6 @@ import {
   WebviewView,
   WebviewViewProvider,
   WebviewViewResolveContext,
-  env,
   window,
   workspace,
 } from "vscode";
@@ -335,23 +334,19 @@ export class DocsEditViewPanel implements WebviewViewProvider {
         return null;
       }
       const { name, namespace, kwargs } = test.test_metadata;
-      const fullName: string = namespace ? `${namespace}.${name}` : name;
+      const testFullName: string = namespace ? `${namespace}.${name}` : name;
 
-      const existingConfig = getColumnTestConfigFromYml(
+      const columnTestConfigFromYml = getColumnTestConfigFromYml(
         existingColumn.tests,
         kwargs,
-        fullName,
+        testFullName,
       );
       // If relationships test, set field and to
       if (isRelationship(kwargs)) {
         const { to, field } = kwargs;
         return {
           relationships: {
-            ...(
-              existingConfig as
-                | { relationships: TestMetadataAcceptedValues }
-                | undefined
-            )?.["relationships"],
+            ...columnTestConfigFromYml,
             field,
             to,
           },
@@ -362,26 +357,19 @@ export class DocsEditViewPanel implements WebviewViewProvider {
       if (isAcceptedValues(kwargs)) {
         return {
           accepted_values: {
-            ...(
-              existingConfig as
-                | { accepted_values: TestMetadataAcceptedValues }
-                | undefined
-            )?.["accepted_values"],
+            ...columnTestConfigFromYml,
             values: kwargs.values,
           },
         };
       }
 
-      if (existingConfig?.[fullName]) {
-        return {
-          [fullName]: existingConfig?.[fullName],
-        };
+      if (columnTestConfigFromYml) {
+        return columnTestConfigFromYml;
       }
 
       // Add extra config from external packages or test macros
-      // Add extra config from external packages or test macros
-      const testMetaKwargs = this.getTestMetadataKwArgs(kwargs, fullName);
-      return testMetaKwargs || fullName;
+      const testMetaKwargs = this.getTestMetadataKwArgs(kwargs, testFullName);
+      return testMetaKwargs || testFullName;
     });
 
     this.terminal.debug(

--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -345,7 +345,7 @@ export class DocsEditViewPanel implements WebviewViewProvider {
       }
       const { name, namespace, kwargs } = test.test_metadata;
       const fullName: string = namespace ? `${namespace}.${name}` : name;
-      const existingConfig = existingColumn?.tests?.find((t: any) => {
+      const existingConfigs = existingColumn?.tests?.filter((t: any) => {
         if (typeof t === "string") {
           return t === fullName;
         }
@@ -353,6 +353,27 @@ export class DocsEditViewPanel implements WebviewViewProvider {
         return key === fullName;
       });
 
+      const existingConfig = existingConfigs.find((t: any) => {
+        if (typeof t === "string") {
+          return t === fullName;
+        }
+
+        if (this.isRelationship(kwargs)) {
+          return (
+            kwargs.field === t.relationships.field &&
+            kwargs.to === t.relationships.to
+          );
+        }
+
+        if (this.isAcceptedValues(kwargs)) {
+          return (
+            kwargs.values?.sort().toString() ===
+            t.accepted_values.values.sort().toString()
+          );
+        }
+
+        return true;
+      });
       // If relationships test, set field and to
       if (this.isRelationship(kwargs)) {
         const { to, field } = kwargs;


### PR DESCRIPTION
## Overview

### Problem
If a column has same type of generic test with diff config, doc editor does not save properly

### Solution
- While finding the config of the test from existing schema, equate the values to get right config

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- add test as in issue #1219 for any column in dbt project
- change some description of model from doc editor
- save
- should save with right config

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
