### PR TITLE
chore: add debug info for query blank issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,6 +341,11 @@
     },
     "commands": [
       {
+        "command": "dbtPowerUser.gatherQueryResultsDebugInfo",
+        "title": "Query Results Debug Info",
+        "category": "dbt Power User"
+      },
+      {
         "command": "dbtPowerUser.resolveConversation",
         "title": "Resolve",
         "category": "dbt Power User"

--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     },
     "commands": [
       {
-        "command": "dbtPowerUser.gatherQueryResultsDebugInfo",
+        "command": "dbtPowerUser.collectQueryResultsDebugInfo",
         "title": "Query Results Debug Info",
         "category": "dbt Power User"
       },

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -79,6 +79,7 @@ interface InjectConfig {
 }
 
 enum InboundCommand {
+  CollectQueryResultsDebugInfo = "collectQueryResultsDebugInfo",
   Info = "info",
   Error = "error",
   UpdateConfig = "updateConfig",
@@ -177,6 +178,19 @@ export class QueryResultPanel extends AltimateWebviewProvider {
     );
 
     this.updateEnableBookmarksInContext();
+    this._disposables.push(
+      commands.registerCommand("dbtPowerUser.gatherQueryResultsDebugInfo", () =>
+        this.collectQueryResultsDebugInfo(),
+      ),
+      this,
+    );
+  }
+
+  private collectQueryResultsDebugInfo() {
+    console.log("Collecting query results debug info");
+    this._panel?.webview?.postMessage({
+      command: "collectQueryResultsDebugInfo",
+    });
   }
 
   private updateEnableBookmarksInContext() {
@@ -471,6 +485,12 @@ export class QueryResultPanel extends AltimateWebviewProvider {
               message.key,
               message.value,
             );
+            break;
+          case InboundCommand.CollectQueryResultsDebugInfo:
+            this.telemetry.sendTelemetryEvent("CollectQueryResultsDebugInfo", {
+              ...message,
+              history: this._queryHistory,
+            });
             break;
           default:
             super.handleCommand(message);

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -179,8 +179,9 @@ export class QueryResultPanel extends AltimateWebviewProvider {
 
     this.updateEnableBookmarksInContext();
     this._disposables.push(
-      commands.registerCommand("dbtPowerUser.gatherQueryResultsDebugInfo", () =>
-        this.collectQueryResultsDebugInfo(),
+      commands.registerCommand(
+        "dbtPowerUser.collectQueryResultsDebugInfo",
+        () => this.collectQueryResultsDebugInfo(),
       ),
       this,
     );

--- a/webview_panels/src/modules/queryPanel/components/perspective/perspective.module.scss
+++ b/webview_panels/src/modules/queryPanel/components/perspective/perspective.module.scss
@@ -1,5 +1,6 @@
 .altimatePerspectiveViewer {
   height: 100%;
+  min-height: 50vh;
   font-size: 1.25rem !important;
   z-index: 20;
 

--- a/webview_panels/src/modules/queryPanel/useQueryPanelListeners.ts
+++ b/webview_panels/src/modules/queryPanel/useQueryPanelListeners.ts
@@ -27,7 +27,8 @@ import {
 
 const useQueryPanelListeners = (): { loading: boolean } => {
   const dispatch = useQueryPanelDispatch();
-  const { loading, hintIndex } = useQueryPanelState();
+  const { loading, hintIndex, queryResults } =
+    useQueryPanelState();
   const hintInterval = useRef<NodeJS.Timeout>();
   const hintIndexRef = useRef<number>(hintIndex);
   const queryExecutionTimer = useRef<NodeJS.Timeout>();
@@ -78,8 +79,8 @@ const useQueryPanelListeners = (): { loading: boolean } => {
   const handleError = (args: Record<string, unknown>) => {
     dispatch(
       setQueryResultsError(
-        args.error as QueryPanelStateProps["queryResultsError"],
-      ),
+        args.error as QueryPanelStateProps["queryResultsError"]
+      )
     );
     dispatch(setCompiledCodeMarkup(args.compiled_sql as string));
     clearHintInterval();
@@ -93,7 +94,7 @@ const useQueryPanelListeners = (): { loading: boolean } => {
         data: args.rows,
         columnNames: args.columnNames,
         columnTypes: args.columnTypes,
-      } as QueryPanelStateProps["queryResults"]),
+      } as QueryPanelStateProps["queryResults"])
     );
     dispatch(setCompiledCodeMarkup(args.compiled_sql as string));
     clearHintInterval();
@@ -108,6 +109,26 @@ const useQueryPanelListeners = (): { loading: boolean } => {
 
   const handleIncomingQueryHistory = (args: QueryHistory[]) => {
     dispatch(setQueryHistory(args));
+  };
+
+  const collectQueryResultsDebugInfo = () => {
+    /**
+     * perspective height
+     * no of rows
+     * theme
+     * data
+     * history length and size
+     *      */
+    const perspectiveViewer = document.querySelector("perspective-viewer");
+    const table = perspectiveViewer
+      ?.querySelector("perspective-datagrid-json-viewer-plugin")
+      ?.shadowRoot?.querySelectorAll("regular-table tr");
+    void executeRequestInSync("collectQueryResultsDebugInfo", {
+      perspectiveHeight: perspectiveViewer?.offsetHeight,
+      perspectiveScrollHeight: perspectiveViewer?.scrollHeight,
+      tableRowsCount: table?.length,
+      queryResults,
+    });
   };
 
   const onMesssage = useCallback(
@@ -134,8 +155,8 @@ const useQueryPanelListeners = (): { loading: boolean } => {
           dispatch(
             setViewType(
               (args.args.body as { type: QueryPanelViewType })
-                .type as QueryPanelViewType,
-            ),
+                .type as QueryPanelViewType
+            )
           );
           break;
         case "getContext":
@@ -145,14 +166,17 @@ const useQueryPanelListeners = (): { loading: boolean } => {
           dispatch(setPerspectiveTheme(args.perspectiveTheme as string));
           dispatch(
             // @ts-expect-error valid type
-            setQueryBookmarksEnabled(args.queryBookmarksEnabled as boolean),
+            setQueryBookmarksEnabled(args.queryBookmarksEnabled as boolean)
           );
+          break;
+        case "collectQueryResultsDebugInfo":
+          collectQueryResultsDebugInfo();
           break;
         default:
           break;
       }
     },
-    [handleLoading, dispatch],
+    [handleLoading, dispatch]
   );
 
   useEffect(() => {
@@ -182,7 +206,7 @@ const useQueryPanelListeners = (): { loading: boolean } => {
         dispatch(
           setQueryExecutionInfo({
             elapsedTime: typedData.queryExecutionInfo!.elapsedTime,
-          }),
+          })
         );
       }
     });

--- a/webview_panels/src/modules/queryPanel/useQueryPanelListeners.ts
+++ b/webview_panels/src/modules/queryPanel/useQueryPanelListeners.ts
@@ -112,13 +112,6 @@ const useQueryPanelListeners = (): { loading: boolean } => {
   };
 
   const collectQueryResultsDebugInfo = () => {
-    /**
-     * perspective height
-     * no of rows
-     * theme
-     * data
-     * history length and size
-     *      */
     const perspectiveViewer = document.querySelector("perspective-viewer");
     const table = perspectiveViewer
       ?.querySelector("perspective-datagrid-json-viewer-plugin")


### PR DESCRIPTION
## Overview

### Problem
Query results panels does not show the table sometimes

### Solution
Added a debug workflow for getting more info for debugging this issue

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- execute a dbt sql
- Open command paletter `Cmd/Ctrl + shift + P`
- Select "Query Results Debug Info"
- This will send a telemetry event with debug info

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command to gather debug information related to query results for improved debugging and data analysis.
	- Enhanced the query panel to collect detailed metrics about query results, including viewer height and row count.
	- Added a new option in the command palette titled "Query Results Debug Info."

- **Bug Fixes**
	- Improved handling of query results and error processing within the query panel.

- **Style**
	- Updated the layout of the perspective viewer component to ensure a minimum height for better usability across different screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->