### PR TITLE
fix: lineage legend UI

### DIFF
--- a/new_lineage_panel/src/components/styles.module.scss
+++ b/new_lineage_panel/src/components/styles.module.scss
@@ -100,6 +100,6 @@
   div {
     height: 2px;
     width: 12px;
-    border-top: dashed 2px #E38E00;
+    border-top: dashed 1px #E38E00;
   }
 }

--- a/new_lineage_panel/src/utils.ts
+++ b/new_lineage_panel/src/utils.ts
@@ -29,7 +29,6 @@ export const VIEWS_TYPE_COLOR = {
   Transformation: "#FF754C",
   Unchanged: "#BC3FBC",
   "Not sure": "#247efe",
-  "Non select": "#BC3FBC",
 };
 
 export type CollectColumn = { column: string; viewsType?: ViewsTypes };


### PR DESCRIPTION
## Overview

### Problem
Lineage legend has duplicate `Non Select` and should show dashed border

### Solution
removed duplicate entry and fixed css

### Screenshot/Demo
![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/3cace643-0017-4774-83fa-ed347d819497)


### How to test

- Open a dbt model
- go to lineage panel
- should see lineage legend with above fixes

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
