### PR TITLE
fix: artifact upload version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,14 +47,14 @@ jobs:
         npm run compile && npm run test:coverage
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-results-${{ matrix.os }}
         path: test-results/
 
     - name: Upload coverage results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ matrix.os }}
         path: |


### PR DESCRIPTION
## Overview

### Problem
Unit tests are failing, because of deprecated upload-artifact package

### Solution
Update package version

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `actions/upload-artifact` to v4 in `tests.yml` to fix unit test failures due to deprecation.
> 
>   - **GitHub Actions**:
>     - Update `actions/upload-artifact` from v3 to v4 in `tests.yml` for test results and coverage results upload steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 1c0e62d7c8101554656f4638edd1aea3b87353fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use the latest version of `actions/upload-artifact` action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->