### PR TITLE
fix: load .env variables per workspace folder in multi-root workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.2.6",
+        "@altimateai/dbt-integration": "^0.2.9",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.2.6.tgz",
-      "integrity": "sha512-V0XQGtNFcMXdrUe89AFkk+K3a2nY4tIDhqDYoGEUXtde82QLd/08fuT3FbB2Uy4jb6C0tW+uJ4oyB9aEJ+DvGg==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.2.9.tgz",
+      "integrity": "sha512-L+sazdclVNVPuRrSRq/0dGfyNEOHHGKqOCGEkZiXFbaW9hRGRqk+9LgmOUwyDq2VA79qvduOehe7+Uk0Oo3sow==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -525,6 +525,7 @@
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -2892,6 +2893,7 @@
       "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3060,6 +3062,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.9.tgz",
       "integrity": "sha512-rkvIVJxsOfBejxK7I0FO5sa2WxFmJCzoDwcd88+fq/CUfynNywTo/1/T6hyFz22CyztsnLS9nVlHOnTI36RH5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -3206,6 +3209,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -3884,8 +3888,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -3927,6 +3930,7 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3985,7 +3989,6 @@
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -4000,6 +4003,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4131,7 +4135,6 @@
       "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "default-require-extensions": "^3.0.0"
       },
@@ -4144,8 +4147,7 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -4600,6 +4602,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -4698,7 +4701,6 @@
       "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hasha": "^5.0.0",
         "make-dir": "^3.0.0",
@@ -4715,7 +4717,6 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -4732,7 +4733,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4742,7 +4742,6 @@
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -5002,7 +5001,6 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5317,8 +5315,7 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/compute-gcd": {
       "version": "1.2.1",
@@ -5927,7 +5924,6 @@
       "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "strip-bom": "^4.0.0"
       },
@@ -5943,7 +5939,6 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -6336,8 +6331,7 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -6370,6 +6364,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6426,6 +6421,7 @@
       "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6822,6 +6818,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7176,7 +7173,6 @@
       "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -7195,7 +7191,6 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -7212,7 +7207,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -7239,7 +7233,6 @@
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
       "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "micromatch": "^4.0.2"
       }
@@ -7377,8 +7370,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -7392,7 +7384,6 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -7708,7 +7699,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -7734,7 +7724,6 @@
       "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-stream": "^2.0.0",
         "type-fest": "^0.8.0"
@@ -7752,7 +7741,6 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -7766,7 +7754,6 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8260,8 +8247,7 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -8282,7 +8268,6 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8351,7 +8336,6 @@
       "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "append-transform": "^2.0.0"
       },
@@ -8382,7 +8366,6 @@
       "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "archy": "^1.0.0",
         "cross-spawn": "^7.0.3",
@@ -8579,6 +8562,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10855,7 +10839,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
       "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -10881,8 +10864,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -10907,7 +10889,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -10920,7 +10901,6 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
       "license": "Public Domain",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11048,7 +11028,6 @@
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
@@ -11364,8 +11343,7 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -11744,7 +11722,6 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -12369,7 +12346,6 @@
       "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "process-on-spawn": "^1.0.0"
       },
@@ -12441,7 +12417,6 @@
       "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.2",
@@ -12484,7 +12459,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12501,7 +12475,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12512,7 +12485,6 @@
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -12525,7 +12497,6 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12538,16 +12509,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nyc/node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nyc/node_modules/decamelize": {
       "version": "1.2.0",
@@ -12555,7 +12524,6 @@
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12565,8 +12533,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nyc/node_modules/find-up": {
       "version": "4.1.0",
@@ -12574,7 +12541,6 @@
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -12590,7 +12556,6 @@
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12612,7 +12577,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12623,7 +12587,6 @@
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -12637,7 +12600,6 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -12654,7 +12616,6 @@
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -12671,7 +12632,6 @@
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -12685,7 +12645,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12696,7 +12655,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -12706,8 +12664,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/nyc/node_modules/string-width": {
       "version": "4.2.3",
@@ -12715,7 +12672,6 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12731,7 +12687,6 @@
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12746,8 +12701,7 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/nyc/node_modules/yargs": {
       "version": "15.4.1",
@@ -12755,7 +12709,6 @@
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -12779,7 +12732,6 @@
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -12814,7 +12766,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -13315,7 +13266,6 @@
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -13339,7 +13289,6 @@
       "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.15",
         "hasha": "^5.0.0",
@@ -13471,7 +13420,6 @@
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
       "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
@@ -13501,7 +13449,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -13517,7 +13464,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13540,7 +13486,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13550,7 +13495,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -13562,15 +13506,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/patch-package/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13580,7 +13522,6 @@
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -13597,7 +13538,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13607,7 +13547,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -13879,6 +13818,7 @@
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13989,7 +13929,6 @@
       "integrity": "sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fromentries": "^1.2.0"
       },
@@ -14298,7 +14237,6 @@
       "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "es6-error": "^4.0.1"
       },
@@ -14330,8 +14268,7 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/require-relative": {
       "version": "0.8.7",
@@ -14630,6 +14567,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14775,15 +14713,13 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -15065,7 +15001,6 @@
       "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "foreground-child": "^2.0.0",
         "is-windows": "^1.0.2",
@@ -15084,7 +15019,6 @@
       "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
@@ -15098,8 +15032,7 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/spawn-wrap/node_modules/make-dir": {
       "version": "3.1.0",
@@ -15107,7 +15040,6 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^6.0.0"
       },
@@ -15124,7 +15056,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -15134,8 +15065,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/spawn-wrap/node_modules/which": {
       "version": "2.0.2",
@@ -15143,7 +15073,6 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -15916,6 +15845,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15968,7 +15898,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -16107,7 +16038,6 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -16118,6 +16048,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16158,7 +16089,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -16400,6 +16330,7 @@
       "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -16447,6 +16378,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -16592,8 +16524,7 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/wildcard": {
       "version": "2.0.1",
@@ -16778,7 +16709,6 @@
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
@@ -16791,8 +16721,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.0",
@@ -16996,6 +16925,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
       "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -17059,6 +16989,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1217,7 +1217,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.2.6",
+    "@altimateai/dbt-integration": "^0.2.9",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -423,26 +423,54 @@ export class VSCodeCommands implements Disposable {
           }
         },
       ),
-      commands.registerCommand("dbtPowerUser.printEnvVars", () =>
-        this.pythonEnvironment.printEnvVars(),
-      ),
+      commands.registerCommand("dbtPowerUser.printEnvVars", () => {
+        const activeFolder = window.activeTextEditor
+          ? workspace.getWorkspaceFolder(window.activeTextEditor.document.uri)
+          : undefined;
+        return this.pythonEnvironment.printEnvVars(activeFolder);
+      }),
       commands.registerCommand("dbtPowerUser.diagnostics", async () => {
         try {
           this.diagnosticsOutputChannel.show();
           this.diagnosticsOutputChannel.logLine("Diagnostics started...");
           this.diagnosticsOutputChannel.logNewLine();
 
-          // Printing env vars
-          this.diagnosticsOutputChannel.logBlockWithHeader(
-            [
-              "Printing environment variables...",
-              "* Please remove any sensitive information before sending it to us",
-            ],
-            Object.entries(this.pythonEnvironment.environmentVariables).map(
-              ([key, value]) => `${key}=${value}`,
-            ),
-          );
-          this.diagnosticsOutputChannel.logNewLine();
+          // Printing env vars per project
+          const dbtProjects = this.dbtProjectContainer.getProjects();
+          if (dbtProjects.length > 0) {
+            for (const project of dbtProjects) {
+              const projectFolder = workspace.getWorkspaceFolder(
+                project.projectRoot,
+              );
+              this.diagnosticsOutputChannel.logBlockWithHeader(
+                [
+                  `Printing environment variables for project: ${project.getProjectName()}`,
+                  `  (root: ${project.projectRoot.fsPath})`,
+                  "* Please remove any sensitive information before sending it to us",
+                ],
+                Object.entries(
+                  this.pythonEnvironment.getEnvironmentVariables(projectFolder),
+                ).map(([key, value]) => `${key}=${value}`),
+              );
+              this.diagnosticsOutputChannel.logNewLine();
+            }
+          } else {
+            const activeFolder = window.activeTextEditor
+              ? workspace.getWorkspaceFolder(
+                  window.activeTextEditor.document.uri,
+                )
+              : undefined;
+            this.diagnosticsOutputChannel.logBlockWithHeader(
+              [
+                "Printing environment variables...",
+                "* Please remove any sensitive information before sending it to us",
+              ],
+              Object.entries(
+                this.pythonEnvironment.getEnvironmentVariables(activeFolder),
+              ).map(([key, value]) => `${key}=${value}`),
+            );
+            this.diagnosticsOutputChannel.logNewLine();
+          }
 
           // Printing python paths
           this.diagnosticsOutputChannel.logBlockWithHeader(

--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -196,7 +196,7 @@ export class WalkthroughCommands {
               command,
               args,
               cwd: getFirstWorkspacePath(),
-              envVars: this.pythonEnvironment.environmentVariables,
+              envVars: this.pythonEnvironment.getEnvironmentVariables(),
             })
             .completeWithTerminalOutput();
 
@@ -241,7 +241,7 @@ export class WalkthroughCommands {
                 "--force-reinstall",
               ],
               cwd: getFirstWorkspacePath(),
-              envVars: this.pythonEnvironment.environmentVariables,
+              envVars: this.pythonEnvironment.getEnvironmentVariables(),
             })
             .completeWithTerminalOutput();
           if (
@@ -339,7 +339,7 @@ export class WalkthroughCommands {
               command: this.pythonEnvironment.pythonPath,
               args,
               cwd: getFirstWorkspacePath(),
-              envVars: this.pythonEnvironment.environmentVariables,
+              envVars: this.pythonEnvironment.getEnvironmentVariables(),
             })
             .completeWithTerminalOutput();
           if (

--- a/src/dbt_client/datapilot.ts
+++ b/src/dbt_client/datapilot.ts
@@ -4,6 +4,7 @@ import {
   DBTTerminal,
 } from "@altimateai/dbt-integration";
 import { inject } from "inversify";
+import { Uri, workspace } from "vscode";
 import { PythonEnvironment } from "./pythonEnvironment";
 
 export class AltimateDatapilot {
@@ -18,13 +19,20 @@ export class AltimateDatapilot {
     private dbtConfiguration: DBTConfiguration,
   ) {}
 
+  private getWorkspaceFolder() {
+    const cwd = this.dbtConfiguration.getWorkingDirectory();
+    return cwd ? workspace.getWorkspaceFolder(Uri.file(cwd)) : undefined;
+  }
+
   async checkIfAltimateDatapilotInstalled(): Promise<string> {
     const process =
       this.commandProcessExecutionFactory.createCommandProcessExecution({
         command: this.pythonEnvironment.pythonPath,
         args: ["-c", "import datapilot;print(datapilot.__version__)"],
         cwd: this.dbtConfiguration.getWorkingDirectory(),
-        envVars: this.pythonEnvironment.environmentVariables,
+        envVars: this.pythonEnvironment.getEnvironmentVariables(
+          this.getWorkspaceFolder(),
+        ),
       });
     const { stdout, stderr } = await process.complete();
     if (stderr) {
@@ -49,7 +57,9 @@ export class AltimateDatapilot {
           `${this.packageName}==${datapilotVersion}`,
         ],
         cwd: this.dbtConfiguration.getWorkingDirectory(),
-        envVars: this.pythonEnvironment.environmentVariables,
+        envVars: this.pythonEnvironment.getEnvironmentVariables(
+          this.getWorkspaceFolder(),
+        ),
       })
       .completeWithTerminalOutput();
     if (!stdout.includes("Successfully installed") && stderr) {

--- a/src/dbt_client/pythonEnvironment.ts
+++ b/src/dbt_client/pythonEnvironment.ts
@@ -1,18 +1,28 @@
 import { DBTTerminal, EnvironmentVariables } from "@altimateai/dbt-integration";
 import { inject } from "inversify";
-import { Disposable, Event, extensions, Uri, workspace } from "vscode";
+import {
+  Disposable,
+  Event,
+  extensions,
+  Uri,
+  workspace,
+  WorkspaceFolder,
+} from "vscode";
 
 type EnvFrom = "process" | "integrated" | "dotenv";
+interface EnvVarsResult {
+  vars: EnvironmentVariables;
+  sources: Record<string, EnvFrom>;
+}
 interface PythonExecutionDetails {
   getPythonPath: () => string;
   onDidChangeExecutionDetails: Event<Uri | undefined>;
-  getEnvVars: () => EnvironmentVariables;
+  getEnvVars: (workspaceFolder?: WorkspaceFolder) => EnvVarsResult;
 }
 
 export class PythonEnvironment {
   private executionDetails?: PythonExecutionDetails;
   private disposables: Disposable[] = [];
-  private environmentVariableSource: Record<string, EnvFrom> = {};
   public allPythonPaths: { path: string; pathType: string }[] = [];
   public isPython3: boolean = true;
   private _pythonVersion?: string;
@@ -31,14 +41,17 @@ export class PythonEnvironment {
     }
   }
 
-  async printEnvVars() {
+  async printEnvVars(workspaceFolder?: WorkspaceFolder) {
     await this.dbtTerminal.show(true);
-    const envVars = this.environmentVariables;
-    this.dbtTerminal.log("Printing environment variables...\r\n");
-    for (const key in envVars) {
-      this.dbtTerminal.log(
-        `${key}=${envVars[key]}\t\tsource:${this.environmentVariableSource[key]}\r\n`,
+    if (!this.executionDetails) {
+      throw new Error(
+        "executionDetails is undefined, cannot retrieve environment variables",
       );
+    }
+    const { vars, sources } = this.executionDetails.getEnvVars(workspaceFolder);
+    this.dbtTerminal.log("Printing environment variables...\r\n");
+    for (const key in vars) {
+      this.dbtTerminal.log(`${key}=${vars[key]}\t\tsource:${sources[key]}\r\n`);
     }
   }
 
@@ -54,12 +67,18 @@ export class PythonEnvironment {
   }
 
   public get environmentVariables(): EnvironmentVariables {
+    return this.getEnvironmentVariables();
+  }
+
+  public getEnvironmentVariables(
+    workspaceFolder?: WorkspaceFolder,
+  ): EnvironmentVariables {
     if (!this.executionDetails) {
       throw new Error(
         "executionDetails is undefined, cannot retrieve environment variables",
       );
     }
-    return this.executionDetails.getEnvVars();
+    return this.executionDetails.getEnvVars(workspaceFolder).vars;
   }
 
   public get onPythonEnvironmentChanged() {
@@ -74,14 +93,22 @@ export class PythonEnvironment {
     this.executionDetails = await this.activatePythonExtension();
   }
 
-  getResolvedConfigValue(key: string) {
-    const value = workspace.getConfiguration("dbt").get<string>(key, "");
-    return this.substituteSettingsVariables(value, this.environmentVariables);
+  getResolvedConfigValue(key: string, workspaceFolder?: WorkspaceFolder) {
+    const value = workspace
+      .getConfiguration("dbt", workspaceFolder?.uri)
+      .get<string>(key, "");
+    return this.substituteSettingsVariables(
+      value,
+      this.getEnvironmentVariables(workspaceFolder),
+      workspaceFolder,
+    );
   }
 
   private substituteSettingsVariables(
     value: any,
     vsCodeEnv: EnvironmentVariables,
+    workspaceFolder?: WorkspaceFolder,
+    sources?: Record<string, EnvFrom>,
   ): any {
     if (!value) {
       return value;
@@ -103,16 +130,14 @@ export class PythonEnvironment {
         );
         this.dbtTerminal.debug(
           "pythonEnvironment:substituteSettingsVariables",
-          `Picking env var ${matchResult[1]} from ${
-            this.environmentVariableSource[matchResult[1]]
-          }`,
+          `Picking env var ${matchResult[1]} from ${sources?.[matchResult[1]]}`,
         );
       }
     }
-    value = value.replace(
-      "${workspaceFolder}",
-      workspace.workspaceFolders![0].uri.fsPath,
-    );
+    const resolvedFolder = workspaceFolder || workspace.workspaceFolders?.[0];
+    if (resolvedFolder) {
+      value = value.replace("${workspaceFolder}", resolvedFolder.uri.fsPath);
+    }
     return value;
   }
 
@@ -170,11 +195,12 @@ export class PythonEnvironment {
       // 1. process env    2. integrated terminal env    3. dot env file(we can get this from python extension)
       // Collecting env vars from all 3 places and merging them into one in the above order
       // While merging, also tagging the places from where the env var has come.
-      getEnvVars: () => {
+      getEnvVars: (workspaceFolder?: WorkspaceFolder) => {
         const envVars: EnvironmentVariables = {};
+        const sources: Record<string, EnvFrom> = {};
         for (const key in process.env) {
           envVars[key] = process.env[key];
-          this.environmentVariableSource[key] = "process";
+          sources[key] = "process";
         }
         try {
           const integratedEnv:
@@ -205,30 +231,35 @@ export class PythonEnvironment {
                 envVars[key] = this.substituteSettingsVariables(
                   integratedEnv[prop][key],
                   process.env,
+                  workspaceFolder,
+                  sources,
                 );
-                this.environmentVariableSource[key] = "integrated";
+                sources[key] = "integrated";
               }
             }
           }
-          if (api.environment) {
-            const workspacePath = workspace.workspaceFolders![0];
-            this.dbtTerminal.debug(
-              "pythonEnvironment:envVars",
-              `workspacePath:${workspacePath.uri.fsPath}`,
-            );
-            const workspaceEnv =
-              api.environments.getEnvironmentVariables(workspacePath);
-            this.dbtTerminal.debug(
-              "pythonEnvironment:envVars",
-              `workspaceEnv:${Object.keys(workspaceEnv)}`,
-            );
-            for (const key in workspaceEnv) {
-              // env var from python extension also includes env var from process env
-              // therefore only merging those env var, which are not present in process env
-              // or whose value differ from process env
-              if (!(key in envVars) || workspaceEnv[key] !== envVars[key]) {
-                envVars[key] = workspaceEnv[key];
-                this.environmentVariableSource[key] = "dotenv";
+          if (api.environments) {
+            const workspacePath =
+              workspaceFolder || workspace.workspaceFolders?.[0];
+            if (workspacePath) {
+              this.dbtTerminal.debug(
+                "pythonEnvironment:envVars",
+                `workspacePath:${workspacePath.uri.fsPath}`,
+              );
+              const workspaceEnv =
+                api.environments.getEnvironmentVariables(workspacePath);
+              this.dbtTerminal.debug(
+                "pythonEnvironment:envVars",
+                `workspaceEnv:${Object.keys(workspaceEnv)}`,
+              );
+              for (const key in workspaceEnv) {
+                // env var from python extension also includes env var from process env
+                // therefore only merging those env var, which are not present in process env
+                // or whose value differ from process env
+                if (!(key in envVars) || workspaceEnv[key] !== envVars[key]) {
+                  envVars[key] = workspaceEnv[key];
+                  sources[key] = "dotenv";
+                }
               }
             }
           }
@@ -240,7 +271,7 @@ export class PythonEnvironment {
           );
         }
 
-        return envVars;
+        return { vars: envVars, sources };
       },
     });
   }

--- a/src/dbt_client/runtimePythonEnvironmentProvider.ts
+++ b/src/dbt_client/runtimePythonEnvironmentProvider.ts
@@ -1,8 +1,10 @@
 import {
+  EnvironmentVariables,
   PythonEnvironmentProvider,
   RuntimePythonEnvironment,
 } from "@altimateai/dbt-integration";
 import { inject, injectable } from "inversify";
+import { Uri, workspace } from "vscode";
 import { PythonEnvironment } from "./pythonEnvironment";
 
 @injectable()
@@ -28,7 +30,16 @@ export class VSCodeRuntimePythonEnvironmentProvider
   getCurrentEnvironment(): RuntimePythonEnvironment {
     return {
       pythonPath: this.vscodeEnvironment.pythonPath,
-      environmentVariables: this.vscodeEnvironment.environmentVariables,
+      getEnvironmentVariables: (
+        workspacePath: string,
+      ): EnvironmentVariables => {
+        // workspacePath may be undefined at runtime when called by dbt-integration
+        // code that hasn't been updated to pass it yet (e.g. DBTCoreDetection)
+        const folder = workspacePath
+          ? workspace.getWorkspaceFolder(Uri.file(workspacePath))
+          : undefined;
+        return this.vscodeEnvironment.getEnvironmentVariables(folder);
+      },
     };
   }
 
@@ -60,7 +71,12 @@ export class StaticRuntimePythonEnvironment
     return this.vscodeEnvironment.pythonPath;
   }
 
-  get environmentVariables() {
-    return this.vscodeEnvironment.environmentVariables;
+  getEnvironmentVariables(workspacePath: string): EnvironmentVariables {
+    // workspacePath may be undefined at runtime when called by dbt-integration
+    // code that hasn't been updated to pass it yet (e.g. DBTCoreDetection)
+    const folder = workspacePath
+      ? workspace.getWorkspaceFolder(Uri.file(workspacePath))
+      : undefined;
+    return this.vscodeEnvironment.getEnvironmentVariables(folder);
   }
 }

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -28,6 +28,7 @@ import {
   DeferConfig,
   DocParser,
   ExposureParser,
+  FunctionParser,
   GraphParser,
   MacroParser,
   MetricParser,
@@ -71,6 +72,7 @@ import { SharedStateService } from "./services/sharedStateService";
 import { StreamingService } from "./services/streamingService";
 import { UsersService } from "./services/usersService";
 import { TelemetryService } from "./telemetry";
+
 import { ValidationProvider } from "./validation_provider";
 
 // Core extension components
@@ -193,6 +195,11 @@ container
     (context) => new ExposureParser(context.container.get("DBTTerminal")),
   );
 container
+  .bind(FunctionParser)
+  .toDynamicValue(
+    (context) => new FunctionParser(context.container.get("DBTTerminal")),
+  );
+container
   .bind(DocParser)
   .toDynamicValue(
     (context) => new DocParser(context.container.get("DBTTerminal")),
@@ -221,16 +228,28 @@ container
   .inSingletonScope();
 
 container
-  .bind(PythonDBTCommandExecutionStrategy)
-  .toDynamicValue((context) => {
-    return new PythonDBTCommandExecutionStrategy(
-      context.container.get(CommandProcessExecutionFactory),
-      context.container.get("RuntimePythonEnvironment"),
-      context.container.get("DBTTerminal"),
-      context.container.get("DBTConfiguration"),
-    );
-  })
-  .inSingletonScope();
+  .bind<
+    interfaces.Factory<PythonDBTCommandExecutionStrategy>
+  >("Factory<PythonDBTCommandExecutionStrategy>")
+  .toFactory<
+    PythonDBTCommandExecutionStrategy,
+    [string]
+  >((context: interfaces.Context) => {
+    return (projectRoot: string) => {
+      const { container } = context;
+      const baseConfig = container.get<DBTConfiguration>("DBTConfiguration");
+      // Create a per-project config that returns the correct working directory
+      // so that PythonDBTCommandExecutionStrategy resolves the right .env file
+      const projectConfig = Object.create(baseConfig) as DBTConfiguration;
+      projectConfig.getWorkingDirectory = () => projectRoot;
+      return new PythonDBTCommandExecutionStrategy(
+        container.get(CommandProcessExecutionFactory),
+        container.get("RuntimePythonEnvironment"),
+        container.get("DBTTerminal"),
+        projectConfig,
+      );
+    };
+  });
 
 container.bind(DBTCommandExecutionInfrastructure).toDynamicValue((context) => {
   return new DBTCommandExecutionInfrastructure(
@@ -544,11 +563,14 @@ container
       onDiagnosticsChanged: () => void,
     ) => {
       const { container } = context;
+      const pythonStrategyFactory = container.get<
+        (projectRoot: string) => PythonDBTCommandExecutionStrategy
+      >("Factory<PythonDBTCommandExecutionStrategy>");
       return new DBTCoreProjectIntegration(
         container.get(DBTCommandExecutionInfrastructure),
         container.get("RuntimePythonEnvironment"),
         container.get("PythonEnvironmentProvider"),
-        container.get(PythonDBTCommandExecutionStrategy),
+        pythonStrategyFactory(projectRoot),
         container.get("Factory<CLIDBTCommandExecutionStrategy>"),
         container.get("DBTTerminal"),
         container.get("DBTConfiguration"),
@@ -576,11 +598,14 @@ container
       onDiagnosticsChanged: () => void,
     ) => {
       const { container } = context;
+      const pythonStrategyFactory = container.get<
+        (projectRoot: string) => PythonDBTCommandExecutionStrategy
+      >("Factory<PythonDBTCommandExecutionStrategy>");
       return new DBTCoreCommandProjectIntegration(
         container.get(DBTCommandExecutionInfrastructure),
         container.get("RuntimePythonEnvironment"),
         container.get("PythonEnvironmentProvider"),
-        container.get(PythonDBTCommandExecutionStrategy),
+        pythonStrategyFactory(projectRoot),
         container.get("Factory<CLIDBTCommandExecutionStrategy>"),
         container.get("DBTTerminal"),
         container.get("DBTConfiguration"),
@@ -680,6 +705,7 @@ container
         container.get(SourceParser),
         container.get(TestParser),
         container.get(ExposureParser),
+        container.get(FunctionParser),
         container.get(DocParser),
         container.get("DBTTerminal"),
         container.get(ModelDepthParser),

--- a/src/test/suite/dbtCloudDetection.test.ts
+++ b/src/test/suite/dbtCloudDetection.test.ts
@@ -3,28 +3,31 @@ import {
   CommandProcessExecutionFactory,
   DBTCloudDetection,
   DBTTerminal,
+  RuntimePythonEnvironment,
 } from "@altimateai/dbt-integration";
 import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
 import { anything, instance, mock, when } from "ts-mockito";
 import { workspace } from "vscode";
-import { PythonEnvironment } from "../../dbt_client/pythonEnvironment";
 import { VSCodeDBTTerminal } from "../../dbt_client/vscodeTerminal";
 
 describe("DBTCloudDetection Tests", () => {
   let mockCommandProcessExecutionFactory: CommandProcessExecutionFactory;
-  let mockPythonEnvironment: PythonEnvironment;
+  let mockPythonEnvironment: RuntimePythonEnvironment;
   let mockTerminal: DBTTerminal;
   let mockCommandProcessExecution: CommandProcessExecution;
   let dbtCloudDetection: DBTCloudDetection;
 
   beforeEach(() => {
     mockCommandProcessExecutionFactory = mock(CommandProcessExecutionFactory);
-    mockPythonEnvironment = mock(PythonEnvironment);
     mockTerminal = mock(VSCodeDBTTerminal);
     mockCommandProcessExecution = mock<CommandProcessExecution>();
 
+    mockPythonEnvironment = {
+      pythonPath: "/usr/bin/python3",
+      getEnvironmentVariables: jest.fn().mockReturnValue({}),
+    };
+
     // Setup default mocks
-    when(mockPythonEnvironment.pythonPath).thenReturn("/usr/bin/python3");
     when(mockTerminal.debug(anything(), anything())).thenReturn();
     when(
       mockCommandProcessExecutionFactory.createCommandProcessExecution(
@@ -40,7 +43,7 @@ describe("DBTCloudDetection Tests", () => {
 
     dbtCloudDetection = new DBTCloudDetection(
       instance(mockCommandProcessExecutionFactory),
-      instance(mockPythonEnvironment),
+      mockPythonEnvironment,
       instance(mockTerminal),
     );
   });

--- a/src/test/suite/dbtCoreDetection.test.ts
+++ b/src/test/suite/dbtCoreDetection.test.ts
@@ -52,7 +52,9 @@ describe("DBTCoreDetection Tests", () => {
 
     mockPythonEnvironment = {
       pythonPath: "/path/to/python",
-      environmentVariables: { PATH: "/some/path" },
+      getEnvironmentVariables: jest
+        .fn()
+        .mockReturnValue({ PATH: "/some/path" }),
     } as unknown as jest.Mocked<PythonEnvironment>;
 
     detection = new DBTCoreDetection(

--- a/src/test/suite/dbtCoreIntegration.test.ts
+++ b/src/test/suite/dbtCoreIntegration.test.ts
@@ -36,7 +36,7 @@ describe("DBTCoreDetection Tests", () => {
 
     mockPythonEnvironment = {
       pythonPath: "/usr/bin/python3",
-      environmentVariables: {},
+      getEnvironmentVariables: jest.fn().mockReturnValue({}),
     } as any;
 
     // Create the instance with mocked dependencies

--- a/src/test/suite/dbtIntegration.test.ts
+++ b/src/test/suite/dbtIntegration.test.ts
@@ -4,14 +4,14 @@ import {
   CommandProcessExecutionFactory,
   DBTCommand,
   DBTTerminal,
+  RuntimePythonEnvironment,
 } from "@altimateai/dbt-integration";
 import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
-import { PythonEnvironment } from "../../dbt_client/pythonEnvironment";
 
 describe("CLIDBTCommandExecutionStrategy Tests", () => {
   let strategy: CLIDBTCommandExecutionStrategy;
   let mockCommandProcessExecutionFactory: jest.Mocked<CommandProcessExecutionFactory>;
-  let mockPythonEnvironment: jest.Mocked<PythonEnvironment>;
+  let mockPythonEnvironment: jest.Mocked<RuntimePythonEnvironment>;
   let mockTerminal: jest.Mocked<DBTTerminal>;
   let mockCommandProcessExecution: jest.Mocked<CommandProcessExecution>;
 
@@ -42,7 +42,10 @@ describe("CLIDBTCommandExecutionStrategy Tests", () => {
     mockPythonEnvironment = {
       pythonPath: "/path/to/python",
       environmentVariables: { PATH: "/some/path" },
-    } as unknown as jest.Mocked<PythonEnvironment>;
+      getEnvironmentVariables: jest
+        .fn()
+        .mockReturnValue({ PATH: "/some/path" }),
+    } as unknown as jest.Mocked<RuntimePythonEnvironment>;
 
     mockTerminal = {
       show: jest.fn(),

--- a/src/test/suite/runtimePythonEnvironmentProvider.test.ts
+++ b/src/test/suite/runtimePythonEnvironmentProvider.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { Uri, workspace } from "vscode";
+import { PythonEnvironment } from "../../dbt_client/pythonEnvironment";
+import {
+  StaticRuntimePythonEnvironment,
+  VSCodeRuntimePythonEnvironmentProvider,
+} from "../../dbt_client/runtimePythonEnvironmentProvider";
+
+describe("StaticRuntimePythonEnvironment", () => {
+  let mockVscodeEnvironment: jest.Mocked<
+    Pick<
+      PythonEnvironment,
+      "pythonPath" | "environmentVariables" | "getEnvironmentVariables"
+    >
+  >;
+  let staticEnv: StaticRuntimePythonEnvironment;
+
+  beforeEach(() => {
+    mockVscodeEnvironment = {
+      pythonPath: "/usr/bin/python3",
+      environmentVariables: { HOME: "/home/user" },
+      getEnvironmentVariables: jest
+        .fn()
+        .mockReturnValue({ HOME: "/home/user" }),
+    } as any;
+
+    // Construct without DI — pass mock directly
+    staticEnv = Object.create(StaticRuntimePythonEnvironment.prototype);
+    (staticEnv as any).vscodeEnvironment = mockVscodeEnvironment;
+  });
+
+  it("should return pythonPath from vscodeEnvironment", () => {
+    expect(staticEnv.pythonPath).toBe("/usr/bin/python3");
+  });
+
+  it("should resolve workspace folder when path is provided", () => {
+    const mockFolder = {
+      uri: { fsPath: "/workspace/project" },
+      name: "project",
+      index: 0,
+    };
+    const folderEnv = { DBT_TARGET: "dev" };
+    mockVscodeEnvironment.getEnvironmentVariables.mockReturnValue(folderEnv);
+
+    // Mock workspace.getWorkspaceFolder
+    const originalGetWorkspaceFolder = (workspace as any).getWorkspaceFolder;
+    (workspace as any).getWorkspaceFolder = jest
+      .fn()
+      .mockReturnValue(mockFolder);
+
+    const result = staticEnv.getEnvironmentVariables("/workspace/project");
+
+    expect((workspace as any).getWorkspaceFolder).toHaveBeenCalledWith(
+      Uri.file("/workspace/project"),
+    );
+    expect(mockVscodeEnvironment.getEnvironmentVariables).toHaveBeenCalledWith(
+      mockFolder,
+    );
+    expect(result).toEqual(folderEnv);
+
+    // Restore
+    (workspace as any).getWorkspaceFolder = originalGetWorkspaceFolder;
+  });
+
+  it("should fall back to default env when workspacePath is undefined", () => {
+    const defaultEnv = { HOME: "/home/user" };
+    mockVscodeEnvironment.getEnvironmentVariables.mockReturnValue(defaultEnv);
+
+    // Simulate dbt-integration calling without args (before PR #33 lands)
+    const result = (staticEnv as any).getEnvironmentVariables(undefined);
+
+    expect(mockVscodeEnvironment.getEnvironmentVariables).toHaveBeenCalledWith(
+      undefined,
+    );
+    expect(result).toEqual(defaultEnv);
+  });
+
+  it("should pass undefined folder when workspace path is not found", () => {
+    const defaultEnv = { HOME: "/home/user" };
+    mockVscodeEnvironment.getEnvironmentVariables.mockReturnValue(defaultEnv);
+
+    const originalGetWorkspaceFolder = (workspace as any).getWorkspaceFolder;
+    (workspace as any).getWorkspaceFolder = jest
+      .fn()
+      .mockReturnValue(undefined);
+
+    const result = staticEnv.getEnvironmentVariables("/unknown/path");
+
+    expect((workspace as any).getWorkspaceFolder).toHaveBeenCalledWith(
+      Uri.file("/unknown/path"),
+    );
+    expect(mockVscodeEnvironment.getEnvironmentVariables).toHaveBeenCalledWith(
+      undefined,
+    );
+    expect(result).toEqual(defaultEnv);
+
+    (workspace as any).getWorkspaceFolder = originalGetWorkspaceFolder;
+  });
+});
+
+describe("VSCodeRuntimePythonEnvironmentProvider", () => {
+  let mockVscodeEnvironment: jest.Mocked<
+    Pick<
+      PythonEnvironment,
+      | "pythonPath"
+      | "environmentVariables"
+      | "getEnvironmentVariables"
+      | "initialize"
+      | "onPythonEnvironmentChanged"
+    >
+  >;
+  let provider: VSCodeRuntimePythonEnvironmentProvider;
+
+  beforeEach(() => {
+    mockVscodeEnvironment = {
+      pythonPath: "/usr/bin/python3",
+      environmentVariables: { KEY: "value" },
+      getEnvironmentVariables: jest.fn().mockReturnValue({ KEY: "value" }),
+      initialize: jest.fn().mockResolvedValue(undefined),
+      onPythonEnvironmentChanged: jest.fn(),
+    } as any;
+
+    // Construct without DI
+    provider = Object.create(VSCodeRuntimePythonEnvironmentProvider.prototype);
+    (provider as any).vscodeEnvironment = mockVscodeEnvironment;
+    (provider as any).callbacks = [];
+  });
+
+  it("should return environment with correct pythonPath", () => {
+    const env = provider.getCurrentEnvironment();
+    expect(env.pythonPath).toBe("/usr/bin/python3");
+  });
+
+  it("should return environment with getEnvironmentVariables that resolves workspace paths", () => {
+    const mockFolder = {
+      uri: { fsPath: "/workspace/project" },
+      name: "project",
+      index: 0,
+    };
+    const folderEnv = { DBT_TARGET: "prod" };
+    mockVscodeEnvironment.getEnvironmentVariables.mockReturnValue(folderEnv);
+
+    const originalGetWorkspaceFolder = (workspace as any).getWorkspaceFolder;
+    (workspace as any).getWorkspaceFolder = jest
+      .fn()
+      .mockReturnValue(mockFolder);
+
+    const env = provider.getCurrentEnvironment();
+    const result = env.getEnvironmentVariables("/workspace/project");
+
+    expect(result).toEqual(folderEnv);
+    expect(mockVscodeEnvironment.getEnvironmentVariables).toHaveBeenCalledWith(
+      mockFolder,
+    );
+
+    (workspace as any).getWorkspaceFolder = originalGetWorkspaceFolder;
+  });
+
+  it("should register and unregister change callbacks", () => {
+    const callback = jest.fn();
+    const unregister = provider.onEnvironmentChanged(callback);
+
+    expect((provider as any).callbacks).toContain(callback);
+
+    unregister();
+    expect((provider as any).callbacks).not.toContain(callback);
+  });
+});

--- a/test-fixtures/.gitignore
+++ b/test-fixtures/.gitignore
@@ -1,0 +1,5 @@
+# dbt artifacts
+target/
+dbt_packages/
+dbt_modules/
+logs/

--- a/test-fixtures/first-dbt-project/.env
+++ b/test-fixtures/first-dbt-project/.env
@@ -1,0 +1,1 @@
+FIRST_ONLY_VAR=from_first_folder

--- a/test-fixtures/first-dbt-project/dbt_project.yml
+++ b/test-fixtures/first-dbt-project/dbt_project.yml
@@ -1,0 +1,7 @@
+name: first_dbt_project
+version: "1.0.0"
+config-version: 2
+
+profile: first_dbt_project
+
+model-paths: ["models"]

--- a/test-fixtures/first-dbt-project/models/example.sql
+++ b/test-fixtures/first-dbt-project/models/example.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/test-fixtures/second-dbt-project/.env
+++ b/test-fixtures/second-dbt-project/.env
@@ -1,0 +1,2 @@
+SECOND_DB_PATH=/tmp/second.duckdb
+SECOND_ONLY_VAR=from_second_folder

--- a/test-fixtures/second-dbt-project/.gitignore
+++ b/test-fixtures/second-dbt-project/.gitignore
@@ -1,0 +1,3 @@
+target/
+dbt_packages/
+logs/

--- a/test-fixtures/second-dbt-project/dbt_project.yml
+++ b/test-fixtures/second-dbt-project/dbt_project.yml
@@ -1,0 +1,6 @@
+name: second_dbt_project
+version: "1.0.0"
+config-version: 2
+profile: second_dbt_project
+
+model-paths: ["models"]

--- a/test-fixtures/second-dbt-project/models/example.sql
+++ b/test-fixtures/second-dbt-project/models/example.sql
@@ -1,0 +1,1 @@
+select 1 as id


### PR DESCRIPTION
## Summary

Fixes Issue #1823

- Went through manual testing workflows defined below.
<img width="2067" height="1295" alt="image" src="https://github.com/user-attachments/assets/d476bc30-ce24-44d1-8e2e-d8eb87993ede" />



The `PythonEnvironment` singleton previously hardcoded `workspace.workspaceFolders![0]` when loading `.env` variables via the Python extension API, causing `env_var required but not provided` errors for dbt projects in the 2nd/3rd/Nth folder of a multi-root workspace.

### Changes
  - package.json — Bump @altimateai/dbt-integration to ^0.2.8, which adds getEnvironmentVariables(workspacePath?) to RuntimePythonEnvironment and exports FunctionParser
  - src/dbt_client/pythonEnvironment.ts — Core fix: the getEnvVars closure previously always read .env from workspaceFolders![0], so the 2nd+ folder in a multi-root workspace never got its own env vars. Now accepts an optional
  WorkspaceFolder and passes it through to the Python extension API. Also fixes the api.environment → api.environments (plural) guard that silently skipped .env loading, and makes substituteSettingsVariables /
  getResolvedConfigValue workspace-folder-aware
  - src/commands/index.ts — printEnvVars and diagnostics commands now resolve the active editor's workspace folder, so output reflects the project you're editing rather than always the first folder
  - src/commands/walkthroughCommands.ts — Install commands explicitly pass workspaceFolders?.[0] to getEnvironmentVariables() instead of using the unscoped getter, since these commands lack project context
  - src/dbt_client/runtimePythonEnvironmentProvider.ts — Implements getEnvironmentVariables(workspacePath?) on both VSCodeRuntimePythonEnvironmentProvider and StaticRuntimePythonEnvironment, bridging string paths from the
  integration interface to VSCode WorkspaceFolder objects
  - src/inversify.config.ts — Registers FunctionParser in the DI container, required by the @altimateai/dbt-integration@^0.2.8 upgrade
  - src/test/suite/dbtCloudDetection.test.ts, dbtCoreDetection.test.ts, dbtCoreIntegration.test.ts, dbtIntegration.test.ts — Updated mocks to satisfy the new getEnvironmentVariables method on RuntimePythonEnvironment

### Scope note

Full per-project env var resolution in dbt command execution (execution strategies, python bridge creation) requires a corresponding change in `@altimateai/dbt-integration` to thread workspace path through the `RuntimePythonEnvironment` interface. That change is in [altimate-dbt-integration#32](https://github.com/AltimateAI/altimate-dbt-integration/pull/32). Once that PR is merged and a new package version is published, a follow-up PR will:

1. Bump `@altimateai/dbt-integration` dependency
2. Implement `getEnvironmentVariables(workspacePath)` on `StaticRuntimePythonEnvironment` and `VSCodeRuntimePythonEnvironmentProvider`
3. Update test mocks to satisfy the updated interface

This PR covers the extension-side changes: all direct callers of `PythonEnvironment.getEnvironmentVariables()` and user-facing commands.

### Backward compatibility

- `environmentVariables` getter (no args) still defaults to first workspace folder
- All existing callers that don't pass a folder continue working unchanged

## Test plan

### Automated
- [x] `npm run test-compile` — TypeScript compilation passes
- [x] `npx jest` — All 17 test suites pass (195 tests)

### Manual testing steps

  ### Prerequisites

  - Open the extension repo in VSCode
  - Press **F5** to launch the Extension Development Host
  - In the Extension Development Host, open the multi-root workspace: `File > Open Workspace from File...` → select `test-fixtures/multi-root.code-workspace`
  - Select Python interpreter: `Cmd+Shift+P` → `Python: Select Interpreter` → choose a Python with dbt-core installed (e.g., `/Users/<you>/.dbt-venv/bin/python`)

  ### Test A: Per-project environment variable loading

  1. **Run diagnostics**: `Cmd+Shift+P` → `dbt Power User: Diagnostics`
  2. **Verify two projects detected**: Output should show `Number of projects=2`
  3. **Verify per-project env var blocks**: Output should show two separate sections:
     Printing environment variables for project: unknown_
       (root: .../test-fixtures/first-dbt-project)
     ...
     FIRST_ONLY_VAR=from_first_folder

     Printing environment variables for project: unknown_
       (root: .../test-fixtures/second-dbt-project)
     ...
     SECOND_DB_PATH=/tmp/second.duckdb
     SECOND_ONLY_VAR=from_second_folder
  4. **Key checks**:
  - Each project block shows its own `.env` values
  - The second project's block includes `SECOND_DB_PATH` and `SECOND_ONLY_VAR` which are NOT in the first project's `.env`
  - The first project's block includes `FIRST_ONLY_VAR` which is NOT in the second project's `.env`

  **Note**: Project names show as `unknown_<uuid>` because the test fixtures don't have `profiles.yml` configured. The "Could not find profile" diagnostic errors are expected.

  ### Test B: Walkthrough prerequisites and dbt detection

  1. **Open the walkthrough**: `Cmd+Shift+P` → `Get Started with dbt Power User`
  2. **Verify prerequisites pass**:
  - Python Interpreter: green checkmark, shows the selected Python path
  - dbt Installation: green checkmark (dbt detected in the selected Python env)
  - File Associations: configure if prompted
  3. **Verify project dropdown**: In the "Validate Setup" step, the dropdown should list two projects (both with `unknown_` prefix since profiles are missing)
  4. **"Install dbt" button** (optional — only if dbt is not already installed):
  - Click "Install dbt" → select Core → choose version and adapter
  - Verify pip install runs with a progress notification
  - The install uses global (unscoped) env vars — it should work regardless of which file is open

### Results

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment variable handling is now scoped to the active workspace folder, improving multi-root workspace behavior and making "print env" reflect the current folder.

* **Tests**
  * Added integration tests to validate per-folder Python environment handling in multi-root workspaces.

* **Chores**
  * Added sample multi-root project fixtures and updated test ignore patterns to support DBT-related artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->