### PR TITLE
fix: detect and use dbtf command for fusion integration

### DIFF
--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -225,6 +225,7 @@ container
         container.get(DeferToProdService),
         projectRoot,
         container.get(AltimateRequest),
+        container.get(CommandProcessExecutionFactory),
       );
     };
   });


### PR DESCRIPTION
- Update fusion detection to use 'dbtf --version' directly
- Set dbtPath to 'dbtf' in DBTFusionCommandProjectIntegration
- Remove unused getDBTPath import from fusion integration
- Ensure dbt cloud integration remains unaffected

This ensures that dbt-fusion installed as 'dbtf' is properly detected
and used for all fusion operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update dbt-fusion integration to detect and use 'dbtf' command, handling aliases and PATH resolution.
> 
>   - **Behavior**:
>     - Update `DBTFusionCommandDetection` in `dbtFusionCommandIntegration.ts` to use `dbtf --version` for detection.
>     - Set `dbtPath` to resolved `dbtf` path in `DBTFusionCommandProjectIntegration`.
>     - Ensure dbt cloud integration remains unaffected.
>   - **Functions**:
>     - Add `resolveDbtfAlias()` and `resolveDbtfPath()` in `dbtFusionCommandIntegration.ts` to handle command resolution.
>   - **Imports**:
>     - Remove unused `getDBTPath` import from `dbtFusionCommandIntegration.ts`.
>   - **Dependency Injection**:
>     - Update `inversify.config.ts` to inject `CommandProcessExecutionFactory` into `DBTFusionCommandProjectIntegration`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fvscode-dbt-power-user&utm_source=github&utm_medium=referral)<sup> for 231eac15afe3c31fece66120f6e7837754a7cc44. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor
* Improved DBT/Fusion command detection and initialization so the app resolves and logs the tool path more reliably across platforms, and propagates that path during project setup for more consistent runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->