### PR TITLE
fix: resolve to DBT_PROFILES_DIR if specified without joining with project_dir

### DIFF
--- a/dbt_core_integration.py
+++ b/dbt_core_integration.py
@@ -217,7 +217,7 @@ def default_profiles_dir(project_dir):
         profiles_dir = os.path.expanduser(os.environ["DBT_PROFILES_DIR"])
         if os.path.isabs(profiles_dir):
             return os.path.normpath(profiles_dir)
-        return os.path.normpath(os.path.join(project_dir, profiles_dir))
+        return os.path.normpath(os.path.join(profiles_dir))
     project_profiles_file = os.path.normpath(os.path.join(project_dir, "profiles.yml"))
     return (
         project_dir


### PR DESCRIPTION
## Overview

### Problem

see https://github.com/AltimateAI/vscode-dbt-power-user/issues/1554#issuecomment-2638276756

Closes #1554

### Solution

Removing the unnecessary path join

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
