### PR TITLE
fix: include exposures in children parent meta map creation

### DIFF
--- a/src/manifest/parsers/childrenParentParser.ts
+++ b/src/manifest/parsers/childrenParentParser.ts
@@ -7,7 +7,7 @@ export class ChildrenParentParser {
   constructor(private terminal: DBTTerminal) {}
 
   createChildrenParentMetaMap(
-    nodesMap: any[],
+    nodesMap: Record<string, any>,
   ): Promise<{ parentMetaMap: DBTGraphType; childMetaMap: DBTGraphType }> {
     const parentMetaMap: DBTGraphType = {};
     const childMetaMap: DBTGraphType = {};

--- a/src/manifest/parsers/index.ts
+++ b/src/manifest/parsers/index.ts
@@ -85,7 +85,10 @@ export class ManifestParser {
       manifest;
 
     const parentChildrenPromise =
-      this.childrenParentParser.createChildrenParentMetaMap(nodes);
+      this.childrenParentParser.createChildrenParentMetaMap({
+        ...nodes,
+        ...exposures,
+      });
 
     const nodeMetaMapPromise = this.nodeParser.createNodeMetaMap(
       nodes,


### PR DESCRIPTION
## Overview

### Problem

Fixes #1707 

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Include `exposures` in `createChildrenParentMetaMap` to improve children-parent metadata mapping in `ManifestParser`.
> 
>   - **Bug Fixes**:
>     - Include `exposures` in `createChildrenParentMetaMap` in `ManifestParser` in `index.ts` to improve children-parent metadata mapping.
>     - Modify `createChildrenParentMetaMap` signature in `childrenParentParser.ts` to accept `Record<string, any>` for `nodesMap`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for fba2f849b0b23a3d335783d86414076966fbb5a7. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of the children-parent metadata mapping by including exposure entries along with nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->