### PR TITLE
Fix favor_state not used when merging manifest

### DIFF
--- a/dbt_core_integration.py
+++ b/dbt_core_integration.py
@@ -548,6 +548,7 @@ class DbtProject:
                     manifest = Manifest.from_writable_manifest(writable_manifest)
                     self.dbt.merge_from_artifact(
                         other=manifest,
+                        favor_state=self.favor_state,
                     )
                 else:
                     with open(self.defer_to_prod_manifest_path) as f:


### PR DESCRIPTION
## Summary
- ensure favor_state option is respected when merging production manifest during defer

## Testing
- `npm test` *(fails: rimraf not found)*
- `npm ci` *(fails: npm fetch EHOSTUNREACH)*
