### PR TITLE
Fix builtin name clash in validate_sql

### DIFF
--- a/altimate_packages/altimate/validate_sql.py
+++ b/altimate_packages/altimate/validate_sql.py
@@ -53,13 +53,13 @@ def _build_schemas(
 def _build_model_mapping(
     models: List[Dict],
 ):
-    map = {}
+    model_map = {}
     for model in models:
         db = model["database"]
         schema = model["schema"]
         table = model["alias"]
-        map[f"{db}.{schema}.{table}".lower()] = model["name"]
-    return map
+        model_map[f"{db}.{schema}.{table}".lower()] = model["name"]
+    return model_map
 
 
 def validate_sql_from_models(


### PR DESCRIPTION
## Summary
- avoid shadowing Python builtin `map`

## Testing
- `npm test` *(fails: rimraf not found)*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename variable `map` to `model_map` in `_build_model_mapping()` to avoid shadowing Python built-in.
> 
>   - **Refactor**:
>     - Rename variable `map` to `model_map` in `_build_model_mapping()` in `validate_sql.py` to avoid shadowing the Python built-in `map`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 6a6afad974fb1599dca52b08db81e692d47d73ac. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved variable naming for better code clarity. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->