### PR TITLE
fix: redirect Cursor users to documentation instead of walkthrough

### DIFF
--- a/src/quickpick/puQuickPick.ts
+++ b/src/quickpick/puQuickPick.ts
@@ -9,6 +9,7 @@ import {
   workspace,
 } from "vscode";
 import { provideSingleton } from "../utils";
+import { isCursor } from "../mcp/utils";
 
 @provideSingleton(DbtPowerUserControlCenterAction)
 export class DbtPowerUserControlCenterAction {
@@ -30,12 +31,24 @@ export class DbtPowerUserControlCenterAction {
             "Switch between dbt core, cloud or fusion",
             "dbtPowerUser.switchDbtIntegration",
           ),
-          new DbtPowerUserControlPanelItem(
-            "Setup Extension",
-            "debug",
-            "Open the extension setup walkthrough",
-            "dbtPowerUser.openSetupWalkthrough",
-          ),
+          isCursor()
+            ? new DbtPowerUserControlPanelItem(
+                "Setup Guide",
+                "link-external",
+                "View the manual setup guide for Cursor IDE",
+                "vscode.open",
+                [
+                  Uri.parse(
+                    "https://docs.myaltimate.com/setup/reqdConfig/#manual-method-of-configuration",
+                  ),
+                ],
+              )
+            : new DbtPowerUserControlPanelItem(
+                "Setup Extension",
+                "debug",
+                "Open the extension setup walkthrough",
+                "dbtPowerUser.openSetupWalkthrough",
+              ),
           new DbtPowerUserControlPanelItem(
             "dbt Power User Tutorials",
             "book",


### PR DESCRIPTION
The Setup Extension action now detects when running in Cursor IDE and redirects users to the manual setup documentation instead of trying to open VSCode's walkthrough feature which is not available in Cursor.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
