### PR TITLE
Feat retry find files if nothing is returned

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -466,7 +466,7 @@ export function getCurrentlySelectedModelNameInYamlConfig(): string {
 }
 
 export async function retryWithBackoff<T>(
-  fn: () => Promise<T>,
+  fn: () => Thenable<T>,
   retries: number = 5,
   backoff: number = 1000,
 ): Promise<T> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -464,3 +464,27 @@ export function getCurrentlySelectedModelNameInYamlConfig(): string {
   }
   return "";
 }
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  retries: number = 5,
+  backoff: number = 1000,
+): Promise<T> {
+  let attempt = 0;
+  while (attempt < retries) {
+    try {
+      const result = await fn();
+      if (Array.isArray(result) && result.length === 0) {
+        throw new Error("Empty array returned");
+      }
+      return result;
+    } catch (error) {
+      attempt++;
+      if (attempt >= retries) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, backoff * attempt));
+    }
+  }
+  throw new Error("Failed after maximum retries");
+}


### PR DESCRIPTION
## Overview

this allows to skip the project discovery as it often fails to discover projects

### Problem

the extension often didn't discover our projects and returned an empty list. this is basically due to a bug in vscode workspace.findFiles (https://github.com/microsoft/vscode/issues/179203)

fixes #1437

### Solution

this forces to retry the workspace.findFiles request for up to 5 times with a backoff time increase of 1 second if no files are found.

### How to test

- if you encounter the mentioned vscode issue above you should now have much more reliable project detections. i used this in prod and so far it seems to find the projects now.

## Checklist

- [X] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change