### PR TITLE
Fix missing legacy lineage panel.

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,7 +11,6 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 .github
-lineage_panel
 new_lineage_panel
 !new_lineage_panel/dist
 webview_panels


### PR DESCRIPTION
## Overview

### Problem

#1430 The legacy LINEAGE panel is not displayed. 

The extension runtime detects an uncaught error:
> ENOENT: no such file or directory, open '/home/vscode/.vscode-server/extensions/innoverio.vscode-dbt-power-user-0.45.1/lineage_panel/index.html'

This issue is caused by the `.vscodeignore` excluding the `lineage_panel` directory from the build package.

### Solution

The solution is to modify the `.vscodeignore` to include the `lineage_panel` directory in the build package.

**NOTE**: `.vscodeignore` was modified in #1410, but the intent behind this change has not been thoroughly investigated.

### Screenshot/Demo

### How to test

Rebuild and install the updated extension package. 
Verify that the legacy LINEAGE panel is displayed correctly.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [x] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix missing legacy LINEAGE panel by including `lineage_panel` in the build package.
> 
>   - **Bug Fix**:
>     - Fix missing legacy LINEAGE panel by including `lineage_panel` directory in the build package.
>     - Modify `.vscodeignore` to remove `lineage_panel` from the exclusion list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 9c53f05bad73b11d5e11ba1fa9fe9a523c8826c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.vscodeignore` file to replace `lineage_panel` with `new_lineage_panel`, ensuring the new panel is properly recognized in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->