### PR TITLE
set fixed telemetry version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.45.3",
+  "version": "0.47.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.45.3",
+      "version": "0.47.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -15,7 +15,7 @@
         "@jupyterlab/services": "^6.6.7",
         "@nteract/messaging": "^7.0.20",
         "@vscode/codicons": "^0.0.36",
-        "@vscode/extension-telemetry": "^0.9.6",
+        "@vscode/extension-telemetry": "0.9.6",
         "@vscode/vsce": "^2.31.1",
         "@vscode/webview-ui-toolkit": "^1.4.0",
         "dayjs": "^1.11.13",
@@ -1572,14 +1572,13 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/extension-telemetry": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.7.tgz",
-      "integrity": "sha512-2GQbcfDUTg0QC1v0HefkHNwYrE5LYKzS3Zb0+uA6Qn1MBDzgiSh23ddOZF/JRqhqBFOG0mE70XslKSGQ5v9KwQ==",
-      "license": "MIT",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.6.tgz",
+      "integrity": "sha512-qWK2GNw+b69QRYpjuNM9g3JKToMICoNIdc0rQMtvb4gIG9vKKCZCVCz+ZOx6XM/YlfWAyuPiyxcjIY0xyF+Djg==",
       "dependencies": {
-        "@microsoft/1ds-core-js": "^4.3.0",
-        "@microsoft/1ds-post-js": "^4.3.0",
-        "@microsoft/applicationinsights-web-basic": "^3.3.0"
+        "@microsoft/1ds-core-js": "^4.1.2",
+        "@microsoft/1ds-post-js": "^4.1.2",
+        "@microsoft/applicationinsights-web-basic": "^3.1.2"
       },
       "engines": {
         "vscode": "^1.75.0"

--- a/package.json
+++ b/package.json
@@ -1253,7 +1253,7 @@
     "@jupyterlab/services": "^6.6.7",
     "@nteract/messaging": "^7.0.20",
     "@vscode/codicons": "^0.0.36",
-    "@vscode/extension-telemetry": "^0.9.6",
+    "@vscode/extension-telemetry": "0.9.6",
     "@vscode/vsce": "^2.31.1",
     "@vscode/webview-ui-toolkit": "^1.4.0",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `@vscode/extension-telemetry` version to `0.9.6` in `package.json` for fixed version usage.
> 
>   - **Dependencies**:
>     - Set `@vscode/extension-telemetry` version to `0.9.6` in `package.json` to ensure a fixed version is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for f24f9cf4b17ab772e806b8b0fa5693d7cbb98993. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `@vscode/extension-telemetry` dependency for improved stability. 
	- Maintained the overall structure of the `package.json` without introducing new features or functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->