### PR TITLE
fix: enable teammates in vscode by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
           "dbt.enableTeammates": {
             "type": "boolean",
             "description": "Enable AltimateAI teammates feature.",
-            "default": false
+            "default": true
           },
           "dbt.disableQueryHistory": {
             "type": "boolean",


### PR DESCRIPTION
## Overview

### Problem
No need for teammates feature flag in vscode as it is already available in saas

### Solution
Make teammates enabled by default in vscode

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable teammates feature by default in VSCode by setting `dbt.enableTeammates` to `true` in `package.json`.
> 
>   - **Behavior**:
>     - Change `dbt.enableTeammates` default to `true` in `package.json`, enabling teammates by default in VSCode.
>   - **Misc**:
>     - No additional settings or configurations are added or removed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for da867c7b271242ac47de4c09de6bd1b59e2d0161. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The AltimateAI teammates feature is now enabled by default, enhancing collaboration capabilities for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->