### PR TITLE
fix: flashing screen in query panel

### DIFF
--- a/webview_panels/src/modules/queryPanel/components/perspective/PerspectiveViewer.tsx
+++ b/webview_panels/src/modules/queryPanel/components/perspective/PerspectiveViewer.tsx
@@ -6,13 +6,13 @@ import {
   HTMLPerspectiveViewerElement,
   PerspectiveViewerConfig,
 } from "@finos/perspective-viewer";
+import "./themes.css";
 import "@finos/perspective-viewer/dist/css/pro.css";
 import "@finos/perspective-viewer/dist/css/pro-dark.css";
 import "@finos/perspective-viewer/dist/css/vaporwave.css";
 import "@finos/perspective-viewer/dist/css/solarized.css";
 import "@finos/perspective-viewer/dist/css/solarized-dark.css";
 import "@finos/perspective-viewer/dist/css/monokai.css";
-import "./themes.css";
 import { useEffect, useRef, useState } from "react";
 import { panelLogger } from "@modules/logger";
 import useAppContext from "@modules/app/useAppContext";


### PR DESCRIPTION
## Overview

### Problem
- white screen flashes when executing query

### Solution
- Modified order of theme to take vintage as default, so we will not see flashing white screen

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- use dark theme in vscode
- Open a dbt model
- execute query
- notice no white flashing screen before rendering results table

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
