### PR TITLE
fix: Run Test action now recognizes singular data tests (#1720)

### DIFF
--- a/src/commands/runModel.ts
+++ b/src/commands/runModel.ts
@@ -15,6 +15,15 @@ export class RunModel {
       return;
     }
     const fullPath = window.activeTextEditor.document.uri;
+    
+    // Check if the file is in the tests directory (singular test)
+    const relativePath = fullPath.fsPath;
+    if (relativePath.includes('/tests/') || relativePath.includes('\\tests\\')) {
+      // This is a singular test file, run it as a test instead of a model
+      this.runDBTModelTest(fullPath);
+      return;
+    }
+    
     this.runDBTModel(fullPath, type);
   }
 


### PR DESCRIPTION
When running "Run Test" command on a singular test file (SQL file in tests/ directory), the extension now correctly executes `dbt test` instead of `dbt run`.

The fix checks if the file path contains '/tests/' or '\tests\' and redirects to the test execution method instead of the model run method.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
