### PR TITLE
feat: button with children as IDs

### DIFF
--- a/webview_panels/src/uiCore/components/button/Button.tsx
+++ b/webview_panels/src/uiCore/components/button/Button.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, ReactNode } from "react";
 import { Button as ReactStrapButton, ButtonProps } from "reactstrap";
 import Tooltip from "../tooltip/Tooltip";
 
 interface CustomButtonProps extends ButtonProps {
   icon?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export const Button = ({
@@ -23,6 +24,9 @@ export const Button = ({
     }
   };
 
+  const isString = (value: ReactNode): value is string =>
+    typeof value === "string";
+
   return (
     <Tooltip title={restProps.title}>
       <ReactStrapButton
@@ -30,7 +34,12 @@ export const Button = ({
         onMouseEnter={() => mouseHoverAction(true)}
         onMouseLeave={() => mouseHoverAction(false)}
       >
-        {icon && icon} {showButtonText && children}
+        {icon && icon}{" "}
+        {children && (
+          <span id={isString(children) ? children : undefined}>
+            {showButtonText && children}
+          </span>
+        )}
       </ReactStrapButton>
     </Tooltip>
   );

--- a/webview_panels/src/uiCore/components/button/Button.tsx
+++ b/webview_panels/src/uiCore/components/button/Button.tsx
@@ -28,7 +28,10 @@ export const Button = ({
     typeof value === "string";
 
   return (
-    <Tooltip title={restProps.title}>
+    <Tooltip
+      id={isString(children) ? children : undefined}
+      title={restProps.title}
+    >
       <ReactStrapButton
         {...restProps}
         onMouseEnter={() => mouseHoverAction(true)}


### PR DESCRIPTION
## Overview

### Problem
Playwright is not able to detect as the button text is not visible(unless hovered)

### Solution
Add IDs to the buttons

### Screenshot/Demo


### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
