### PR TITLE
pass profile, target and vars via env vars

### DIFF
--- a/dbt_core_integration.py
+++ b/dbt_core_integration.py
@@ -272,19 +272,21 @@ class ConfigInterface:
         defer: Optional[bool] = False,
         state: Optional[str] = None,
         favor_state: Optional[bool] = False,
+        vars: Optional[Dict[str, Any]] = {},
     ):
         self.threads = threads
-        self.target = target
+        self.target = target if target else os.environ.get("DBT_TARGET")
         self.profiles_dir = profiles_dir
         self.project_dir = project_dir
         self.dependencies = []
         self.single_threaded = threads == 1
         self.quiet = True
-        self.profile = profile
+        self.profile = profile if profile else os.environ.get("DBT_PROFILE")
         self.target_path = target_path
         self.defer = defer
         self.state = state
         self.favor_state = favor_state
+        self.vars = vars if vars else json.loads(os.environ.get("DBT_VARS", "{}"))
 
     def __str__(self):
         return f"ConfigInterface(threads={self.threads}, target={self.target}, profiles_dir={self.profiles_dir}, project_dir={self.project_dir}, profile={self.profile}, target_path={self.target_path})"
@@ -346,6 +348,7 @@ class DbtProject:
         defer_to_prod: bool = False,
         manifest_path: Optional[str] = None,
         favor_state: bool = False,
+        vars: Optional[Dict[str, Any]] = {},
     ):
         self.args = ConfigInterface(
             threads=threads,
@@ -357,6 +360,7 @@ class DbtProject:
             defer=defer_to_prod,
             state=manifest_path,
             favor_state=favor_state,
+            vars=vars,
         )
 
         # Utilities
@@ -461,6 +465,7 @@ class DbtProject:
             threads=args.threads,
             profile=args.profile,
             target_path=args.target_path,
+            vars=args.vars,
         )
 
     @property


### PR DESCRIPTION
## Overview

### Problem

https://github.com/AltimateAI/vscode-dbt-power-user/issues/1340

I have a complicated dbt project requires specifying profile, target and vars explicitly on dbt-compile. So currently some features run dbt-compile (e.g. compiled sql preview, lineage) don't work.

### Solution

Allow to provide these parameters via environment variables.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
