### PR TITLE
fix: Improve SQL formatter handling of long lines (#1717)

### DIFF
--- a/src/test/fixtures/formatter/issue-1717-exact-reproducer.sql
+++ b/src/test/fixtures/formatter/issue-1717-exact-reproducer.sql
@@ -1,0 +1,42 @@
+with
+
+    cte1 as (
+
+        select src.*
+        from {{ source("my_looooooooooooooong_source_schema_name", "my_table_name") }} as src
+
+    ),
+
+    cte2 as (
+
+        select
+            my_looooooooooooooooooooooooong_column_name1 as my_loooooooong_alias0,
+        from cte1
+
+    ),
+
+    cte3 as (
+
+        select
+            my_looooooooooooooooooooooooong_column_name1 as my_loooooooong_alias1,
+            my_looooooooooooooooooooooooong_column_name2 as my_loooooooong_alias2,
+            my_looooooooooooooooooooooooong_column_name3 as my_loooooooong_alias3,
+            my_looooooooooooooooooooooooong_column_name4 as my_loooooooong_alias4,
+            my_looooooooooooooooooooooooong_column_name5 as my_loooooooong_alias5,
+            my_column_name1,
+            my_looooooooooooooooooooooooong_column_name6
+            as my_loooooooong_alias6,
+            my_looooooooooooooooooooooooong_column_name7
+            as my_loooooooong_alias7,
+            my_column_name2,
+            my_column_name3
+        from
+            cte2
+
+    )
+
+select
+    my_arbitrary_function(
+        my_nested_function('my_loooooooonooooooog_string', d.my_column_name1)
+    ) as my_column_name4
+from cte3 as d


### PR DESCRIPTION
## Summary
Fixes #1717 - SQL formatter corrupting files with long lines

## Problem
When sqlfmt splits a long line into multiple lines, the formatter inserted them incorrectly, corrupting the SQL.

## Screenshots:
**Before**:

**After**:


## Solution
- Track position in old document with `lastOldLineProcessed`
- Track consecutive ADD operations with `consecutiveAddCount` to insert in correct order
- Add early return for empty documents
- Simplify diff processing by removing complex inter-chunk logic

## Tests
Added 14 unit tests for `processDiffOutput` covering long lines, multi-chunk diffs, and edge cases.

## Checklist
- [x] All tests pass (149 existing + 14 new)
- [x] Build succeeds
