### PR TITLE
feat: allow to specify dbt projects directly and skip discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -283,6 +283,14 @@
                 }
               }
             }
+          },
+          "dbt.specifiedProjects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "description": "Specify dbt project paths to override the discovered projects."
           }
         }
       }

--- a/src/dbt_client/dbtCloudIntegration.ts
+++ b/src/dbt_client/dbtCloudIntegration.ts
@@ -150,6 +150,14 @@ export class DBTCloudProjectDetection
 
   async discoverProjects(projectDirectories: Uri[]): Promise<Uri[]> {
     this.altimate.handlePreviewFeatures();
+    const specifiedProjects = workspace
+      .getConfiguration("dbt")
+      .get<string[]>("specifiedProjects", []);
+
+    if (specifiedProjects.length > 0) {
+      return specifiedProjects.map((projectPath) => Uri.file(projectPath));
+    }
+
     const packagesInstallPaths = projectDirectories.map((projectDirectory) =>
       path.join(projectDirectory.fsPath, "dbt_packages"),
     );

--- a/src/dbt_client/dbtCoreIntegration.ts
+++ b/src/dbt_client/dbtCoreIntegration.ts
@@ -175,6 +175,14 @@ export class DBTCoreProjectDetection
   }
 
   async discoverProjects(projectDirectories: Uri[]): Promise<Uri[]> {
+    const specifiedProjects = workspace
+      .getConfiguration("dbt")
+      .get<string[]>("specifiedProjects", []);
+
+    if (specifiedProjects.length > 0) {
+      return specifiedProjects.map((projectPath) => Uri.file(projectPath));
+    }
+
     let packagesInstallPaths = projectDirectories.map((projectDirectory) =>
       path.join(projectDirectory.fsPath, "dbt_packages"),
     );


### PR DESCRIPTION
## Overview

this allows to skip the project discovery as it often fails to discover projects

### Problem

the extension often didn't discover our projects and returned an empty list.

### Solution

allow to specify the dbt projects manually through a setting `dbt.specifiedProjects`

### How to test

- Add dbt project paths to  `dbt.specifiedProjects` in settings.json
- Restart extension and it should pickup the project without using discovery

## Checklist

- [X] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
