### PR TITLE
chore: add ide name in telemetry

### DIFF
--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -5,6 +5,6 @@ export const findAvailablePort = async (): Promise<number> => {
   return await portfinder.getPortPromise({ port: 7700, stopPort: 7900 });
 };
 
-export const isCursor = () => {
+export const isCursor = (): boolean => {
   return env.appName === "Cursor";
 };

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -1,11 +1,10 @@
 import portfinder from "portfinder";
+import { env } from "vscode";
 
 export const findAvailablePort = async (): Promise<number> => {
   return await portfinder.getPortPromise({ port: 7700, stopPort: 7900 });
 };
 
 export const isCursor = () => {
-  return (
-    process.env.VSCODE_CWD?.includes("Cursor") || !!process.env.CURSOR_TRACE_ID
-  );
+  return env.appName === "Cursor";
 };

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -10,6 +10,10 @@ export class TelemetryService implements vscode.Disposable {
   );
   private eventMeasurements = new Map();
 
+  constructor() {
+    this.customAttributes["ide"] = vscode.env.appName;
+  }
+
   setTelemetryCustomAttribute(key: string, value: string) {
     this.customAttributes[key] = value;
   }


### PR DESCRIPTION
## Overview

### Problem
Ide name is not available in telemetry to figure out usage based on ide

### Solution
Add `ide` attribute to telemetry events

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ide` attribute to telemetry events and update `isCursor()` to use `vscode.env.appName`.
> 
>   - **Telemetry**:
>     - Add `ide` attribute to telemetry events in `TelemetryService` constructor using `vscode.env.appName`.
>   - **Utils**:
>     - Update `isCursor()` in `utils.ts` to use `vscode.env.appName` for IDE check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for dcbd2c3691cab35f42760cb65285966eaa96efed. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the application's environment verification process.
- **New Features**
  - Enhanced telemetry to automatically capture the IDE context for improved tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->