### PR TITLE
fix: add check for backend connectivity while validating credentials

### DIFF
--- a/src/validation_provider/index.ts
+++ b/src/validation_provider/index.ts
@@ -72,6 +72,13 @@ export class ValidationProvider implements Disposable {
       }
       return;
     }
+    const connectivity = await this.altimate.checkApiConnectivity();
+    if (connectivity?.status !== "ok") {
+      if (!silent) {
+        window.showErrorMessage("Unable to connect to altimate backend.");
+      }
+      return;
+    }
     const validation = await this.altimate.validateCredentials(instance, key);
     if (!validation?.ok) {
       this._isAuthenticated = false;

--- a/src/validation_provider/index.ts
+++ b/src/validation_provider/index.ts
@@ -74,6 +74,7 @@ export class ValidationProvider implements Disposable {
     }
     const connectivity = await this.altimate.checkApiConnectivity();
     if (connectivity?.status !== "ok") {
+      this._isAuthenticated = false;
       if (!silent) {
         window.showErrorMessage("Unable to connect to altimate backend.");
       }


### PR DESCRIPTION
## Overview



### Problem

Currently if user is behind a firewall and unable to connect to altimate backend, he gets error message of "invalidate credentials".

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds backend connectivity check in `_validateCredentials()` in `index.ts` to prevent validation when backend is unreachable.
> 
>   - **Behavior**:
>     - Adds a backend connectivity check in `_validateCredentials()` in `index.ts` before validating credentials.
>     - Displays error message if backend is unreachable, preventing further validation attempts.
>   - **Functions**:
>     - Modifies `_validateCredentials()` to include `checkApiConnectivity()` call and handle its response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 11d96a6abd8ec9062297079a0f83bcdc064afc44. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->