### PR TITLE
fix: add new feature indicator to open in tab button

### DIFF
--- a/src/webview_provider/altimateWebviewProvider.ts
+++ b/src/webview_provider/altimateWebviewProvider.ts
@@ -332,6 +332,15 @@ export class AltimateWebviewProvider implements WebviewViewProvider {
             params.value,
           );
           break;
+        case "getFromContext":
+          this.sendResponseToWebview({
+            command: "response",
+            data: this.dbtProjectContainer.getFromGlobalState(
+              params.key as string,
+            ),
+            syncRequestId,
+          });
+          break;
         case "updateConfig":
           if (!this.isUpdateConfigProps(params)) {
             return;

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -175,6 +175,10 @@ export class QueryResultPanel extends AltimateWebviewProvider {
         );
         break;
       case "queryResultTab:render":
+        this.dbtProjectContainer.setToGlobalState(
+          "open-query-results-in-tab-clicked",
+          true,
+        );
         this.dbtTerminal.debug(
           "queryResultTab:render",
           "rendering query result tab",

--- a/webview_panels/src/main.scss
+++ b/webview_panels/src/main.scss
@@ -171,6 +171,6 @@ code {
   height: 12px;
   border-radius: 50%;
   position: absolute;
-  bottom: -4px;
+  top: -4px;
   right: -4px;
 }

--- a/webview_panels/src/main.scss
+++ b/webview_panels/src/main.scss
@@ -164,3 +164,13 @@ code {
   overflow-x: hidden;
   white-space: nowrap;
 }
+
+.new-feature{
+  background: rgb(255, 105, 74);
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+}

--- a/webview_panels/src/modules/newFeature/NewFeatureIndicator.tsx
+++ b/webview_panels/src/modules/newFeature/NewFeatureIndicator.tsx
@@ -1,4 +1,5 @@
 import { executeRequestInSync } from "@modules/app/requestExecutor";
+import { Tooltip } from "@uicore";
 import { useEffect, useState } from "react";
 
 const NewFeatureIndicator = ({
@@ -20,7 +21,11 @@ const NewFeatureIndicator = ({
   if (!show) {
     return null;
   }
-  return <div className="new-feature" />;
+  return (
+    <Tooltip title="New feature">
+      <div className="new-feature" />
+    </Tooltip>
+  );
 };
 
 export default NewFeatureIndicator;

--- a/webview_panels/src/modules/newFeature/NewFeatureIndicator.tsx
+++ b/webview_panels/src/modules/newFeature/NewFeatureIndicator.tsx
@@ -1,0 +1,26 @@
+import { executeRequestInSync } from "@modules/app/requestExecutor";
+import { useEffect, useState } from "react";
+
+const NewFeatureIndicator = ({
+  featureKey,
+}: {
+  featureKey: string;
+}): JSX.Element | null => {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    executeRequestInSync("getFromContext", { key: featureKey })
+      .then((value) => {
+        setShow(!value);
+      })
+      .catch(() => {
+        setShow(true);
+      });
+  }, []);
+
+  if (!show) {
+    return null;
+  }
+  return <div className="new-feature" />;
+};
+
+export default NewFeatureIndicator;

--- a/webview_panels/src/modules/queryPanel/components/openInTabButton/OpenInTabButton.tsx
+++ b/webview_panels/src/modules/queryPanel/components/openInTabButton/OpenInTabButton.tsx
@@ -1,18 +1,25 @@
 import { executeRequestInAsync } from "@modules/app/requestExecutor";
+import NewFeatureIndicator from "@modules/newFeature/NewFeatureIndicator";
 import useQueryPanelState from "@modules/queryPanel/useQueryPanelState";
 import { Button } from "@uicore";
+import { useState } from "react";
 
 const OpenInTabButton = (): JSX.Element | null => {
   const queryTabData = useQueryPanelState();
+  const [isClicked, setIsClicked] = useState(false);
   const handleClick = () => {
+    setIsClicked(true);
     executeRequestInAsync("queryResultTab:render", { queryTabData });
   };
   if (!queryTabData?.queryResults) {
     return null;
   }
   return (
-    <Button outline onClick={handleClick}>
+    <Button outline onClick={handleClick} className="position-relative">
       Open in Tab
+      {!isClicked ? (
+        <NewFeatureIndicator featureKey="open-query-results-in-tab-clicked-2" />
+      ) : null}
     </Button>
   );
 };

--- a/webview_panels/src/modules/queryPanel/components/openInTabButton/OpenInTabButton.tsx
+++ b/webview_panels/src/modules/queryPanel/components/openInTabButton/OpenInTabButton.tsx
@@ -18,7 +18,7 @@ const OpenInTabButton = (): JSX.Element | null => {
     <Button outline onClick={handleClick} className="position-relative">
       Open in Tab
       {!isClicked ? (
-        <NewFeatureIndicator featureKey="open-query-results-in-tab-clicked-2" />
+        <NewFeatureIndicator featureKey="open-query-results-in-tab-clicked" />
       ) : null}
     </Button>
   );

--- a/webview_panels/src/uiCore/components/tooltip/Tooltip.tsx
+++ b/webview_panels/src/uiCore/components/tooltip/Tooltip.tsx
@@ -1,12 +1,13 @@
 import { ErrorBoundary } from "react-error-boundary";
 import { ReactNode, useRef, useState } from "react";
-import { Tooltip as ReactStrapTooltip } from "reactstrap";
+import { Tooltip as ReactStrapTooltip, TooltipProps } from "reactstrap";
 
 interface Props {
   children: ReactNode;
   title?: string;
   id?: string;
   className?: string;
+  placement?: TooltipProps["placement"];
 }
 const Tooltip = (props: Props): JSX.Element => {
   const [tooltipOpen, setTooltipOpen] = useState(false);
@@ -26,6 +27,7 @@ const Tooltip = (props: Props): JSX.Element => {
           target={idRef.current}
           toggle={toggle}
           className={props.className}
+          placement={props.placement ?? "auto"}
         >
           {props.title}
         </ReactStrapTooltip>


### PR DESCRIPTION
## Overview

### Problem
New features are not highlighted

### Solution
Add new feature indicator, in this case for `Open in Tab` button in query results panel

### Screenshot/Demo
![image](https://github.com/AltimateAI/vscode-dbt-power-user/assets/1147025/df50a5f8-e11d-4d6d-bf4e-93b4fef0c170)

### How to test
- Execute a query and in query results panel, open in tab button should have red indictor

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
