### PR TITLE
fix: return empty array instead of throwing error when dependency nod…

### DIFF
--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -1415,7 +1415,7 @@ export class DBTProject implements Disposable {
     const dependencyNodes = graphMetaMap[key];
     const dependencyNode = dependencyNodes.get(node.uniqueId);
     if (!dependencyNode) {
-      throw Error("graphMetaMap[" + key + "] has no entries for " + table);
+      return [];
     }
     const tables: Map<string, Table> = new Map();
     dependencyNode.nodes.forEach(({ url, key }) => {


### PR DESCRIPTION
…e not found

Replace error throw with graceful degradation in getConnectedTables when dependency node is missing from graphMetaMap. No callers handle this error, and MCP tools expect array return values.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `getConnectedTables()` in `DBTProject` now returns an empty array instead of throwing an error when a dependency node is missing.
> 
>   - **Behavior**:
>     - In `DBTProject` class, `getConnectedTables()` now returns an empty array instead of throwing an error when a dependency node is missing from `graphMetaMap`.
>     - This change ensures that no error is thrown when the node is not found, aligning with MCP tools' expectations of array return values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 035c21835645d9587391b067d64d53ac6cb7c510. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where viewing connected or related tables could fail if a dependency was missing. The view now returns no results instead of showing an error, improving stability during lineage/relationship exploration. Users will see a clear empty state instead of an exception. No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->