### PR TITLE
feat: AI-1863-In-doc-editor-implement-auto-expandable-UI

### DIFF
--- a/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
+++ b/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
@@ -119,7 +119,7 @@ const DocumentationEditor = (): JSX.Element => {
   }
 
   return (
-    <div className={classes.documentationWrapper}>
+    <div className={`${classes.documentationWrapper} ${classes.limitWidth}`}>
       <Stack className="mb-2 justify-content-between">
         <Stack>
           <Button
@@ -157,7 +157,7 @@ const DocumentationEditor = (): JSX.Element => {
         </Stack>
         <CommonActionButtons />
       </Stack>
-      <div className={`${classes.docGenerator} ${classes.limitWidth}`}>
+      <div className={classes.docGenerator}>
         <Stack className={classes.head}>
           <Stack>
             <h3 className="mb-2">Model: {currentDocsData.name}</h3>

--- a/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
+++ b/webview_panels/src/modules/documentationEditor/DocumentationEditor.tsx
@@ -157,7 +157,7 @@ const DocumentationEditor = (): JSX.Element => {
         </Stack>
         <CommonActionButtons />
       </Stack>
-      <div className={classes.docGenerator}>
+      <div className={`${classes.docGenerator} ${classes.limitWidth}`}>
         <Stack className={classes.head}>
           <Stack>
             <h3 className="mb-2">Model: {currentDocsData.name}</h3>

--- a/webview_panels/src/modules/documentationEditor/styles.module.scss
+++ b/webview_panels/src/modules/documentationEditor/styles.module.scss
@@ -2,6 +2,16 @@
 
 
 .documentation-wrapper {
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  box-sizing: border-box;
+  top: 0;
+  left: 0;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  overflow-y: overlay;
   :global .btn-group {
     margin-bottom: var(--spacing-3xl);
   }
@@ -102,7 +112,8 @@
   }
 }
 .doc-generator {
-  max-height: calc(100vh - 100px);
+  max-height: calc(100% - 40px);
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
 
@@ -118,10 +129,8 @@
   & .body-wrap {
     overflow: hidden;
     & .body {
-      width: 80%;
-      min-width: var(--bs-breakpoint-md);
+      width: 100%;
       overflow: overlay;
-      padding-right: 1rem;
 
       & :global .alert {
         margin-top: 12px;

--- a/webview_panels/src/modules/documentationEditor/styles.module.scss
+++ b/webview_panels/src/modules/documentationEditor/styles.module.scss
@@ -2,16 +2,6 @@
 
 
 .documentation-wrapper {
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  box-sizing: border-box;
-  top: 0;
-  left: 0;
-  padding: 0.5rem;
-  display: flex;
-  flex-direction: column;
-  overflow-y: overlay;
   :global .btn-group {
     margin-bottom: var(--spacing-3xl);
   }
@@ -112,8 +102,7 @@
   }
 }
 .doc-generator {
-  max-height: calc(100% - 40px);
-  flex-grow: 1;
+  max-height: calc(100vh - 100px);
   display: flex;
   flex-direction: column;
   
@@ -130,7 +119,9 @@
     overflow: hidden;
     & .body {
       width: 100%;
+      min-width: var(--bs-breakpoint-md);
       overflow: overlay;
+      padding-right: 1rem;
 
       & :global .alert {
         margin-top: 12px;

--- a/webview_panels/src/modules/documentationEditor/styles.module.scss
+++ b/webview_panels/src/modules/documentationEditor/styles.module.scss
@@ -116,7 +116,7 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-
+  
   & .head {
     justify-content: space-between;
     > div {
@@ -332,5 +332,16 @@
   textarea{
     top: 5px !important;
     height: 80% !important;
+  }
+}
+
+.limitWidth {
+  max-width: 100%;
+  min-width: 0;
+  flex: 1;
+}
+@media (min-width: 1400px) {
+  .limitWidth {
+    max-width: 1440px;
   }
 }


### PR DESCRIPTION
## Overview

### Problem
https://altimateai.atlassian.net/browse/AI-1863

In doc editor panel, currently width of the doc editor is fixed. In small screens, some of the space in right side is unused. Fixing that.

### Solution

Changing the styles for doc editor

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.
Change:
<img width="969" alt="Screenshot 2024-07-25 at 6 15 51 PM" src="https://github.com/user-attachments/assets/96c5221c-fe17-4968-b0b2-062983d93168">
<img width="1659" alt="Screenshot 2024-07-25 at 6 16 08 PM" src="https://github.com/user-attachments/assets/8a64d3ae-1e99-4816-bda8-e0a2d7e9f5bb">

Before:
<img width="1657" alt="Screenshot 2024-07-25 at 6 16 28 PM" src="https://github.com/user-attachments/assets/7dc61b90-3890-41c1-b239-e95159f01d51">

### How to test

- run the extension with this branch
- open doc editor panel
- see if it fills the whole screen

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
