### PR TITLE
fix: clean up non-proving tests and fix 3 confirmed bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
           },
           "dbt.enableNewLineagePanel": {
             "type": "boolean",
-            "description": "Enable the new lineage panel in dbt."
+            "description": "Enable the new lineage panel in dbt.",
+            "default": true
           },
           "dbt.enableCollaboration": {
             "type": "boolean",

--- a/src/commands/runModel.ts
+++ b/src/commands/runModel.ts
@@ -30,7 +30,13 @@ export class RunModel {
       return;
     }
     const fullPath = window.activeTextEditor.document.uri;
-    this.runDBTModelTest(fullPath);
+    const segments = fullPath.fsPath.split(path.sep);
+    if (segments.includes("tests")) {
+      const testName = path.basename(fullPath.fsPath, ".sql");
+      this.runDBTTest(fullPath, testName);
+    } else {
+      this.runDBTModelTest(fullPath);
+    }
   }
 
   compileModelOnActiveWindow() {

--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -115,7 +115,7 @@ export class DocGenService {
           description: column.description,
           generated: false,
           source: Source.YAML,
-          type: column.data_type?.toLowerCase(),
+          type: column.data_type,
         };
       }),
     };
@@ -442,7 +442,7 @@ export class DocGenService {
               description: column.description || "",
               generated: false,
               source: Source.YAML,
-              type: column.data_type?.toLowerCase(),
+              type: column.data_type,
             })),
           },
         };

--- a/src/test/helpers/mockProjectContainer.ts
+++ b/src/test/helpers/mockProjectContainer.ts
@@ -1,0 +1,47 @@
+import { Uri } from "vscode";
+import { DBTProjectContainer } from "../../dbt_client/dbtProjectContainer";
+import { ManifestCacheChangedEvent } from "../../dbt_client/event/manifestCacheChangedEvent";
+import { MockEventEmitter } from "../common";
+
+/**
+ * Creates a jest-mocked DBTProjectContainer with configurable behavior.
+ */
+export function createMockDBTProjectContainer(
+  overrides: {
+    projectRootFsPath?: string;
+    packageName?: string;
+  } = {},
+): jest.Mocked<DBTProjectContainer> {
+  const { projectRootFsPath = "/mock/project", packageName = "my_project" } =
+    overrides;
+
+  const manifestChangedEmitter =
+    new MockEventEmitter<ManifestCacheChangedEvent>();
+
+  const container = {
+    getProjectRootpath: jest
+      .fn()
+      .mockReturnValue(
+        projectRootFsPath ? ({ fsPath: projectRootFsPath } as Uri) : undefined,
+      ),
+    getPackageName: jest.fn().mockReturnValue(packageName),
+    onManifestChanged: manifestChangedEmitter.event,
+    runModelTest: jest.fn(),
+    runTest: jest.fn(),
+    runModel: jest.fn(),
+    buildModel: jest.fn(),
+    compileModel: jest.fn(),
+    compileQuery: jest.fn(),
+    executeSQL: jest.fn(),
+    showCompiledSQL: jest.fn(),
+    showRunSQL: jest.fn(),
+    generateSchemaYML: jest.fn(),
+    generateDocs: jest.fn(),
+    findDBTProject: jest.fn(),
+    getFromWorkspaceState: jest.fn().mockReturnValue(undefined),
+    // Expose emitter so tests can fire events
+    _manifestChangedEmitter: manifestChangedEmitter,
+  } as any;
+
+  return container;
+}

--- a/src/test/helpers/mockTerminal.ts
+++ b/src/test/helpers/mockTerminal.ts
@@ -1,0 +1,17 @@
+import { DBTTerminal } from "@altimateai/dbt-integration";
+
+/**
+ * Creates a jest-mocked DBTTerminal with all logging methods stubbed.
+ * Extracted from the repeated pattern in cteCodeLensProvider.test.ts
+ * and other test files.
+ */
+export function createMockDBTTerminal(): jest.Mocked<DBTTerminal> {
+  return {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    log: jest.fn(),
+    trace: jest.fn(),
+  } as any;
+}

--- a/src/test/suite/docGenService.test.ts
+++ b/src/test/suite/docGenService.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for DocGenService.getCompiledDocumentationFromNode().
+ *
+ * Issue #1645: Column data_type should preserve original case
+ *              (e.g. "VARCHAR(255)" not "varchar(255)").
+ */
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { DocGenService } from "../../services/docGenService";
+import { createMockDBTTerminal } from "../helpers/mockTerminal";
+
+describe("DocGenService", () => {
+  let service: DocGenService;
+  let mockAltimateRequest: any;
+
+  beforeEach(() => {
+    mockAltimateRequest = {
+      enabled: jest.fn().mockReturnValue(true),
+    };
+
+    const mockProjectContainer = {} as any;
+    const mockTelemetry = {} as any;
+    const mockQueryManifestService = {} as any;
+    const mockDbtTerminal = createMockDBTTerminal();
+    const mockAuthService = {} as any;
+
+    service = new DocGenService(
+      mockAltimateRequest,
+      mockProjectContainer,
+      mockTelemetry,
+      mockQueryManifestService,
+      mockDbtTerminal,
+      mockAuthService,
+    );
+  });
+
+  describe("getCompiledDocumentationFromNode (Issue #1645)", () => {
+    // Access private method via `as any`
+    const callGetCompiledDocumentation = (
+      svc: DocGenService,
+      node: any,
+      modelName: string,
+      filePath: string,
+    ) => {
+      return (svc as any).getCompiledDocumentationFromNode(
+        node,
+        modelName,
+        filePath,
+      );
+    };
+
+    const createNodeWithColumns = (
+      columns: Record<
+        string,
+        { name: string; description: string; data_type?: string }
+      >,
+    ) => ({
+      columns,
+      description: "test model",
+      patch_path: "models/schema.yml",
+      unique_id: "model.test.my_model",
+      resource_type: "model",
+    });
+
+    it("should preserve VARCHAR(255) case in column type", () => {
+      const node = createNodeWithColumns({
+        col1: {
+          name: "col1",
+          description: "A varchar column",
+          data_type: "VARCHAR(255)",
+        },
+      });
+
+      const result = callGetCompiledDocumentation(
+        service,
+        node,
+        "my_model",
+        "/path/to/model.sql",
+      );
+
+      // BUG: `.toLowerCase()` on line 118 converts this to "varchar(255)"
+      // This test should FAIL before the fix
+      expect(result.columns[0].type).toBe("VARCHAR(255)");
+    });
+
+    it("should preserve BigInt case in column type", () => {
+      const node = createNodeWithColumns({
+        col1: {
+          name: "col1",
+          description: "A bigint column",
+          data_type: "BigInt",
+        },
+      });
+
+      const result = callGetCompiledDocumentation(
+        service,
+        node,
+        "my_model",
+        "/path/to/model.sql",
+      );
+
+      // BUG: `.toLowerCase()` converts to "bigint"
+      // This test should FAIL before the fix
+      expect(result.columns[0].type).toBe("BigInt");
+    });
+
+    it("should handle undefined data_type gracefully", () => {
+      const node = createNodeWithColumns({
+        col1: {
+          name: "col1",
+          description: "No type specified",
+          data_type: undefined,
+        },
+      });
+
+      const result = callGetCompiledDocumentation(
+        service,
+        node,
+        "my_model",
+        "/path/to/model.sql",
+      );
+
+      // Should already pass — no regression
+      expect(result.columns[0].type).toBeUndefined();
+    });
+
+    it("should preserve already-lowercase types unchanged", () => {
+      const node = createNodeWithColumns({
+        col1: {
+          name: "col1",
+          description: "A text column",
+          data_type: "text",
+        },
+      });
+
+      const result = callGetCompiledDocumentation(
+        service,
+        node,
+        "my_model",
+        "/path/to/model.sql",
+      );
+
+      // Should already pass — lowercase stays lowercase
+      expect(result.columns[0].type).toBe("text");
+    });
+
+    it("should return undefined when currentNode is undefined", () => {
+      const result = callGetCompiledDocumentation(
+        service,
+        undefined,
+        "my_model",
+        "/path/to/model.sql",
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should map all columns preserving their types", () => {
+      const node = createNodeWithColumns({
+        id: {
+          name: "id",
+          description: "Primary key",
+          data_type: "INT64",
+        },
+        name: {
+          name: "name",
+          description: "User name",
+          data_type: "STRING",
+        },
+        created_at: {
+          name: "created_at",
+          description: "Creation timestamp",
+          data_type: "TIMESTAMP_NTZ",
+        },
+      });
+
+      const result = callGetCompiledDocumentation(
+        service,
+        node,
+        "my_model",
+        "/path/to/model.sql",
+      );
+
+      // BUG: all get lowercased
+      // These should FAIL before the fix
+      expect(result.columns).toHaveLength(3);
+      const typesByName = Object.fromEntries(
+        result.columns.map((c: any) => [c.name, c.type]),
+      );
+      expect(typesByName["id"]).toBe("INT64");
+      expect(typesByName["name"]).toBe("STRING");
+      expect(typesByName["created_at"]).toBe("TIMESTAMP_NTZ");
+    });
+  });
+});

--- a/src/test/suite/packageJsonConfig.test.ts
+++ b/src/test/suite/packageJsonConfig.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for package.json configuration correctness.
+ *
+ * Issue #1682: `enableNewLineagePanel` should default to `true`.
+ */
+import { describe, expect, it } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+
+const packageJsonPath = path.resolve(__dirname, "../../../package.json");
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+
+describe("package.json configuration", () => {
+  describe("Issue #1682: enableNewLineagePanel default value", () => {
+    // `configuration` can be an array of config sections
+    const configSections = Array.isArray(packageJson.contributes?.configuration)
+      ? packageJson.contributes.configuration
+      : [packageJson.contributes?.configuration].filter(Boolean);
+
+    let prop: any;
+    for (const section of configSections) {
+      if (section?.properties?.["dbt.enableNewLineagePanel"]) {
+        prop = section.properties["dbt.enableNewLineagePanel"];
+        break;
+      }
+    }
+
+    it("should have the enableNewLineagePanel setting defined", () => {
+      expect(prop).toBeDefined();
+    });
+
+    it("should default to true", () => {
+      // BUG: currently missing default — this test should FAIL before the fix
+      expect(prop.default).toBe(true);
+    });
+  });
+});

--- a/src/test/suite/runModel.test.ts
+++ b/src/test/suite/runModel.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for RunModel.runTestsOnActiveWindow().
+ *
+ * Issue #1720: Running tests from a singular test file should call
+ *              `runTest()` (not `runModelTest()`), so the correct
+ *              dbt command is dispatched for singular tests.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { Uri, window } from "vscode";
+import { RunModel } from "../../commands/runModel";
+import { createMockDBTProjectContainer } from "../helpers/mockProjectContainer";
+
+describe("RunModel", () => {
+  let runModel: RunModel;
+  let mockContainer: ReturnType<typeof createMockDBTProjectContainer>;
+
+  beforeEach(() => {
+    mockContainer = createMockDBTProjectContainer();
+    runModel = new RunModel(mockContainer as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    // Reset activeTextEditor
+    (window as any).activeTextEditor = undefined;
+  });
+
+  /**
+   * Helper to set up a fake active text editor with a specific file path.
+   */
+  function setActiveEditor(fsPath: string) {
+    (window as any).activeTextEditor = {
+      document: {
+        uri: { fsPath } as Uri,
+        getText: jest.fn().mockReturnValue("select 1"),
+      },
+      selection: { isEmpty: true },
+    };
+  }
+
+  describe("runTestsOnActiveWindow (Issue #1720)", () => {
+    it("should call runModelTest for model files", () => {
+      setActiveEditor("/project/models/my_model.sql");
+
+      runModel.runTestsOnActiveWindow();
+
+      // For model files, runModelTest is the expected call
+      expect(mockContainer.runModelTest).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: "/project/models/my_model.sql" }),
+        "my_model",
+      );
+    });
+
+    it("should call runTest (not runModelTest) for singular test files", () => {
+      // BUG: current code on line 33 always calls this.runDBTModelTest(fullPath)
+      // which always calls dbtProjectContainer.runModelTest().
+      // For singular tests in the tests/ directory, it should call runTest() instead.
+      setActiveEditor("/project/tests/my_singular_test.sql");
+
+      runModel.runTestsOnActiveWindow();
+
+      // This test should FAIL before the fix:
+      // The code currently calls runModelTest even for singular test files
+      expect(mockContainer.runTest).toHaveBeenCalled();
+      expect(mockContainer.runModelTest).not.toHaveBeenCalled();
+    });
+
+    it("should not call any method when no active editor", () => {
+      (window as any).activeTextEditor = undefined;
+
+      runModel.runTestsOnActiveWindow();
+
+      expect(mockContainer.runModelTest).not.toHaveBeenCalled();
+      expect(mockContainer.runTest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("runModelOnActiveWindow", () => {
+    it("should call runModel with the active file URI", () => {
+      setActiveEditor("/project/models/my_model.sql");
+
+      runModel.runModelOnActiveWindow();
+
+      expect(mockContainer.runModel).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: "/project/models/my_model.sql" }),
+        undefined,
+      );
+    });
+
+    it("should not call runModel when no active editor", () => {
+      (window as any).activeTextEditor = undefined;
+
+      runModel.runModelOnActiveWindow();
+
+      expect(mockContainer.runModel).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Remove non-proving test files (#1787, #1754) and revert already-fixed test additions (#1702)
- Fix #1645: preserve original column type casing in `docGenService.ts` (removed `.toLowerCase()` in both compiled and YAML paths)
- Fix #1682: add `"default": true` to `enableNewLineagePanel` in `package.json`
- Fix #1720: dispatch `runDBTTest` for files in `tests/` directory in `runModel.ts`

**Note:** SVG icon fix (#1763) removed per review — already handled by PR #1779.

## Test plan

- [x] All 149 tests pass (`npx jest --no-coverage --verbose`)
- [ ] Verify column types display with original casing in doc generation
- [ ] Verify new lineage panel is enabled by default
- [ ] Verify singular dbt tests run correctly from `tests/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lineage panel enabled by default in extension settings
  * Run tests directly from test files with automatic test-type detection

* **Bug Fixes**
  * Generated documentation preserves original column data-type casing (e.g., VARCHAR(255), TIMESTAMP_NTZ)
  * Test execution routing improved to correctly distinguish model tests from standalone test files

* **Tests**
  * New test suites added to validate defaults, documentation casing, and test-run behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->