### PR TITLE
fix: fixed an issues where parsed numbers were wrongly being identifi…

### DIFF
--- a/webview_panels/src/modules/queryPanel/components/perspective/PerspectivePlugins.ts
+++ b/webview_panels/src/modules/queryPanel/components/perspective/PerspectivePlugins.ts
@@ -19,9 +19,9 @@ function dispatchCustomEvent(
 // Checks if the given string is a valid JSON
 const isJson = (str: string) => {
   try {
-    const parsedAsssumingJson: unknown = JSON.parse(str);
+    const parsedAssumingJson: unknown = JSON.parse(str);
     return (
-      typeof parsedAsssumingJson === "object" && parsedAsssumingJson !== null
+      typeof parsedAssumingJson === "object" && parsedAssumingJson !== null
     );
   } catch (e) {
     return false;

--- a/webview_panels/src/modules/queryPanel/components/perspective/PerspectivePlugins.ts
+++ b/webview_panels/src/modules/queryPanel/components/perspective/PerspectivePlugins.ts
@@ -19,11 +19,13 @@ function dispatchCustomEvent(
 // Checks if the given string is a valid JSON
 const isJson = (str: string) => {
   try {
-    JSON.parse(str);
+    const parsedAsssumingJson: unknown = JSON.parse(str);
+    return (
+      typeof parsedAsssumingJson === "object" && parsedAsssumingJson !== null
+    );
   } catch (e) {
     return false;
   }
-  return true;
 };
 
 // Appends an image to the td element


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixed an issue in the Perspective plugin where numeric values were incorrectly identified as JSON, causing truncation when parsing JSON in the dbt Power User VS Code extension.

- Modified the `isJson()` function in `webview_panels/src/modules/queryPanel/components/perspective/PerspectivePlugins.ts` to check that parsed JSON is an object type, not just any valid JSON-parseable value.
- Added type checking to ensure only actual JSON objects trigger the JSON viewer, preventing numbers and other primitives from being treated as JSON.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

…ed as JSON, leading to truncation when parsing JSON

## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON validation to ensure only non-null objects are accepted, preventing primitives like strings, numbers, booleans, or null from being incorrectly treated as valid JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes JSON parsing issue in `PerspectivePlugins.ts` by ensuring only objects are treated as valid JSON, preventing misidentification of primitives.
> 
>   - **Bug Fix**:
>     - Updated `isJson()` in `PerspectivePlugins.ts` to validate JSON as non-null objects only, preventing primitives from being misidentified as JSON.
>     - Ensures only objects trigger JSON viewer, fixing truncation issue in dbt Power User VS Code extension.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 4c2266177eaf7aee2df8a74cfe52d8c0e0bc7ba0. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->