### PR TITLE
fix: allow saving custom queries in specific location

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -624,10 +624,18 @@ export class VSCodeCommands implements Disposable {
               return;
             }
 
-            const fileNamePrefix = fileName || "poweruser";
-            const uri = Uri.parse(
-              `${project.projectRoot}/${fileNamePrefix}-${getFormattedDateTime()}.sql`,
-            ).with({ scheme: "untitled" });
+            // Open a new untitled sql file by default
+            let docOpenPromise = workspace.openTextDocument({
+              language: "jinja-sql",
+            });
+            // If file name is provided, open the file in the project
+            if (fileName) {
+              const uri = Uri.parse(
+                `${project.projectRoot}/${fileName}-${getFormattedDateTime()}.sql`,
+              ).with({ scheme: "untitled" });
+              docOpenPromise = workspace.openTextDocument(uri);
+            }
+
             const annotationDecoration: TextEditorDecorationType =
               window.createTextEditorDecorationType({
                 rangeBehavior: DecorationRangeBehavior.OpenOpen,
@@ -650,7 +658,7 @@ export class VSCodeCommands implements Disposable {
               },
             ];
 
-            workspace.openTextDocument(uri).then((doc) => {
+            docOpenPromise.then((doc) => {
               // set this to sql language so we can bind codelens and other features
               languages.setTextDocumentLanguage(doc, "jinja-sql");
               window.showTextDocument(doc).then((editor) => {

--- a/src/manifest/dbtProjectContainer.ts
+++ b/src/manifest/dbtProjectContainer.ts
@@ -269,6 +269,14 @@ export class DBTProjectContainer implements Disposable {
   }
 
   executeSQL(uri: Uri, query: string, modelName: string): void {
+    if (uri.scheme === "untitled") {
+      const selectedProject = this.getFromWorkspaceState(
+        "dbtPowerUser.projectSelected",
+      );
+      if (selectedProject) {
+        uri = selectedProject.uri;
+      }
+    }
     this.findDBTProject(uri)?.executeSQL(query, modelName);
   }
 

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -429,9 +429,7 @@ export class QueryResultPanel extends AltimateWebviewProvider {
             );
             break;
           case InboundCommand.RunAdhocQuery:
-            commands.executeCommand("dbtPowerUser.createSqlFile", {
-              fileName: "Custom Query",
-            });
+            commands.executeCommand("dbtPowerUser.createSqlFile", {});
             break;
           case InboundCommand.ExecuteQueryFromActiveWindow:
             await this.executeQueryFromActiveWindow(message);

--- a/webview_panels/src/modules/queryPanel/components/runAdhocQueryButton/RunAdhocQueryButton.tsx
+++ b/webview_panels/src/modules/queryPanel/components/runAdhocQueryButton/RunAdhocQueryButton.tsx
@@ -7,7 +7,12 @@ const RunAdhocQueryButton = (): JSX.Element => {
     executeRequestInAsync("runAdhocQuery", {});
   };
   return (
-    <Button outline onClick={handleClick} icon={<AddIcon />}>
+    <Button
+      aria-label="open-adhoc-query"
+      outline
+      onClick={handleClick}
+      icon={<AddIcon />}
+    >
       New query
     </Button>
   );


### PR DESCRIPTION
## Overview

### Problem
New query triggered from query results panel is getting saved in root of the project. Unable to save in desired location

### Solution
- using vscode extension api, open the new query as untitled file, so when user wants to save, it will show save dialog for selecting directory

Resolves: https://github.com/AltimateAI/vscode-dbt-power-user/issues/1625

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR modifies the behavior of new query creation to open as untitled files, allowing users to select the save location, and updates related commands and UI components.
> 
>   - **Behavior**:
>     - New queries are opened as untitled files using VSCode API in `VSCodeCommands` in `index.ts`, allowing users to choose save location.
>     - `executeSQL()` in `dbtProjectContainer.ts` now uses selected project URI for untitled files.
>     - `RunAdhocQueryButton.tsx` updated to trigger `runAdhocQuery` command without preset file name.
>   - **Commands**:
>     - `createSqlFile` command in `index.ts` modified to open untitled SQL files by default.
>     - `RunAdhocQuery` command in `queryResultPanel.ts` now calls `createSqlFile` without a file name.
>   - **Misc**:
>     - Minor UI update in `RunAdhocQueryButton.tsx` to include `aria-label` for accessibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for a06519d41c15d2e0d9223affe58bdad9cc7eccf2. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced SQL file creation: Untitled SQL documents now open with improved language support.
	- Improved SQL execution: Queries run within the context of your selected project when using untitled files.
	- Updated ad hoc query handling: SQL files are created without a preset name, offering a more flexible workflow.
	- Improved accessibility: Added an `aria-label` to the Run Adhoc Query button for better screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->