### PR TITLE
fix: find error when modifying column names

### DIFF
--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -444,9 +444,8 @@ export class DocsEditViewPanel implements WebviewViewProvider {
       return columns;
     }
 
-    const existingColumnNames = (model.columns as { name: string }[])?.map(
-      (c) => c.name,
-    );
+    const existingColumnNames =
+      (model.columns as { name: string }[])?.map((c) => c.name) || [];
 
     return this.modifyColumnNames(columns, existingColumnNames);
   }


### PR DESCRIPTION
## Overview

### Problem
If schema.yml has entry only for model and no columns, then getting below error 
```
TypeError: Cannot read properties of undefined (reading 'find')
```

### Solution
use default array if columns are not added in schema.yml

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- in schema.yml, create a model without columns
- sync with db from doc editor
- should not see any error

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
