### PR TITLE
chore: send slack notification for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,13 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Send Slack notification
-        if: ${{ always() && (failure() || cancelled()) }}
+        if: ${{ always() }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          text: "Release to vsstudio-marketplace: ${{ job.status == 'success' && 'succeeded' || 'failed' }} :${{ job.status == 'success' && 'tada' || 'disappointed' }}:"
+          text: "Tag: ${{  github.ref_name }} release to Visual Studio Marketplace status: ${{ job.status == 'success' && 'succeeded' || 'failed' }} :${{ job.status == 'success' && 'tada' || 'disappointed' }}:"
   
   release-openvsx-marketplace:
     runs-on: ubuntu-latest
@@ -66,11 +66,11 @@ jobs:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
       - name: Send Slack notification
-        if: ${{ always() && (failure() || cancelled()) }}
+        if: ${{ always() }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          text: "Release to openvsx-marketplace: ${{ job.status == 'success' && 'succeeded' || 'failed' }} :${{ job.status == 'success' && 'tada' || 'disappointed' }}:"
+          text: "Tag: ${{  github.ref_name }} release to openvsx marketplace status: ${{ job.status == 'success' && 'succeeded' || 'failed' }} :${{ job.status == 'success' && 'tada' || 'disappointed' }}:"
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,16 @@ jobs:
           fi
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Send Slack notification
+        if: ${{ always() && (failure() || cancelled()) }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          text: "Release to vsstudio-marketplace: ${{ job.status == 'success' && 'succeeded' || 'failed' }} :${{ job.status == 'success' && 'tada' || 'disappointed' }}:"
+  
   release-openvsx-marketplace:
     runs-on: ubuntu-latest
     if: success() && startsWith( github.ref, 'refs/tags/')
@@ -54,3 +64,13 @@ jobs:
           fi
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
+
+      - name: Send Slack notification
+        if: ${{ always() && (failure() || cancelled()) }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          text: "Release to openvsx-marketplace: ${{ job.status == 'success' && 'succeeded' || 'failed' }} :${{ job.status == 'success' && 'tada' || 'disappointed' }}:"
+  


### PR DESCRIPTION
## Overview

### Problem
Release failures are not reported

### Solution
Send slack notification about release status
Sends separate message for each platform release. If needed we can optimize this.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Slack notifications for release job failures and cancellations in `ci.yml`.
> 
>   - **Behavior**:
>     - Adds Slack notifications for release jobs in `ci.yml`.
>     - Notifications trigger on job failure or cancellation using `8398a7/action-slack@v3`.
>     - Sends status and emoji based on success or failure.
>   - **Jobs**:
>     - `release-vsstudio-marketplace` and `release-openvsx-marketplace` now include Slack notification steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 9701fee6de555e7d8cba4a05b6087eebeb209a98. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced Slack notifications for release processes, providing real-time updates on job outcomes (success, failure, or cancellation) for better visibility.
- **Enhancements**
	- Improved feedback mechanism for release jobs in the CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->