### PR TITLE
Fix substring helper return value

### DIFF
--- a/altimate_packages/altimate/utils.py
+++ b/altimate_packages/altimate/utils.py
@@ -56,7 +56,8 @@ def find_single_occurrence_indices(main_string, substring):
     substring = substring.lower() if substring else ""
 
     if not substring:
-        return None, None
+        # return consistent tuple when substring is empty
+        return None, None, 0
 
     num_occurrences = main_string.count(substring)
     # Check if the substring occurs only once in the main string


### PR DESCRIPTION
## Summary
- ensure `find_single_occurrence_indices` always returns three values

## Testing
- `npm test` *(fails: `rimraf: not found`)*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `find_single_occurrence_indices` in `utils.py` always returns a tuple of three values.
> 
>   - **Behavior**:
>     - `find_single_occurrence_indices` in `utils.py` now returns `(None, None, 0)` when `substring` is empty, ensuring a consistent return tuple of three values.
>   - **Testing**:
>     - `npm test` fails due to `rimraf: not found`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for d2f34f6602af41c78df97eb69011ed7e63900d26. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->