### PR TITLE
fix: make log info instead of debug for query results blank issue

### DIFF
--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -513,10 +513,11 @@ export class QueryResultPanel extends AltimateWebviewProvider {
               historyItems: this._queryHistory.length,
               historySize: JSON.stringify(this._queryHistory).length,
             };
-            this.dbtTerminal.debug(
+            this.dbtTerminal.info(
               "CollectQueryResultsDebugInfo",
               "collecting query results debug info",
-              data,
+              false,
+              JSON.stringify(data),
             );
             this.telemetry.sendTelemetryEvent(
               "CollectQueryResultsDebugInfo",


### PR DESCRIPTION
## Overview

### Problem
- debug logs are not showing in output channel

### Solution

make the log as info

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 627b04271b76702fd5a93e508ee968c1306fb801  | 
|--------|--------|

fix: change log level to info for query results debug info

### Summary:
Change log level from debug to info for `CollectQueryResultsDebugInfo` in `queryResultPanel.ts`.

**Key points**:
- **Logging**:
  - Change log level from `debug` to `info` for `CollectQueryResultsDebugInfo` in `queryResultPanel.ts` to ensure visibility in output channel.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated logging behavior in the Query Result Panel for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->