### PR TITLE
feat: Add dbt fusion integration option (#1712)

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,10 +109,11 @@
             "type": "string",
             "enum": [
               "core",
-              "cloud"
+              "cloud",
+              "fusion"
             ],
             "default": "core",
-            "description": "Select dbt core or dbt cloud"
+            "description": "Select dbt core, dbt cloud, or dbt fusion"
           },
           "dbt.dbtPythonPathOverride": {
             "type": "string",

--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -128,14 +128,19 @@ export class WalkthroughCommands {
   }
 
   async installDbt(): Promise<void> {
-    if (
-      workspace
-        .getConfiguration("dbt")
-        .get<string>("dbtIntegration", "core") === "cloud"
-    ) {
-      this.installDbtCloud();
-    } else {
-      this.installDbtCore();
+    const dbtIntegration = workspace
+      .getConfiguration("dbt")
+      .get<string>("dbtIntegration", "core");
+    
+    switch (dbtIntegration) {
+      case "cloud":
+      case "fusion":
+        // Fusion uses cloud CLI installation for now
+        this.installDbtCloud();
+        break;
+      default:
+        this.installDbtCore();
+        break;
     }
   }
 

--- a/src/dbt_client/index.ts
+++ b/src/dbt_client/index.ts
@@ -48,6 +48,8 @@ export class DBTClient implements Disposable {
 
     switch (this.dbtIntegrationMode) {
       case "cloud":
+      case "fusion":
+        // Fusion uses the same detection as cloud for now
         this.dbtDetection = this.dbtCloudDetection;
         break;
       default:

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -137,6 +137,8 @@ export class DBTProject implements Disposable {
 
     switch (dbtIntegrationMode) {
       case "cloud":
+      case "fusion":
+        // Fusion uses the same integration as cloud for now
         this.dbtProjectIntegration = this.dbtCloudIntegrationFactory(
           this.projectRoot,
         );

--- a/src/statusbar/versionStatusBar.ts
+++ b/src/statusbar/versionStatusBar.ts
@@ -45,7 +45,14 @@ export class VersionStatusBar implements Disposable {
     const dbtIntegrationMode = workspace
       .getConfiguration("dbt")
       .get<string>("dbtIntegration", "core");
-    return dbtIntegrationMode === "cloud" ? "dbt cloud" : "dbt core";
+    switch (dbtIntegrationMode) {
+      case "cloud":
+        return "dbt cloud";
+      case "fusion":
+        return "dbt fusion";
+      default:
+        return "dbt core";
+    }
   }
 
   private onRebuildManifestStatusChange(


### PR DESCRIPTION
Added support for "fusion" as a dbtIntegration option that uses the cloud CLI integration. This allows users with dbt fusion installed to select it as their integration type.
fix for #1712 
Changes:
- Added "fusion" to the dbtIntegration enum in package.json
- Updated DBTProject to use cloud integration for fusion mode
- Updated DBTClient detection to use cloud detection for fusion
- Updated status bar to display "dbt fusion" when fusion is selected
- Updated walkthrough commands to use cloud installation for fusion

The fusion integration reuses the existing cloud CLI infrastructure since dbt fusion is based on the cloud CLI architecture.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
