### PR TITLE
fix: get limit sub query macro

### DIFF
--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -324,7 +324,7 @@ export class DBTCoreProjectIntegration
       const dbtVersion = await this.version;
       //dbt supports limit macro after v1.5
       if (dbtVersion && dbtVersion[0] >= 1 && dbtVersion[1] >= 5) {
-        const args = { sql: query, limit };
+        const args = { compiled_code: query, limit };
         const queryTemplateFromMacro = await this.python?.lock(
           (python) =>
             python!`to_dict(project.execute_macro('get_show_sql', ${args}))`,


### PR DESCRIPTION
## Overview

### Problem
Error is thrown while executing limit query macro. Details: https://github.com/AltimateAI/vscode-dbt-power-user/pull/1320#issuecomment-2249057494

### Solution
Pass right arguments

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Execute a query using poweruser execute button
- Compiled sql in query results panel should show query with limit

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
