### PR TITLE
fix: datapilot code block ui

### DIFF
--- a/webview_panels/src/modules/dataPilot/components/queryAnalysis/QueryAnalysis.tsx
+++ b/webview_panels/src/modules/dataPilot/components/queryAnalysis/QueryAnalysis.tsx
@@ -10,6 +10,7 @@ import { QueryAnalysisCommands } from "./commands";
 import { AltimateIcon } from "@assets/icons";
 import { QueryAnalysisType } from "./types";
 import { useMemo } from "react";
+import classes from "../../datapilot.module.scss";
 
 const QUERY_HAPPY_LIMIT = 10;
 const DefaultActions = [
@@ -52,7 +53,7 @@ const QueryAnalysis = (): JSX.Element | null => {
     <Stack direction="column">
       <DatapilotHeader />
 
-      <CodeBlock code={chat.query} language="sql" fileName={chat.fileName} />
+      <CodeBlock code={chat.query} language="sql" fileName={chat.fileName} classname={classes.codeblock}/>
       {showLineLimitWarning ? (
         <Card>
           <CardTitle>

--- a/webview_panels/src/modules/dataPilot/datapilot.module.scss
+++ b/webview_panels/src/modules/dataPilot/datapilot.module.scss
@@ -153,3 +153,7 @@ body {
     }}
   }
 }
+
+.codeblock{
+  --code-bg: transparent;
+}

--- a/webview_panels/src/uiCore/components/codeblock/index.tsx
+++ b/webview_panels/src/uiCore/components/codeblock/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   fileName?: string;
   showLineNumbers?: boolean;
   titleActions?: ReactNode;
+  classname?: string;
 }
 const CodeBlockComponent = ({
   code,
@@ -17,11 +18,13 @@ const CodeBlockComponent = ({
   fileName,
   showLineNumbers,
   titleActions,
+  classname
 }: Props): JSX.Element => {
   const {
     state: { theme },
   } = useAppContext();
   const codeBlockTheme = theme === Themes.Dark ? "dark" : "light";
+  const editorTheme = theme === Themes.Dark ? "vsc-dark-plus" : "vs";
   return (
     <div className={classes.codeblock}>
       <CodeblockLib
@@ -29,8 +32,10 @@ const CodeBlockComponent = ({
         code={code}
         fileName={fileName}
         theme={codeBlockTheme}
+        editorTheme={editorTheme}
         language={language}
         titleActions={titleActions}
+        className={classname}
       />
     </div>
   );


### PR DESCRIPTION
## Overview

### Problem
In datapilot, codeblock UI is broken

### Solution
Fix the codeblock with right css and theme

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test
- Open a dbt model
- right click -> datapilot -> change
- codeblock should be having right UI

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes DataPilot code block UI by adding a `classname` prop to `CodeBlockComponent` and updating styles in `datapilot.module.scss`.
> 
>   - **UI Fix**:
>     - Add `classname` prop to `CodeBlockComponent` in `index.tsx` to allow custom styling.
>     - Update `QueryAnalysis.tsx` to pass `classname` from `datapilot.module.scss` to `CodeBlock`.
>     - Define `.codeblock` class in `datapilot.module.scss` to set `--code-bg` to `transparent`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 49403e93bc56a9e31a12038b58b15178556c6cc4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `CodeBlock` component with customizable styling through a new `classname` prop.
	- Introduced theme-based styling for the `CodeBlock` component.

- **Style**
	- Added a new CSS class `.codeblock` for improved styling options, setting the background to transparent. 

These updates improve the visual flexibility and customization options for users interacting with the `QueryAnalysis` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->