### PR TITLE
feat: add dbt run history tree view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.2.2",
+        "@altimateai/dbt-integration": "^0.2.3",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^6.6.7",
@@ -29,6 +29,7 @@
         "node-abort-controller": "^3.1.1",
         "node-fetch": "^3.3.2",
         "parse-diff": "^0.11.1",
+        "python-bridge": "^1.1.0",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.6.3",
         "which": "^4.0.0",
@@ -91,9 +92,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.2.2.tgz",
-      "integrity": "sha512-ScyvMvO8uifoaefnHi96wOrgqEvF0iQDPq5ISFPGViIKf2Oems8BpqFQ2cIsj/CagzRkM2ukTasPGxw5UiPdOw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.2.3.tgz",
+      "integrity": "sha512-LLvhpySqMf5mYmARmmrolwAScCS7YZJZa5H+iPGyxTOz+FnG2Q3yH01UhU0dvAx/ITjFR+FCtrPoivpzf79iOg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16522,7 +16523,8 @@
     },
     "node_modules/python-bridge": {
       "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/mdesmet/node-python-bridge.git#6c37181b41710c7b83e08b5c67de5ec0bc759010",
+      "resolved": "https://registry.npmjs.org/python-bridge/-/python-bridge-1.1.0.tgz",
+      "integrity": "sha512-qjQ0QB8p9cn/XDeILQH0aP307hV58lrmv0Opjyub68Um7FHdF+ZXlTqyxNkKaXOFk2QSkScoPWwn7U9GGnrkeQ==",
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -352,6 +352,11 @@
           "id": "insights_view",
           "title": "Actions",
           "icon": "./media/images/dbt_icon.svg"
+        },
+        {
+          "id": "run_history_view",
+          "title": "Run History",
+          "icon": "./media/images/dbt_icon.svg"
         }
       ]
     },
@@ -412,6 +417,12 @@
           "id": "dbtPowerUser.Insights",
           "name": "",
           "type": "webview"
+        }
+      ],
+      "run_history_view": [
+        {
+          "id": "run_history_treeview",
+          "name": "Runs"
         }
       ]
     },
@@ -497,6 +508,12 @@
           "light": "./media/images/run-light.svg",
           "dark": "./media/images/run-dark.svg"
         }
+      },
+      {
+        "command": "dbtPowerUser.rerunFromHistory",
+        "title": "Re-run Command",
+        "category": "dbt Power User",
+        "icon": "$(debug-rerun)"
       },
       {
         "command": "dbtPowerUser.openDatapilotWithQuery",
@@ -1036,6 +1053,11 @@
       ],
       "view/item/context": [
         {
+          "command": "dbtPowerUser.rerunFromHistory",
+          "when": "view == run_history_treeview && viewItem == runHistoryEntry",
+          "group": "inline"
+        },
+        {
           "command": "dbtPowerUser.runTest",
           "when": "view == model_test_treeview && viewItem != source",
           "group": "inline"
@@ -1391,7 +1413,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.2.2",
+    "@altimateai/dbt-integration": "^0.2.3",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^6.6.7",
@@ -1410,6 +1432,7 @@
     "node-abort-controller": "^3.1.1",
     "node-fetch": "^3.3.2",
     "parse-diff": "^0.11.1",
+    "python-bridge": "^1.1.0",
     "reflect-metadata": "^0.2.2",
     "semver": "^7.6.3",
     "which": "^4.0.0",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -37,6 +37,7 @@ import { ProjectQuickPickItem } from "../quickpick/projectQuickPick";
 import { DiagnosticsOutputChannel } from "../services/diagnosticsOutputChannel";
 import { QueryManifestService } from "../services/queryManifestService";
 import { SharedStateService } from "../services/sharedStateService";
+import { RunTreeItem } from "../treeview_provider/runHistoryTreeItems";
 import {
   deepEqual,
   extendErrorWithSupportLinks,
@@ -88,6 +89,12 @@ export class VSCodeCommands implements Disposable {
       ),
       commands.registerCommand("dbtPowerUser.runCurrentModel", () =>
         this.runModel.runModelOnActiveWindow(),
+      ),
+      commands.registerCommand(
+        "dbtPowerUser.rerunFromHistory",
+        (item: RunTreeItem) => {
+          this.dbtProjectContainer.rerunFromHistory(item.entry);
+        },
       ),
       commands.registerCommand("dbtPowerUser.testCurrentModel", () =>
         this.runModel.runTestsOnActiveWindow(),

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -66,6 +66,7 @@ import { DocGenService } from "./services/docGenService";
 import { FileService } from "./services/fileService";
 import { QueryAnalysisService } from "./services/queryAnalysisService";
 import { QueryManifestService } from "./services/queryManifestService";
+import { RunHistoryService } from "./services/runHistoryService";
 import { SharedStateService } from "./services/sharedStateService";
 import { StreamingService } from "./services/streamingService";
 import { UsersService } from "./services/usersService";
@@ -137,6 +138,7 @@ import {
   ModelTestTreeview,
   ParentModelTreeview,
 } from "./treeview_provider/modelTreeviewProvider";
+import { RunHistoryTreeviewProvider } from "./treeview_provider/runHistoryTreeviewProvider";
 import { WebviewViewProviders } from "./webview_provider";
 import { DataPilotPanel } from "./webview_provider/datapilotPanel";
 import { DbtDocsView } from "./webview_provider/DbtDocsView";
@@ -708,6 +710,7 @@ container
         container.get(AltimateRequest),
         container.get(ValidationProvider),
         container.get(AltimateAuthService),
+        container.get(RunHistoryService),
         path,
         projectConfig,
         _onManifestChanged,
@@ -829,6 +832,22 @@ container
   .bind(SharedStateService)
   .toDynamicValue(() => {
     return new SharedStateService();
+  })
+  .inSingletonScope();
+
+container
+  .bind(RunHistoryService)
+  .toDynamicValue(() => {
+    return new RunHistoryService();
+  })
+  .inSingletonScope();
+
+container
+  .bind(RunHistoryTreeviewProvider)
+  .toDynamicValue((context) => {
+    return new RunHistoryTreeviewProvider(
+      context.container.get(RunHistoryService),
+    );
   })
   .inSingletonScope();
 
@@ -1679,6 +1698,7 @@ container
       context.container.get(ModelTestTreeview),
       context.container.get(DocumentationTreeview),
       context.container.get(IconActionsTreeview),
+      context.container.get(RunHistoryTreeviewProvider),
     );
   })
   .inSingletonScope();

--- a/src/services/runHistoryService.ts
+++ b/src/services/runHistoryService.ts
@@ -1,0 +1,45 @@
+import type { RunResultsEventData } from "@altimateai/dbt-integration";
+import { injectable } from "inversify";
+import { Disposable, Event, EventEmitter } from "vscode";
+
+export type {
+  RunResultEntry,
+  RunResultsEventData,
+  RunStatus,
+} from "@altimateai/dbt-integration";
+
+@injectable()
+export class RunHistoryService implements Disposable {
+  private static readonly MAX_ENTRIES = 50;
+
+  private history: RunResultsEventData[] = [];
+
+  private _onHistoryChanged = new EventEmitter<
+    RunResultsEventData | undefined
+  >();
+  readonly onHistoryChanged: Event<RunResultsEventData | undefined> =
+    this._onHistoryChanged.event;
+
+  private disposables: Disposable[] = [this._onHistoryChanged];
+
+  /**
+   * Add a completed run to history.
+   * Accepts pre-parsed RunResultsEventData from dbt-integration.
+   */
+  addEntry(entry: RunResultsEventData): RunResultsEventData {
+    this.history.unshift(entry);
+    if (this.history.length > RunHistoryService.MAX_ENTRIES) {
+      this.history.pop();
+    }
+    this._onHistoryChanged.fire(entry);
+    return entry;
+  }
+
+  get entries(): readonly RunResultsEventData[] {
+    return this.history;
+  }
+
+  dispose(): void {
+    this.disposables.forEach((d) => d.dispose());
+  }
+}

--- a/src/test/fixtures/runHistory.ts
+++ b/src/test/fixtures/runHistory.ts
@@ -1,0 +1,28 @@
+import type {
+  RunResultEntry,
+  RunResultsEventData,
+} from "@altimateai/dbt-integration";
+
+export const createResult = (
+  overrides: Partial<RunResultEntry> = {},
+): RunResultEntry => ({
+  name: "model1",
+  uniqueId: "model.project.model1",
+  status: "success",
+  executionTime: 1.0,
+  resourceType: "model",
+  ...overrides,
+});
+
+export const createEntry = (
+  overrides: Partial<RunResultsEventData> = {},
+): RunResultsEventData => ({
+  id: "test-invocation",
+  command: "run",
+  args: [],
+  completedAt: new Date("2024-01-15T10:30:00"),
+  projectName: "test-project",
+  results: [createResult()],
+  elapsedTime: 1.0,
+  ...overrides,
+});

--- a/src/test/integration/runHistoryTreeview.test.ts
+++ b/src/test/integration/runHistoryTreeview.test.ts
@@ -1,0 +1,142 @@
+import type { RunResultsEventData } from "@altimateai/dbt-integration";
+import * as assert from "assert";
+import "reflect-metadata";
+import * as vscode from "vscode";
+import { RunHistoryService } from "../../services/runHistoryService";
+import {
+  ResultTreeItem,
+  RunTreeItem,
+} from "../../treeview_provider/runHistoryTreeItems";
+import { RunHistoryTreeviewProvider } from "../../treeview_provider/runHistoryTreeviewProvider";
+
+function createEntry(
+  overrides: Partial<RunResultsEventData> = {},
+): RunResultsEventData {
+  return {
+    id: "inv-001",
+    command: "run",
+    args: [],
+    completedAt: new Date(),
+    projectName: "test-project",
+    results: [
+      {
+        name: "my_model",
+        uniqueId: "model.project.my_model",
+        status: "success",
+        executionTime: 1.5,
+        resourceType: "model",
+      },
+    ],
+    elapsedTime: 2.0,
+    ...overrides,
+  };
+}
+
+suite("Run History TreeView Integration", function () {
+  this.timeout(10_000);
+
+  let service: RunHistoryService;
+  let provider: RunHistoryTreeviewProvider;
+  let registration: vscode.Disposable;
+
+  setup(function () {
+    service = new RunHistoryService();
+    provider = new RunHistoryTreeviewProvider(service);
+    registration = vscode.window.registerTreeDataProvider(
+      "run_history_treeview",
+      provider,
+    );
+  });
+
+  teardown(function () {
+    registration.dispose();
+    provider.dispose();
+    service.dispose();
+  });
+
+  test("registers tree data provider without error", function () {
+    assert.ok(registration, "Registration should return a disposable");
+  });
+
+  test("empty history returns no children", function () {
+    const children = provider.getChildren();
+    assert.strictEqual(children.length, 0);
+  });
+
+  test("added entry produces a RunTreeItem at root", function () {
+    service.addEntry(createEntry());
+
+    const children = provider.getChildren();
+    assert.strictEqual(children.length, 1);
+    assert.ok(children[0] instanceof RunTreeItem);
+  });
+
+  test("RunTreeItem has expected label and description", function () {
+    service.addEntry(createEntry({ command: "build", args: ["+stg_orders+"] }));
+
+    const item = provider.getChildren()[0] as RunTreeItem;
+    assert.strictEqual(item.label, "dbt build +stg_orders+");
+    assert.ok(
+      typeof item.description === "string" && item.description.length > 0,
+    );
+  });
+
+  test("RunTreeItem exposes real ThemeIcon", function () {
+    service.addEntry(createEntry());
+
+    const item = provider.getChildren()[0] as RunTreeItem;
+    assert.ok(item.iconPath instanceof vscode.ThemeIcon);
+  });
+
+  test("expanding a RunTreeItem yields ResultTreeItems", function () {
+    service.addEntry(
+      createEntry({
+        results: [
+          {
+            name: "m1",
+            uniqueId: "model.p.m1",
+            status: "success",
+            executionTime: 1.0,
+            resourceType: "model",
+          },
+          {
+            name: "t1",
+            uniqueId: "test.p.t1",
+            status: "error",
+            executionTime: 0.3,
+            resourceType: "test",
+          },
+        ],
+      }),
+    );
+
+    const runItem = provider.getChildren()[0] as RunTreeItem;
+    const children = provider.getChildren(runItem);
+    assert.strictEqual(children.length, 2);
+    assert.ok(children[0] instanceof ResultTreeItem);
+    assert.ok(children[1] instanceof ResultTreeItem);
+  });
+
+  test("ResultTreeItem is a leaf node", function () {
+    service.addEntry(createEntry());
+
+    const runItem = provider.getChildren()[0] as RunTreeItem;
+    const resultItem = provider.getChildren(runItem)[0] as ResultTreeItem;
+    assert.strictEqual(provider.getChildren(resultItem).length, 0);
+  });
+
+  test("onDidChangeTreeData fires on real EventEmitter", function (done) {
+    provider.onDidChangeTreeData(() => done());
+    service.addEntry(createEntry());
+  });
+
+  test("multiple entries appear in reverse chronological order", function () {
+    service.addEntry(createEntry({ id: "first" }));
+    service.addEntry(createEntry({ id: "second" }));
+
+    const children = provider.getChildren() as RunTreeItem[];
+    assert.strictEqual(children.length, 2);
+    assert.strictEqual(children[0].entry.id, "second");
+    assert.strictEqual(children[1].entry.id, "first");
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -93,10 +93,18 @@ jest.mock("vscode", () => ({
     Collapsed: 1,
     Expanded: 2,
   },
-  TreeItem: jest.fn().mockImplementation((label, collapsibleState) => ({
-    label,
-    collapsibleState,
-  })),
+  TreeItem: class TreeItem {
+    label: string | undefined;
+    collapsibleState: number | undefined;
+    description?: string;
+    iconPath?: any;
+    tooltip?: string;
+    contextValue?: string;
+    constructor(label?: string, collapsibleState?: number) {
+      this.label = label;
+      this.collapsibleState = collapsibleState;
+    }
+  },
   CancellationTokenSource: jest.fn().mockImplementation(() => ({
     token: {
       onCancellationRequested: jest.fn(),
@@ -111,4 +119,11 @@ jest.mock("vscode", () => ({
       isCancellationRequested: false,
     },
   },
+  ThemeIcon: jest.fn().mockImplementation((id, color) => ({
+    id,
+    color,
+  })),
+  ThemeColor: jest.fn().mockImplementation((id) => ({
+    id,
+  })),
 }));

--- a/src/test/suite/runHistoryService.test.ts
+++ b/src/test/suite/runHistoryService.test.ts
@@ -1,0 +1,78 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { RunHistoryService } from "../../services/runHistoryService";
+import { createEntry } from "../fixtures/runHistory";
+
+describe("RunHistoryService", () => {
+  let service: RunHistoryService;
+
+  beforeEach(() => {
+    service = new RunHistoryService();
+  });
+
+  afterEach(() => {
+    service.dispose();
+    jest.clearAllMocks();
+  });
+
+  describe("addEntry", () => {
+    it("should store the entry and return it", () => {
+      const entry = createEntry({ id: "test-123" });
+
+      const result = service.addEntry(entry);
+
+      expect(result).toBe(entry);
+      expect(result.id).toBe("test-123");
+    });
+
+    it("should add new runs at the beginning of history", () => {
+      service.addEntry(createEntry({ id: "first" }));
+      service.addEntry(createEntry({ id: "second" }));
+
+      const entries = service.entries;
+      expect(entries[0].id).toBe("second");
+      expect(entries[1].id).toBe("first");
+    });
+
+    it("should fire onHistoryChanged event when entry is added", () => {
+      const listener = jest.fn();
+      service.onHistoryChanged(listener);
+
+      const entry = createEntry({ id: "test-invocation" });
+      service.addEntry(entry);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "test-invocation" }),
+      );
+    });
+
+    it("should cap history at MAX_ENTRIES", () => {
+      for (let i = 0; i < 55; i++) {
+        service.addEntry(createEntry({ id: `run-${i}` }));
+      }
+
+      expect(service.entries).toHaveLength(50);
+      expect(service.entries[0].id).toBe("run-54");
+      expect(service.entries[49].id).toBe("run-5");
+    });
+  });
+
+  describe("entries", () => {
+    it("should return empty array when no runs added", () => {
+      expect(service.entries).toEqual([]);
+    });
+  });
+
+  describe("dispose", () => {
+    it("should dispose without throwing", () => {
+      expect(() => service.dispose()).not.toThrow();
+    });
+  });
+});

--- a/src/test/suite/runHistoryTreeItems.test.ts
+++ b/src/test/suite/runHistoryTreeItems.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "@jest/globals";
+import { TreeItemCollapsibleState } from "vscode";
+import {
+  getStatusIcon,
+  ResultTreeItem,
+  RunTreeItem,
+} from "../../treeview_provider/runHistoryTreeItems";
+import { createEntry, createResult } from "../fixtures/runHistory";
+
+describe("RunHistoryTreeItems", () => {
+  describe("RunTreeItem", () => {
+    it("should format label with command and args", () => {
+      const item = new RunTreeItem(
+        createEntry({ command: "build", args: ["+my_model+"] }),
+        1,
+      );
+      expect(item.label).toBe("dbt build +my_model+");
+    });
+
+    it("should be expanded when run count is within threshold", () => {
+      const item = new RunTreeItem(
+        createEntry({ results: [createResult()] }),
+        3,
+      );
+      expect(item.collapsibleState).toBe(TreeItemCollapsibleState.Expanded);
+    });
+
+    it("should be collapsed when run count exceeds threshold", () => {
+      const item = new RunTreeItem(
+        createEntry({ results: [createResult()] }),
+        10,
+      );
+      expect(item.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+    });
+
+    it("should be None when results are empty regardless of run count", () => {
+      const item = new RunTreeItem(createEntry({ results: [] }), 1);
+      expect(item.collapsibleState).toBe(TreeItemCollapsibleState.None);
+    });
+
+    it("should show duration and pass count in description", () => {
+      const allPass = new RunTreeItem(
+        createEntry({
+          elapsedTime: 5.5,
+          results: [
+            createResult(),
+            createResult({ name: "m2", uniqueId: "model.p.m2" }),
+          ],
+        }),
+        1,
+      );
+      const someFail = new RunTreeItem(
+        createEntry({
+          results: [
+            createResult({ status: "success" }),
+            createResult({
+              name: "m2",
+              uniqueId: "model.p.m2",
+              status: "error",
+            }),
+          ],
+        }),
+        1,
+      );
+
+      expect(allPass.description).toContain("5.50s");
+      expect(allPass.description).toContain("2 passed");
+      expect(someFail.description).toContain("1/2 passed");
+    });
+
+    it("should use pass icon when all results succeed", () => {
+      const item = new RunTreeItem(
+        createEntry({ results: [createResult({ status: "success" })] }),
+        1,
+      );
+      expect((item.iconPath as any).id).toBe("pass");
+    });
+
+    it("should use error icon when any result has error", () => {
+      const item = new RunTreeItem(
+        createEntry({ results: [createResult({ status: "error" })] }),
+        1,
+      );
+      expect((item.iconPath as any).id).toBe("error");
+    });
+
+    it("should use warning icon when results have warns but no errors", () => {
+      const item = new RunTreeItem(
+        createEntry({
+          results: [
+            createResult({ status: "success" }),
+            createResult({
+              name: "m2",
+              uniqueId: "model.p.m2",
+              status: "warn",
+            }),
+          ],
+        }),
+        1,
+      );
+      expect((item.iconPath as any).id).toBe("warning");
+      expect((item.iconPath as any).color.id).toBe("charts.yellow");
+    });
+
+    it("should include project, duration, and invocation in tooltip", () => {
+      const item = new RunTreeItem(
+        createEntry({
+          projectName: "my-project",
+          elapsedTime: 12.34,
+          id: "abc-123",
+        }),
+        1,
+      );
+
+      expect(item.tooltip).toContain("Project: my-project");
+      expect(item.tooltip).toContain("Duration: 12.34s");
+      expect(item.tooltip).toContain("Invocation: abc-123");
+    });
+
+    it("should handle completedAt as a string (JSON deserialization)", () => {
+      const item = new RunTreeItem(
+        createEntry({
+          completedAt: "2024-01-15T10:30:00.000Z" as unknown as Date,
+        }),
+        1,
+      );
+
+      expect(item.tooltip).toContain("Completed:");
+    });
+
+    it("should have runHistoryEntry contextValue", () => {
+      expect(new RunTreeItem(createEntry(), 1).contextValue).toBe(
+        "runHistoryEntry",
+      );
+    });
+  });
+
+  describe("ResultTreeItem", () => {
+    it("should use model name as label with None collapsibleState", () => {
+      const item = new ResultTreeItem(createResult({ name: "stg_customers" }));
+
+      expect(item.label).toBe("stg_customers");
+      expect(item.collapsibleState).toBe(TreeItemCollapsibleState.None);
+    });
+
+    it("should include resource type and execution time in description", () => {
+      const item = new ResultTreeItem(
+        createResult({ resourceType: "test", executionTime: 3.45 }),
+      );
+
+      expect(item.description).toContain("test");
+      expect(item.description).toContain("3.45s");
+    });
+
+    it("should use check icon for success status", () => {
+      const item = new ResultTreeItem(createResult({ status: "success" }));
+      expect((item.iconPath as any).id).toBe("check");
+    });
+
+    it("should use x icon for error status", () => {
+      const item = new ResultTreeItem(createResult({ status: "error" }));
+      expect((item.iconPath as any).id).toBe("x");
+    });
+
+    it("should use debug-step-over icon for skipped status", () => {
+      const item = new ResultTreeItem(createResult({ status: "skipped" }));
+      expect((item.iconPath as any).id).toBe("debug-step-over");
+    });
+
+    it("should include all fields in tooltip", () => {
+      const item = new ResultTreeItem(
+        createResult({
+          name: "my_model",
+          resourceType: "seed",
+          status: "success",
+          executionTime: 4.56,
+          message: "Database error",
+          uniqueId: "model.jaffle.customers",
+        }),
+      );
+
+      expect(item.tooltip).toContain("Name: my_model");
+      expect(item.tooltip).toContain("Type: seed");
+      expect(item.tooltip).toContain("Status: success");
+      expect(item.tooltip).toContain("Execution Time: 4.56s");
+      expect(item.tooltip).toContain("Message: Database error");
+      expect(item.tooltip).toContain("Unique ID: model.jaffle.customers");
+    });
+
+    it("should not include message in tooltip when absent", () => {
+      const item = new ResultTreeItem(createResult({ message: undefined }));
+      expect(item.tooltip).not.toContain("Message:");
+    });
+
+    it.each(["model", "test", "seed", "snapshot"] as const)(
+      "should set contextValue for %s resource type",
+      (resourceType) => {
+        const item = new ResultTreeItem(createResult({ resourceType }));
+        expect(item.contextValue).toBe(`runHistoryResult.${resourceType}`);
+      },
+    );
+  });
+
+  describe("getStatusIcon", () => {
+    it.each<[string, string, string]>([
+      ["success", "check", "charts.green"],
+      ["error", "x", "charts.red"],
+      ["warn", "warning", "charts.yellow"],
+      ["skipped", "debug-step-over", "disabledForeground"],
+    ])(
+      "should return correct icon for %s status",
+      (status, expectedIcon, expectedColor) => {
+        const result = getStatusIcon(status as any);
+        expect(result.icon).toBe(expectedIcon);
+        expect(result.color).toBe(expectedColor);
+      },
+    );
+  });
+});

--- a/src/test/suite/runHistoryTreeviewProvider.test.ts
+++ b/src/test/suite/runHistoryTreeviewProvider.test.ts
@@ -1,0 +1,119 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { RunHistoryService } from "../../services/runHistoryService";
+import {
+  ResultTreeItem,
+  RunTreeItem,
+} from "../../treeview_provider/runHistoryTreeItems";
+import { RunHistoryTreeviewProvider } from "../../treeview_provider/runHistoryTreeviewProvider";
+import { createEntry, createResult } from "../fixtures/runHistory";
+
+describe("RunHistoryTreeviewProvider", () => {
+  let service: RunHistoryService;
+  let provider: RunHistoryTreeviewProvider;
+
+  beforeEach(() => {
+    service = new RunHistoryService();
+    provider = new RunHistoryTreeviewProvider(service);
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    service.dispose();
+    jest.clearAllMocks();
+  });
+
+  describe("getTreeItem", () => {
+    it("should return the element itself", () => {
+      const entry = createEntry();
+      service.addEntry(entry);
+      const treeItem = new RunTreeItem(entry, 1);
+
+      expect(provider.getTreeItem(treeItem)).toBe(treeItem);
+    });
+  });
+
+  describe("getChildren", () => {
+    it("should return empty array when no history", () => {
+      expect(provider.getChildren()).toEqual([]);
+    });
+
+    it("should return RunTreeItems at root level in reverse chronological order", () => {
+      service.addEntry(createEntry({ id: "first" }));
+      service.addEntry(
+        createEntry({
+          id: "second",
+          results: [
+            createResult(),
+            createResult({
+              name: "m2",
+              uniqueId: "model.project.m2",
+              status: "error",
+            }),
+          ],
+        }),
+      );
+
+      const rootChildren = provider.getChildren() as RunTreeItem[];
+
+      expect(rootChildren).toHaveLength(2);
+      expect(rootChildren[0].entry.id).toBe("second");
+      expect(rootChildren[1].entry.id).toBe("first");
+    });
+
+    it("should return ResultTreeItems for RunTreeItem children", () => {
+      service.addEntry(
+        createEntry({
+          results: [
+            createResult(),
+            createResult({
+              name: "model2",
+              uniqueId: "model.project.model2",
+              status: "error",
+              executionTime: 0.5,
+            }),
+          ],
+        }),
+      );
+
+      const runTreeItem = provider.getChildren()[0] as RunTreeItem;
+      const children = provider.getChildren(runTreeItem) as ResultTreeItem[];
+
+      expect(children).toHaveLength(2);
+      expect(children[0].result.name).toBe("model1");
+      expect(children[1].result.name).toBe("model2");
+    });
+
+    it("should return empty array for ResultTreeItem children", () => {
+      service.addEntry(createEntry());
+
+      const runTreeItem = provider.getChildren()[0] as RunTreeItem;
+      const resultItem = provider.getChildren(runTreeItem)[0] as ResultTreeItem;
+
+      expect(provider.getChildren(resultItem)).toEqual([]);
+    });
+  });
+
+  describe("onDidChangeTreeData", () => {
+    it("should fire when history changes", () => {
+      const listener = jest.fn();
+      provider.onDidChangeTreeData(listener);
+
+      service.addEntry(createEntry());
+
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+
+  describe("dispose", () => {
+    it("should dispose without throwing", () => {
+      expect(() => provider.dispose()).not.toThrow();
+    });
+  });
+});

--- a/src/treeview_provider/index.ts
+++ b/src/treeview_provider/index.ts
@@ -6,6 +6,7 @@ import {
   ModelTestTreeview,
   ParentModelTreeview,
 } from "./modelTreeviewProvider";
+import { RunHistoryTreeviewProvider } from "./runHistoryTreeviewProvider";
 
 export class TreeviewProviders implements Disposable {
   private disposables: Disposable[] = [];
@@ -16,6 +17,7 @@ export class TreeviewProviders implements Disposable {
     private testModelTreeview: ModelTestTreeview,
     private documentationTreeView: DocumentationTreeview,
     private iconActionsTreeview: IconActionsTreeview,
+    private runHistoryTreeviewProvider: RunHistoryTreeviewProvider,
   ) {
     this.disposables.push(
       window.registerTreeDataProvider(
@@ -37,6 +39,10 @@ export class TreeviewProviders implements Disposable {
       window.registerTreeDataProvider(
         "icon_actions_treeview",
         this.iconActionsTreeview,
+      ),
+      window.registerTreeDataProvider(
+        "run_history_treeview",
+        this.runHistoryTreeviewProvider,
       ),
     );
   }

--- a/src/treeview_provider/runHistoryTreeItems.ts
+++ b/src/treeview_provider/runHistoryTreeItems.ts
@@ -1,0 +1,169 @@
+import type {
+  RunResultEntry,
+  RunResultsEventData,
+  RunStatus,
+} from "@altimateai/dbt-integration";
+import {
+  ThemeColor,
+  ThemeIcon,
+  TreeItem,
+  TreeItemCollapsibleState,
+} from "vscode";
+
+/** Number of runs beyond which new items default to collapsed */
+const COLLAPSE_THRESHOLD = 5;
+
+/**
+ * Top-level tree item representing a dbt command execution (e.g., `dbt run`, `dbt test`).
+ * This is the parent node displayed in the Run History treeview panel.
+ * Each RunTreeItem contains child ResultTreeItems for individual model/test/seed results.
+ */
+export class RunTreeItem extends TreeItem {
+  constructor(
+    public readonly entry: RunResultsEventData,
+    runCount: number,
+  ) {
+    super(
+      RunTreeItem.getLabel(entry),
+      RunTreeItem.getCollapsibleState(entry, runCount),
+    );
+
+    this.description = RunTreeItem.getDescription(entry);
+    this.iconPath = RunTreeItem.getIcon(entry);
+    this.tooltip = RunTreeItem.getTooltip(entry);
+    this.contextValue = "runHistoryEntry";
+  }
+
+  private static getCollapsibleState(
+    entry: RunResultsEventData,
+    runCount: number,
+  ): TreeItemCollapsibleState {
+    if (entry.results.length === 0) {
+      return TreeItemCollapsibleState.None;
+    }
+    return runCount > COLLAPSE_THRESHOLD
+      ? TreeItemCollapsibleState.Collapsed
+      : TreeItemCollapsibleState.Expanded;
+  }
+
+  private static getLabel(entry: RunResultsEventData): string {
+    const args = entry.args.length > 0 ? ` ${entry.args.join(" ")}` : "";
+    return `dbt ${entry.command}${args}`;
+  }
+
+  private static getDescription(entry: RunResultsEventData): string {
+    const duration = `${(entry.elapsedTime ?? 0).toFixed(2)}s`;
+    const resultCount = entry.results.length;
+    const successCount = entry.results.filter(
+      (r: RunResultEntry) => r.status === "success",
+    ).length;
+    const errorCount = entry.results.filter(
+      (r: RunResultEntry) => r.status === "error",
+    ).length;
+
+    const parts: string[] = [duration];
+    if (resultCount > 0) {
+      if (errorCount > 0) {
+        parts.push(`${successCount}/${resultCount} passed`);
+      } else {
+        parts.push(`${resultCount} passed`);
+      }
+    }
+
+    return parts.join(" • ");
+  }
+
+  private static getIcon(entry: RunResultsEventData): ThemeIcon {
+    const hasError = entry.results.some(
+      (r: RunResultEntry) => r.status === "error",
+    );
+    if (hasError) {
+      return new ThemeIcon("error", new ThemeColor("charts.red"));
+    }
+    const hasWarn = entry.results.some(
+      (r: RunResultEntry) => r.status === "warn",
+    );
+    if (hasWarn) {
+      return new ThemeIcon("warning", new ThemeColor("charts.yellow"));
+    }
+    return new ThemeIcon("pass", new ThemeColor("charts.green"));
+  }
+
+  private static getTooltip(entry: RunResultsEventData): string {
+    const completedAt =
+      entry.completedAt instanceof Date
+        ? entry.completedAt
+        : new Date(entry.completedAt);
+    const lines: string[] = [];
+    lines.push(`Project: ${entry.projectName}`);
+    lines.push(`Completed: ${completedAt.toLocaleTimeString()}`);
+    lines.push(`Duration: ${(entry.elapsedTime ?? 0).toFixed(2)}s`);
+    lines.push(`Invocation: ${entry.id}`);
+    return lines.join("\n");
+  }
+}
+
+/** Maps normalized RunStatus to icon and theme color for display */
+export function getStatusIcon(status: RunStatus): {
+  icon: string;
+  color: string;
+} {
+  switch (status) {
+    case "success":
+      return { icon: "check", color: "charts.green" };
+    case "error":
+      return { icon: "x", color: "charts.red" };
+    case "warn":
+      return { icon: "warning", color: "charts.yellow" };
+    case "skipped":
+    default:
+      return { icon: "debug-step-over", color: "disabledForeground" };
+  }
+}
+
+/**
+ * Child tree item representing an individual model, test, seed, or snapshot result.
+ * These appear as expandable children under their parent RunTreeItem.
+ * Displays the resource name, type, execution time, and status icon.
+ */
+export class ResultTreeItem extends TreeItem {
+  constructor(public readonly result: RunResultEntry) {
+    super(result.name, TreeItemCollapsibleState.None);
+
+    this.description = ResultTreeItem.getDescription(result);
+    this.iconPath = ResultTreeItem.getIcon(result);
+    this.tooltip = ResultTreeItem.getTooltip(result);
+    this.contextValue = `runHistoryResult.${result.resourceType}`;
+  }
+
+  private static getDescription(result: RunResultEntry): string {
+    const parts: string[] = [];
+    parts.push(result.resourceType);
+    if (result.executionTime !== null && result.executionTime !== undefined) {
+      parts.push(`${result.executionTime.toFixed(2)}s`);
+    }
+    return parts.join(" • ");
+  }
+
+  private static getIcon(result: RunResultEntry): ThemeIcon {
+    const config = getStatusIcon(result.status);
+    return new ThemeIcon(config.icon, new ThemeColor(config.color));
+  }
+
+  private static getTooltip(result: RunResultEntry): string {
+    const lines: string[] = [];
+    lines.push(`Name: ${result.name}`);
+    lines.push(`Type: ${result.resourceType}`);
+    lines.push(`Status: ${result.status}`);
+    if (result.executionTime !== null && result.executionTime !== undefined) {
+      lines.push(`Execution Time: ${result.executionTime.toFixed(2)}s`);
+    }
+    if (result.message) {
+      lines.push(`Message: ${result.message}`);
+    }
+    lines.push(`Unique ID: ${result.uniqueId}`);
+    return lines.join("\n");
+  }
+}
+
+export type RunHistoryTreeItem = RunTreeItem | ResultTreeItem;

--- a/src/treeview_provider/runHistoryTreeviewProvider.ts
+++ b/src/treeview_provider/runHistoryTreeviewProvider.ts
@@ -1,0 +1,56 @@
+import {
+  Disposable,
+  Event,
+  EventEmitter,
+  TreeDataProvider,
+  TreeItem,
+} from "vscode";
+import { RunHistoryService } from "../services/runHistoryService";
+import {
+  ResultTreeItem,
+  RunHistoryTreeItem,
+  RunTreeItem,
+} from "./runHistoryTreeItems";
+
+export class RunHistoryTreeviewProvider
+  implements TreeDataProvider<RunHistoryTreeItem>, Disposable
+{
+  private _onDidChangeTreeData = new EventEmitter<
+    RunHistoryTreeItem | undefined | void
+  >();
+  readonly onDidChangeTreeData: Event<RunHistoryTreeItem | undefined | void> =
+    this._onDidChangeTreeData.event;
+
+  private disposables: Disposable[] = [this._onDidChangeTreeData];
+
+  constructor(private runHistoryService: RunHistoryService) {
+    this.disposables.push(
+      this.runHistoryService.onHistoryChanged(() => {
+        this._onDidChangeTreeData.fire();
+      }),
+    );
+  }
+
+  // Called by VS Code's TreeDataProvider interface
+  getTreeItem(element: RunHistoryTreeItem): TreeItem {
+    return element;
+  }
+
+  // Called by VS Code's TreeDataProvider interface to populate the tree view
+  getChildren(element?: RunHistoryTreeItem): RunHistoryTreeItem[] {
+    if (!element) {
+      const entries = this.runHistoryService.entries;
+      return entries.map((entry) => new RunTreeItem(entry, entries.length));
+    }
+
+    if (element instanceof RunTreeItem) {
+      return element.entry.results.map((result) => new ResultTreeItem(result));
+    }
+
+    return [];
+  }
+
+  dispose(): void {
+    this.disposables.forEach((d) => d.dispose());
+  }
+}


### PR DESCRIPTION
## Summary
![dbt_run_history](https://github.com/user-attachments/assets/d063674a-5954-43e2-bc09-266e1eb421ce)

<img width="485" height="313" alt="Screenshot 2026-01-02 at 5 47 36 PM" src="https://github.com/user-attachments/assets/7dbb0726-7f15-4992-9d34-c61000d21077" />

- dbt-integration changes: https://github.com/AltimateAI/altimate-dbt-integration/pull/14

Adds a dbt Run History panel that displays completed command executions and their results directly in VS Code.

## Features

- **Run History Tree View** - Shows history of completed dbt commands in the bottom panel
- **Command Tracking** - Tracks `run`, `build`, and `test` commands with their arguments
- **Result Display** - Shows per-model/test results with status icons, execution times
- **Auto-updates** - Tree view updates when commands complete

## Implementation

### Architecture

```
dbt command executes
  └─> run_results.json written
      └─> RUN_RESULTS_PARSED event fires
          └─> runHistoryService.addCompletedRun(results, projectName)
              └─> Tree view updates
```

### Key Components

1. **`RunHistoryService`** (`src/services/runHistoryService.ts`)
   - Manages run history entries
   - Single `addCompletedRun()` method processes completed results
   - Extracts command/args from dbt's `metadata.args`
   - Emits `onHistoryChanged` events for UI updates

2. **`RunHistoryTreeviewProvider`** (`src/treeview_provider/runHistoryTreeviewProvider.ts`)
   - VS Code TreeDataProvider for the run history panel
   - Displays runs as expandable items with model results as children

3. **`RunHistoryTreeItems`** (`src/treeview_provider/runHistoryTreeItems.ts`)
   - `RunTreeItem` - Represents a completed dbt command
   - `ModelResultTreeItem` - Represents individual model/test results

4. **Integration in `DBTProject`** (`src/dbt_client/dbtProject.ts`)
   - `RUN_RESULTS_PARSED` event handler calls `addCompletedRun()`
   - Command/args extracted from dbt's invocation metadata

### Commands Tracked

| Command | Example Args |
|---------|-------------|
| run | --select model_name |
| build | --select model_name |
| test | --select test_name |

## Dependencies

- **dbt-integration PR**: https://github.com/AltimateAI/altimate-dbt-integration/pull/14
  - Extends `RunResultsEventData` with `metadata.args` and result fields
  - Currently using type assertions until this PR is merged and published

## Test Plan

- [ ] Run a model and verify it appears in run history after completion
- [ ] Run build and verify models/tests are shown as children
- [ ] Verify correct command and args are displayed
- [ ] Verify status icons (green check, red X) match results

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Run History panel to the IDE sidebar, displaying a tree view of recent dbt runs with execution details, command information, duration, results summary, and status indicators for quick reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->