### PR TITLE
feat: handled unknown dialect for cloud

### DIFF
--- a/src/dbt_client/dbtCloudIntegration.ts
+++ b/src/dbt_client/dbtCloudIntegration.ts
@@ -238,7 +238,12 @@ export class DBTCloudProjectIntegration
     }
     if (!this.adapterType) {
       // We only fetch the adapter type once, as it may impact compilation preview otherwise
-      this.findAdapterType();
+      const startTime = Date.now();
+      await this.findAdapterType();
+      const elapsedTime = Date.now() - startTime;
+      this.telemetry.sendTelemetryEvent("cloudFindAdapterTypeElapsedTime", {
+        elapsedTime: elapsedTime.toString(),
+      });
     }
     if (!this.version) {
       await this.findVersion();
@@ -1029,7 +1034,13 @@ export class DBTCloudProjectIntegration
       return;
     }
     this.firstRun = true;
-    this.findAdapterType();
+    const startTime = Date.now();
+    await this.findAdapterType();
+    const elapsedTime = Date.now() - startTime;
+    this.telemetry.sendTelemetryEvent("cloudFindAdapterTypeElapsedTime", {
+      elapsedTime: elapsedTime.toString(),
+      retry: "true",
+    });
   }
 
   private async findAdapterType() {

--- a/src/dbt_client/dbtCloudIntegration.ts
+++ b/src/dbt_client/dbtCloudIntegration.ts
@@ -1023,6 +1023,15 @@ export class DBTCloudProjectIntegration
     }
   }
 
+  private firstRun = false;
+  private async retryOnce() {
+    if (this.firstRun) {
+      return;
+    }
+    this.firstRun = true;
+    this.findAdapterType();
+  }
+
   private async findAdapterType() {
     const adapterTypeCommand = this.dbtCloudCommand(
       new DBTCommand("Getting adapter type...", [
@@ -1062,6 +1071,11 @@ export class DBTCloudProjectIntegration
         true,
         error,
       );
+    }
+    if (!this.adapterType) {
+      setTimeout(() => {
+        this.retryOnce();
+      }, 5000);
     }
   }
 


### PR DESCRIPTION
## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds retry mechanism in `DBTCloudProjectIntegration` to handle unknown adapter types by retrying adapter type detection once.
> 
>   - **Behavior**:
>     - Adds `retryOnce()` method in `DBTCloudProjectIntegration` to retry fetching adapter type if unknown.
>     - Modifies `findAdapterType()` to call `retryOnce()` if `adapterType` is not set.
>   - **State Management**:
>     - Introduces `firstRun` boolean to ensure `retryOnce()` is only executed once.
>   - **Telemetry**:
>     - Logs elapsed time for `findAdapterType()` and `retryOnce()` in `DBTCloudProjectIntegration`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for fdfa089c57da5bcbac5990bf57ce6d343e1608c7. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved adapter type detection with a retry mechanism for enhanced reliability.
	- Enhanced error handling for diagnostics reporting and telemetry tracking during adapter type detection.
- **Bug Fixes**
	- Added robust authentication checks and error handling throughout the integration process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->