### PR TITLE
fix: skip chat participant init for cursor in mcp server

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -290,7 +290,12 @@ export class DbtPowerUserMcpServer implements Disposable {
           isHttps,
         },
       );
-      this.dbtChatParticipant.initializeChatParticipant(this.getMcpServerUrl());
+      if (!isCursor()) {
+        // This should only be called in vscode
+        this.dbtChatParticipant.initializeChatParticipant(
+          this.getMcpServerUrl(),
+        );
+      }
     });
 
     return port;


### PR DESCRIPTION
## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Conditionally initialize `dbtChatParticipant` in `DbtPowerUserMcpServer` based on `isCursor()` check in `index.ts`.
> 
>   - **Behavior**:
>     - In `DbtPowerUserMcpServer` class, `initializeChatParticipant()` is now conditionally called based on `isCursor()` check.
>     - If `isCursor()` returns false, `initializeChatParticipant()` is called with `getMcpServerUrl()`.
>   - **Files**:
>     - Changes made in `index.ts` to implement the conditional check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 1f4dc820802c15c024c8c5beee1d666042d68bad. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the chat initialization so it activates only in the supported environment, ensuring the feature works correctly when using Visual Studio Code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->