### PR TITLE
fix: telemetry errors

### DIFF
--- a/src/code_lens_provider/virtualSqlCodeLensProvider.ts
+++ b/src/code_lens_provider/virtualSqlCodeLensProvider.ts
@@ -35,7 +35,7 @@ export class VirtualSqlCodeLensProvider implements CodeLensProvider {
   ): CodeLens[] | Thenable<CodeLens[]> {
     // Enable this code lens only for adhoc query files created using command: dbtPowerUser.createSqlFile
     if (
-      document.uri.scheme !== "untitled" &&
+      document.uri.scheme !== "untitled" ||
       document.languageId !== "jinja-sql"
     ) {
       return [];

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -614,6 +614,10 @@ export class QueryResultPanel extends AltimateWebviewProvider {
     duration: number,
     modelName: string,
   ) {
+    // Do not update query history if bookmarks are disabled
+    if (!workspace.getConfiguration("dbt").get("enableQueryBookmarks", false)) {
+      return;
+    }
     const project = projectName
       ? this.queryManifestService.getProjectByName(projectName) // for queries executed from history and bookmarks tab
       : this.queryManifestService.getProject(); // queries executed from main window

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -333,8 +333,8 @@ export class QueryResultPanel extends AltimateWebviewProvider {
     name: string;
   }) {
     commands.executeCommand("dbtPowerUser.createSqlFile", {
-      code: message.code,
-      name: message.name,
+      code: message?.code,
+      name: message?.name,
     });
   }
 
@@ -482,7 +482,7 @@ export class QueryResultPanel extends AltimateWebviewProvider {
   }
 
   private sendQueryPanelViewEvent() {
-    if (this._panel!.visible) {
+    if (this._panel?.visible) {
       this.telemetry.sendTelemetryEvent("QueryPanelActive");
     }
   }


### PR DESCRIPTION
## Overview

### Problem
- errors are shown in telemetry
- project selector codelens shows for all dbt related files

### Solution
- add sanity check for optional objects for below errors
```
Cannot read properties of undefined (reading 'visible')
Cannot destructure property `code` of undefined
```
- updated condition to show project selector only for new query files

### Screenshot/Demo
![image](https://github.com/user-attachments/assets/50cdbae7-0819-45cd-aa53-6e2be0565401)


### How to test
- open any existing dbt related files. Should not see project selector codelens
- Click `New Query` button in query results panel - should see project selector codelens

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
