### PR TITLE
chore: remove feature flag for mcp server

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,11 +107,6 @@
             "description": "Flag to identify if onboarding is done for MCP server",
             "default": false
           },
-          "dbt.enableMcpServer": {
-            "type": "boolean",
-            "description": "Enable MCP server feature for Cursor IDE",
-            "default": false
-          },
           "dbt.enableMcpDataSourceQueryTools": {
             "type": "boolean",
             "description": "Enable data source query tools (EXECUTE_SQL_WITH_LIMIT and GET_COLUMN_VALUES)",

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -42,16 +42,6 @@ export class DbtPowerUserMcpServer implements Disposable {
 
   private async startOnboarding() {
     this.dbtTerminal.info("DbtPowerUserMcpServer", "Starting onboarding");
-    const enableMcpServer = workspace
-      .getConfiguration("dbt")
-      .get<boolean>("enableMcpServer", false);
-    if (!enableMcpServer) {
-      this.dbtTerminal.info(
-        "DbtPowerUserMcpServer",
-        "MCP server is not enabled",
-      );
-      return;
-    }
 
     const onboardedMcpServer = workspace
       .getConfiguration("dbt")


### PR DESCRIPTION
## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `dbt.enableMcpServer` feature flag, simplifying MCP server onboarding logic in `index.ts`.
> 
>   - **Configuration**:
>     - Removed `dbt.enableMcpServer` feature flag from `package.json`.
>   - **Logic**:
>     - Removed check for `enableMcpServer` in `startOnboarding()` in `index.ts`.
>     - Simplified onboarding logic by assuming MCP server is always enabled if `onboardedMcpServer` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 8182e929556b9f83a46be9f3694946b25d6afdfb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an obsolete configuration option no longer required for the current version.
- **Refactor**
  - Streamlined the onboarding process by eliminating an unnecessary activation check, ensuring a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->