### PR TITLE
fix: show error on failure while getting distinct column values

### DIFF
--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -827,6 +827,7 @@ export class DBTProject implements Disposable {
         error,
         { column, model },
       );
+      throw error;
     }
   }
 

--- a/src/webview_provider/altimateWebviewProvider.ts
+++ b/src/webview_provider/altimateWebviewProvider.ts
@@ -135,6 +135,7 @@ export class AltimateWebviewProvider implements WebviewViewProvider {
       this.sendResponseToWebview({
         command: "response",
         syncRequestId,
+        status: true,
         data: response,
       });
     } catch (error) {
@@ -154,6 +155,7 @@ export class AltimateWebviewProvider implements WebviewViewProvider {
         command: "response",
         syncRequestId,
         error: message,
+        status: false,
       });
     }
   }

--- a/webview_panels/src/modules/documentationEditor/components/tests/forms/AcceptedValues.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/tests/forms/AcceptedValues.tsx
@@ -4,6 +4,7 @@ import { LoadingButton, OptionType, Select, Stack } from "@uicore";
 import { useEffect, useState } from "react";
 import { Control, Controller, UseFormSetValue } from "react-hook-form";
 import { SaveRequest } from "../types";
+import { panelLogger } from "@modules/logger";
 
 interface Props {
   control: Control<SaveRequest, unknown>;
@@ -24,23 +25,28 @@ const AcceptedValues = ({
   const [isLoading, setIsLoading] = useState(false);
   const getDistinctColumnValues = async () => {
     setIsLoading(true);
-    const result = (await executeRequestInSync("getDistinctColumnValues", {
-      model: currentDocsData?.name,
-      column,
-    })) as string[] | undefined;
-    setIsLoading(false);
+    try {
+      const result = (await executeRequestInSync("getDistinctColumnValues", {
+        model: currentDocsData?.name,
+        column,
+      })) as string[] | undefined;
 
-    if (result?.length && values?.length) {
-      const items = ["Yes, overwrite", "Cancel"];
-      const response = await executeRequestInSync("showInformationMessage", {
-        infoMessage: "Overwrite the existing values?",
-        items,
-      });
-      if (response !== items[0]) {
-        return;
+      if (result?.length && values?.length) {
+        const items = ["Yes, overwrite", "Cancel"];
+        const response = await executeRequestInSync("showInformationMessage", {
+          infoMessage: "Overwrite the existing values?",
+          items,
+        });
+        if (response !== items[0]) {
+          return;
+        }
       }
+      setValue("accepted_values", result);
+    } catch (e) {
+      panelLogger.error("Unable to get distinct values", e);
+    } finally {
+      setIsLoading(false);
     }
-    setValue("accepted_values", result);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Overview

### Problem
When getting distinct column values for adding accepted_values test, if there is an error, it is not shown to user.

### Solution
Show error message on failure

### Screenshot/Demo
![image](https://github.com/user-attachments/assets/9d00cfb9-259f-4a3a-8664-e646f352a3ca)


### How to test

- Open a dbt cloud project which could throw error while getting distinct column values from db
- Try to add accepted_values test and click get distinct column values
- If any error happens, error should be shown

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
