### PR TITLE
Add Docker setup for extension testing and Playwright MCP config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__playwright__*"
+    ],
+    "deny": []
+  },
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ Thumbs.db
 .aider*
 certs
 mcp.json
+
+# Docker setup
+docker-setup/*.vsix
+docker-setup/.env
+
+# Playwright MCP
+.playwright-mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp"],
+      "env": { "BROWSER_NAME": "chromium" }
+    }
+  }
+}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,5 +11,11 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 .github
+.claude
+.mcp.json
+.playwright-mcp
+docker-setup
+**/*.test.*
+CLAUDE.md
 webview_panels
 !webview_panels/dist

--- a/docker-setup/Dockerfile
+++ b/docker-setup/Dockerfile
@@ -1,0 +1,54 @@
+FROM codercom/code-server:latest
+
+USER root
+
+# Install Node.js 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && corepack enable
+
+# Install Python 3, pip, git, and other dependencies
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-venv \
+    git \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dbt-duckdb globally (available for all users)
+RUN pip3 install --break-system-packages dbt-duckdb
+
+USER coder
+
+# Create altimate directory
+RUN mkdir -p ~/.altimate
+
+# Clone jaffle_shop_duckdb sample project
+RUN git clone https://github.com/dbt-labs/jaffle_shop_duckdb.git /home/coder/jaffle_shop_duckdb
+
+# Set up dbt profiles directory and create profile for jaffle_shop
+RUN mkdir -p ~/.dbt && \
+    echo "jaffle_shop:\n\
+  target: dev\n\
+  outputs:\n\
+    dev:\n\
+      type: duckdb\n\
+      path: /home/coder/jaffle_shop_duckdb/jaffle_shop.duckdb\n\
+      threads: 4\n" > ~/.dbt/profiles.yml
+
+# Install dbt dependencies for the project
+WORKDIR /home/coder/jaffle_shop_duckdb
+RUN dbt deps
+
+# Install all required extensions for dbt Power User (extensionDependencies in package.json)
+RUN code-server --install-extension ms-python.python \
+    && code-server --install-extension samuelcolvin.jinjahtml \
+    && code-server --install-extension altimateai.vscode-altimate-mcp-server
+
+EXPOSE 3001
+
+WORKDIR /home/coder
+COPY --chown=coder:coder start-code-server.sh /usr/local/bin/
+ENTRYPOINT []
+CMD ["/usr/local/bin/start-code-server.sh"]

--- a/docker-setup/README.md
+++ b/docker-setup/README.md
@@ -1,0 +1,89 @@
+# Docker Development Setup
+
+Develop and test the dbt Power User extension in code-server (VS Code in browser) with volume-mounted source for hot-reload.
+
+## Quick Start
+
+```bash
+npm run docker:deploy
+```
+
+This builds the extension, starts the container, and enters webpack watch mode. Open http://localhost:3001/?folder=/home/coder/project in your browser.
+
+## How It Works
+
+The extension source is **volume-mounted** into the container (read-only), so you don't need to rebuild a VSIX or the Docker image for every change:
+
+1. `deploy.sh` runs `npm run webpack` to build the extension
+2. Docker container starts with the repo mounted at `/home/coder/extension-src`
+3. `start-code-server.sh` symlinks the mounted source into code-server's extensions directory
+4. `npm run watch` runs on the host — any source change triggers a webpack rebuild
+5. Reload the browser to pick up changes
+
+## Configuration
+
+### Custom dbt Project
+
+By default, the container uses the built-in `jaffle_shop_duckdb` project. To use your own:
+
+1. Copy `.env.example` to `.env`
+2. Set `DBT_PROJECT_PATH=/absolute/path/to/your/project`
+3. Re-run `npm run docker:deploy`
+
+## What's Pre-Installed
+
+- **code-server**: VS Code in the browser (port 3001, no auth)
+- **Node.js 20**: For extension host
+- **Python 3 + dbt-duckdb**: For dbt integration
+- **jaffle_shop_duckdb**: Sample dbt project with pre-configured profile and deps
+- **Python extension**: Required dependency for dbt Power User
+- **Xvfb**: For headless testing
+
+## Commands
+
+| Command                 | Description                                  |
+| ----------------------- | -------------------------------------------- |
+| `npm run docker:deploy` | Build, start container, and enter watch mode |
+| `npm run docker:logs`   | View container logs                          |
+| `npm run docker:stop`   | Stop the container                           |
+
+## Playwright MCP Testing
+
+Use Playwright MCP tools to programmatically verify the extension:
+
+```
+mcp__playwright__browser_navigate → http://localhost:3001/?folder=/home/coder/project
+mcp__playwright__browser_snapshot → verify extension loaded
+```
+
+## Troubleshooting
+
+**Container won't start:**
+
+```bash
+npm run docker:stop
+cd docker-setup && docker compose up --build
+```
+
+**Extension not loading:**
+
+```bash
+# Check the symlink exists
+docker exec -it docker-setup-code-server-1 ls -la ~/.local/share/code-server/extensions/
+
+# Check extension source is mounted
+docker exec -it docker-setup-code-server-1 ls /home/coder/extension-src/package.json
+```
+
+**Rebuild from scratch:**
+
+```bash
+npm run docker:stop
+cd docker-setup && docker compose build --no-cache && docker compose up -d
+```
+
+**Check dbt installation:**
+
+```bash
+docker exec -it docker-setup-code-server-1 dbt --version
+```

--- a/docker-setup/deploy.sh
+++ b/docker-setup/deploy.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+# Determine docker compose command (V2 syntax with fallback)
+if docker compose version &>/dev/null; then
+    DC="docker compose -f docker-setup/docker-compose.yml"
+else
+    DC="docker-compose -f docker-setup/docker-compose.yml"
+fi
+
+# Step 1: Check for .env file with DBT_PROJECT_PATH
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    echo "Loading .env from docker-setup/.env"
+    export $(grep -v '^#' "$SCRIPT_DIR/.env" | xargs)
+fi
+
+if [ -n "$DBT_PROJECT_PATH" ]; then
+    echo "Using custom dbt project: $DBT_PROJECT_PATH"
+else
+    echo "Using built-in jaffle_shop_duckdb project"
+fi
+
+# Step 2: Build the extension
+echo ""
+echo "Building extension with webpack..."
+npm run webpack
+
+# Step 3: Build and start the container
+echo ""
+echo "Building and starting code-server container..."
+$DC up --build -d
+
+# Step 4: Wait for code-server to be ready
+echo ""
+echo "Waiting for code-server to be ready..."
+MAX_WAIT=60
+WAITED=0
+until curl -sf http://localhost:3001/healthz > /dev/null 2>&1; do
+    if [ $WAITED -ge $MAX_WAIT ]; then
+        echo "Timed out waiting for code-server after ${MAX_WAIT}s"
+        echo "Check logs with: npm run docker:logs"
+        exit 1
+    fi
+    sleep 2
+    WAITED=$((WAITED + 2))
+    echo "  Waiting... (${WAITED}s)"
+done
+echo "code-server is ready at http://localhost:3001/?folder=/home/coder/project"
+
+# Step 5: Start webpack watch for auto-recompilation
+echo ""
+echo "Starting webpack watch mode for hot-reload..."
+echo "  Changes to extension source will auto-rebuild."
+echo "  After rebuild, reload code-server in browser to pick up changes."
+echo ""
+npm run watch

--- a/docker-setup/docker-compose.yml
+++ b/docker-setup/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  code-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3001"
+    environment:
+      - PORT=3001
+    volumes:
+      - ..:/home/coder/extension-src:ro
+      - ${DBT_PROJECT_PATH:-/home/coder/jaffle_shop_duckdb}:/home/coder/project
+    restart: unless-stopped

--- a/docker-setup/start-code-server.sh
+++ b/docker-setup/start-code-server.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Symlink the volume-mounted extension source into code-server extensions directory
+EXTENSIONS_DIR="$HOME/.local/share/code-server/extensions"
+mkdir -p "$EXTENSIONS_DIR"
+
+# Remove any stale symlink or directory (publisher.name must match package.json)
+rm -rf "$EXTENSIONS_DIR/innoverio.vscode-dbt-power-user"
+rm -rf "$EXTENSIONS_DIR/altimate.vscode-dbt-power-user"
+
+# Create symlink to the mounted extension source
+ln -s /home/coder/extension-src "$EXTENSIONS_DIR/innoverio.vscode-dbt-power-user"
+
+# Determine project directory
+if [ -d "/home/coder/project" ] && [ "$(ls -A /home/coder/project 2>/dev/null)" ]; then
+    PROJECT_DIR="/home/coder/project"
+else
+    PROJECT_DIR="/home/coder/jaffle_shop_duckdb"
+fi
+
+# Start code-server with the project open
+exec code-server \
+    --bind-addr 0.0.0.0:${PORT:-3001} \
+    --auth none \
+    --disable-telemetry \
+    --disable-workspace-trust \
+    --log debug \
+    "$PROJECT_DIR"

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "lint-staged": "^15.2.5",
         "mocha": "^10.7.0",
         "ovsx": "^0.9.2",
+        "patch-package": "^8.0.1",
         "prettier": "^3.3.3",
         "prettier-eslint": "^15.0.1",
         "prettier-plugin-organize-imports": "^3.2.4",
@@ -13564,6 +13565,20 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/patch-package/node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1171,7 +1171,10 @@
     "test:coverage": "jest --coverage",
     "pretest": "npm run clean && npm run compile",
     "clean": "rimraf out coverage",
-    "compile": "tsc -p ./"
+    "compile": "tsc -p ./",
+    "docker:deploy": "./docker-setup/deploy.sh",
+    "docker:logs": "cd docker-setup && docker compose logs -f || docker-compose logs -f",
+    "docker:stop": "cd docker-setup && docker compose down || docker-compose down"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -1208,6 +1211,7 @@
     "lint-staged": "^15.2.5",
     "mocha": "^10.7.0",
     "ovsx": "^0.9.2",
+    "patch-package": "^8.0.1",
     "prettier": "^3.3.3",
     "prettier-eslint": "^15.0.1",
     "prettier-plugin-organize-imports": "^3.2.4",


### PR DESCRIPTION
- Add docker-setup/ with code-server container for testing extension
- Pre-configures jaffle_shop_duckdb sample project with dbt-duckdb
- Add npm scripts for docker:deploy, docker:logs, docker:stop
- Add Claude Code settings with Playwright MCP server integration
- Update .gitignore for Docker and Playwright artifacts

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local Docker-based development environment for running the extension with Node.js, Python/dbt, and a sample DuckDB project.
  * Playwright MCP test server configured for automated UI/browser testing and an accompanying access control config.

* **Documentation**
  * Detailed Docker setup guide with quick start, hot-reload workflow, verification, and troubleshooting steps.

* **Chores**
  * npm scripts to deploy, stream logs, and stop the local container; updated packaging ignore patterns and added a dev dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->