### PR TITLE
fix: scope defer config reads to target project root

### DIFF
--- a/src/dbt_client/dbtProject.ts
+++ b/src/dbt_client/dbtProject.ts
@@ -1769,7 +1769,7 @@ export class DBTProject implements Disposable {
   private retrieveDeferConfigFromSettings(): DeferConfig | undefined {
     const relativePath = getProjectRelativePath(this.projectRoot);
     const currentConfig: Record<string, DeferConfig> = workspace
-      .getConfiguration("dbt")
+      .getConfiguration("dbt", this.projectRoot)
       .get("deferConfigPerProject", {});
     if (currentConfig[relativePath]) {
       const config = currentConfig[relativePath];

--- a/src/webview_provider/insightsPanel.ts
+++ b/src/webview_provider/insightsPanel.ts
@@ -169,7 +169,7 @@ export class InsightsPanel extends AltimateWebviewProvider {
       );
 
       const currentConfig: Record<string, DeferConfig> = workspace
-        .getConfiguration("dbt")
+        .getConfiguration("dbt", Uri.file(params.projectRoot))
         .get("deferConfigPerProject", {});
       const root = getProjectRelativePath(Uri.file(params.projectRoot));
 
@@ -669,7 +669,9 @@ export class InsightsPanel extends AltimateWebviewProvider {
         break;
       case "getDeferToProductionConfig":
         const { projectRoot } = params as { projectRoot?: string };
-        const project = this.getCurrentProject();
+        const project = projectRoot
+          ? this.dbtProjectContainer.findDBTProject(Uri.file(projectRoot))
+          : this.getCurrentProject();
         if (!project) {
           this.sendResponseToWebview({
             command: "response",


### PR DESCRIPTION
## Summary

In multi-root workspaces, the defer-to-production config (`dbt.deferConfigPerProject`) could show stale state and corrupt saved settings.

### Root cause

**1. Unscoped config reads**

`workspace.getConfiguration("dbt")` without a scope URI resolves settings based on the active editor's workspace folder. In a multi-root workspace, if the active editor is in a different workspace folder than the dbt project, VS Code looks up settings from the wrong folder's `.vscode/settings.json`, returning `{}`.

The **write** side was already correct — `updateDeferConfig()` scopes to the project root:

```typescript
const workspaceFolder = workspace.getWorkspaceFolder(Uri.file(params.projectRoot));
workspace.getConfiguration("dbt", workspaceFolder).update("deferConfigPerProject", newConfig, target);
```

But the **read** used for merging was unscoped:

```typescript
const currentConfig = workspace
  .getConfiguration("dbt")              // ← no scope, falls back to active editor
  .get("deferConfigPerProject", {});
const newConfig = { ...currentConfig, [root]: { ...currentConfig[root], ...updates } };
```

So the write goes to the right file, but the merge-read pulls `{}` from the wrong scope. The result: it correctly writes **garbage** to the correct location — only the toggled key survives, all other config keys (`deferToProduction`, `manifestPathForDeferral`, etc.) are lost.

**2. Project lookup ignores webview-provided `projectRoot`**

`getDeferToProductionConfig` destructures `projectRoot` from the webview params but never uses it — it always calls `getCurrentProject()`, which depends on the active editor. When the active editor is outside the dbt project folder, this returns "No project selected" and the Actions tab shows empty config.

### Fix

- Pass the project root URI as the scope to `getConfiguration("dbt", scope)` at both read sites, matching the write scope.
- Use the webview-provided `projectRoot` param to find the project in `getDeferToProductionConfig`, falling back to `getCurrentProject()` when not provided.

### Changes

- **`insightsPanel.ts`**: `updateDeferConfig()` merge-read scoped to `Uri.file(params.projectRoot)`.
- **`insightsPanel.ts`**: `getDeferToProductionConfig` uses `projectRoot` param via `findDBTProject(Uri.file(projectRoot))`, falls back to `getCurrentProject()`.
- **`dbtProject.ts`**: `retrieveDeferConfigFromSettings()` scoped to `this.projectRoot`.

## Test plan

- [ ] Rebuild: `npm run webpack`
- [ ] F5 → Extension Dev Host with a multi-root workspace (dbt project folder + another folder)
- [ ] Active editor in the non-dbt folder
- [ ] Actions tab should show correct defer state for the dbt project (project lookup fix)
- [ ] Toggle favor-state → check `.vscode/settings.json` retains all keys (merge-read fix)
- [ ] Reload window → defer state persists
- [ ] Run `dbt build` with defer on → compiled SQL resolves upstream refs to prod schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)