### PR TITLE
fix: return default doc structure when model not found

### DIFF
--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -96,7 +96,13 @@ export class DocGenService {
     const { event } = eventResult;
     const currentNode = event.nodeMetaMap.lookupByBaseName(modelName);
     if (!currentNode?.patch_path) {
-      return undefined;
+      return {
+        aiEnabled: this.altimateRequest.enabled(),
+        name: modelName,
+        description: "",
+        generated: false,
+        columns: [],
+      } as DBTDocumentation;
     }
 
     try {
@@ -111,7 +117,13 @@ export class DocGenService {
       // Find matching model definition
       const modelDef = parsedDoc.models?.find((m) => m.name === modelName);
       if (!modelDef) {
-        return undefined;
+        return {
+          aiEnabled: this.altimateRequest.enabled(),
+          name: modelName,
+          description: "",
+          generated: false,
+          columns: [],
+        } as DBTDocumentation;
       }
 
       // Map to DBTDocumentation format


### PR DESCRIPTION
## Overview

### Problem

Fixes #1700

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `getDocumentationFromYaml()` in `docGenService.ts` now returns a default documentation structure when a model is not found.
> 
>   - **Behavior**:
>     - In `docGenService.ts`, `getDocumentationFromYaml()` now returns a default `DBTDocumentation` structure when a model is not found, instead of `undefined`.
>     - Default structure includes `aiEnabled`, `name`, `description`, `generated`, and `columns` fields.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 8d85a6d749054024cae5dbbb31871cc956f705a7. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency by ensuring that documentation retrieval always returns a default documentation object when information is missing, instead of returning nothing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->