### PR TITLE
feat: dbt 1.11 UDF (function) nodes in lineage view

### DIFF
--- a/src/domain.ts
+++ b/src/domain.ts
@@ -6,6 +6,7 @@ export type MetricMetaMap = Map<string, MetricMetaData>;
 export type SourceMetaMap = Map<string, SourceMetaData>;
 export type TestMetaMap = Map<string, TestMetaData>;
 export type ExposureMetaMap = Map<string, ExposureMetaData>;
+export type FunctionMetaMap = Map<string, FunctionMetaData>;
 export type DocMetaMap = Map<string, DocMetaData>;
 export type NodeMetaType = NodeMetaData;
 export type SourceMetaType = SourceTable;
@@ -133,6 +134,41 @@ export interface ExposureMetaData {
   meta?: Record<string, unknown>;
 }
 
+export interface FunctionArgument {
+  name: string;
+  data_type: string;
+  description?: string;
+  default_value?: string;
+}
+
+export interface FunctionReturns {
+  data_type: string;
+  description?: string;
+}
+
+export interface FunctionMetaData {
+  unique_id: string;
+  name: string;
+  database?: string;
+  schema?: string;
+  description?: string;
+  depends_on: DependsOn;
+  path: string | undefined;
+  package_name: string;
+  is_external_project: boolean;
+  resource_type: string;
+  config: {
+    materialized?: string;
+    type?: string;
+    volatility?: string;
+    runtime_version?: string;
+    entry_point?: string;
+  };
+  arguments?: FunctionArgument[];
+  returns?: FunctionReturns;
+  meta?: Record<string, unknown>;
+}
+
 interface NodeGraphMetaData {
   currentNode: Node;
   nodes: Node[];
@@ -196,6 +232,9 @@ export class Analysis extends Node {
   displayInModelTree = true;
 }
 export class Exposure extends Node {
+  displayInModelTree = true;
+}
+export class Function extends Node {
   displayInModelTree = true;
 }
 export class Metric extends Node {

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -78,6 +78,7 @@ export class DBTProject implements Disposable {
   static RESOURCE_TYPE_SNAPSHOT = "snapshot";
   static RESOURCE_TYPE_TEST = "test";
   static RESOURCE_TYPE_METRIC = "semantic_model";
+  static RESOURCE_TYPE_FUNCTION = "function";
 
   readonly projectRoot: Uri;
   private projectConfig: any; // TODO: typing

--- a/src/manifest/event/manifestCacheChangedEvent.ts
+++ b/src/manifest/event/manifestCacheChangedEvent.ts
@@ -2,6 +2,7 @@ import { Uri } from "vscode";
 import {
   DocMetaMap,
   ExposureMetaMap,
+  FunctionMetaMap,
   GraphMetaMap,
   MacroMetaMap,
   MetricMetaMap,
@@ -21,6 +22,7 @@ export interface ManifestCacheProjectAddedEvent {
   testMetaMap: TestMetaMap;
   docMetaMap: DocMetaMap;
   exposureMetaMap: ExposureMetaMap;
+  functionMetaMap: FunctionMetaMap;
 }
 
 export interface ManifestCacheProjectRemovedEvent {

--- a/src/manifest/parsers/functionParser.ts
+++ b/src/manifest/parsers/functionParser.ts
@@ -1,0 +1,45 @@
+import { provide } from "inversify-binding-decorators";
+import * as path from "path";
+import { FunctionMetaMap } from "../../domain";
+import { DBTProject } from "../dbtProject";
+import { DBTTerminal } from "../../dbt_client/dbtTerminal";
+
+@provide(FunctionParser)
+export class FunctionParser {
+  constructor(private terminal: DBTTerminal) {}
+
+  createFunctionMetaMap(
+    functionsMap: any[],
+    project: DBTProject,
+  ): Promise<FunctionMetaMap> {
+    return new Promise((resolve) => {
+      this.terminal.debug(
+        "FunctionParser",
+        `Parsing functions for "${project.getProjectName()}" at ${
+          project.projectRoot
+        }`,
+      );
+      const functionMetaMap: FunctionMetaMap = new Map();
+      if (functionsMap === null || functionsMap === undefined) {
+        resolve(functionMetaMap);
+        return;
+      }
+      Object.values(functionsMap)
+        .filter((fn) => fn.resource_type === DBTProject.RESOURCE_TYPE_FUNCTION)
+        .forEach((fn) => {
+          const fullPath = fn.original_file_path
+            ? path.join(project.projectRoot.fsPath, fn.original_file_path)
+            : undefined;
+          functionMetaMap.set(fn.name, { ...fn, path: fullPath });
+        });
+      this.terminal.debug(
+        "FunctionParser",
+        `Returning functions for "${project.getProjectName()}" at ${
+          project.projectRoot
+        }`,
+        functionMetaMap,
+      );
+      resolve(functionMetaMap);
+    });
+  }
+}

--- a/src/manifest/parsers/graphParser.ts
+++ b/src/manifest/parsers/graphParser.ts
@@ -2,6 +2,7 @@ import { provide } from "inversify-binding-decorators";
 import {
   Analysis,
   Exposure,
+  Function,
   GraphMetaMap,
   Metric,
   MetricMetaMap,
@@ -187,6 +188,9 @@ export class GraphParser {
         }
         case "semantic_model": {
           return new Metric(nodeName, parentNodeName);
+        }
+        case "function": {
+          return new Function(nodeName, parentNodeName);
         }
         default:
           console.log(`Node Type '${nodeType}' not implemented!`);

--- a/src/manifest/parsers/index.ts
+++ b/src/manifest/parsers/index.ts
@@ -13,6 +13,7 @@ import { SourceParser } from "./sourceParser";
 import { TestParser } from "./testParser";
 import { TelemetryService } from "../../telemetry";
 import { ExposureParser } from "./exposureParser";
+import { FunctionParser } from "./functionParser";
 import { MetricParser } from "./metricParser";
 
 @provide(ManifestParser)
@@ -27,6 +28,7 @@ export class ManifestParser {
     private sourceParser: SourceParser,
     private testParser: TestParser,
     private exposureParser: ExposureParser,
+    private functionParser: FunctionParser,
     private docParser: DocParser,
     private terminal: DBTTerminal,
     private telemetry: TelemetryService,
@@ -68,6 +70,7 @@ export class ManifestParser {
             },
             docMetaMap: new Map(),
             exposureMetaMap: new Map(),
+            functionMetaMap: new Map(),
           },
         ],
       };
@@ -83,6 +86,7 @@ export class ManifestParser {
       child_map,
       docs,
       exposures,
+      functions,
     } = manifest;
 
     const nodeMetaMapPromise = this.nodeParser.createNodeMetaMap(
@@ -109,6 +113,10 @@ export class ManifestParser {
       exposures,
       project,
     );
+    const functionMetaMapPromise = this.functionParser.createFunctionMetaMap(
+      functions,
+      project,
+    );
 
     const docMetaMapPromise = this.docParser.createDocMetaMap(docs, project);
 
@@ -120,6 +128,7 @@ export class ManifestParser {
       testMetaMap,
       docMetaMap,
       exposureMetaMap,
+      functionMetaMap,
     ] = await Promise.all([
       nodeMetaMapPromise,
       macroMetaMapPromise,
@@ -128,6 +137,7 @@ export class ManifestParser {
       testMetaMapPromise,
       docMetaMapPromise,
       exposuresMetaMapPromise,
+      functionMetaMapPromise,
     ]);
 
     const graphMetaMap = this.graphParser.createGraphMetaMap(
@@ -181,6 +191,7 @@ export class ManifestParser {
           testMetaMap: testMetaMap,
           docMetaMap: docMetaMap,
           exposureMetaMap: exposureMetaMap,
+          functionMetaMap: functionMetaMap,
         },
       ],
     };

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -19,6 +19,7 @@ import {
 import { AltimateRequest, ModelNode } from "../altimate";
 import {
   ExposureMetaData,
+  FunctionMetaData,
   GraphMetaMap,
   NodeGraphMap,
   NodeMetaData,
@@ -181,6 +182,15 @@ export class NewLineagePanel implements LineagePanelView {
 
     if (command === "getExposureDetails") {
       const body = await this.getExposureDetails(params);
+      this._panel?.webview.postMessage({
+        command: "response",
+        args: { id, body, status: true },
+      });
+      return;
+    }
+
+    if (command === "getFunctionDetails") {
+      const body = await this.getFunctionDetails(params);
       this._panel?.webview.postMessage({
         command: "response",
         args: { id, body, status: true },
@@ -365,6 +375,19 @@ export class NewLineagePanel implements LineagePanelView {
     return exposureMetaMap.get(name);
   }
 
+  private async getFunctionDetails({
+    name,
+  }: {
+    name: string;
+  }): Promise<FunctionMetaData | undefined> {
+    const event = this.getEvent();
+    if (!event) {
+      return;
+    }
+    const { functionMetaMap } = event;
+    return functionMetaMap.get(name);
+  }
+
   private async getColumns({
     table,
     refresh,
@@ -450,6 +473,45 @@ export class NewLineagePanel implements LineagePanelView {
       };
     }
     const tableName = splits[2];
+    if (nodeType === DBTProject.RESOURCE_TYPE_FUNCTION) {
+      const { functionMetaMap } = event;
+      const fn = functionMetaMap.get(tableName);
+      if (!fn) {
+        return;
+      }
+      const columns: {
+        table: string;
+        name: string;
+        datatype: string;
+        can_lineage_expand: boolean;
+        description: string;
+      }[] = [];
+      if (fn.arguments) {
+        for (const arg of fn.arguments) {
+          columns.push({
+            table,
+            name: arg.name,
+            datatype: arg.data_type || "",
+            can_lineage_expand: false,
+            description: arg.description || "",
+          });
+        }
+      }
+      if (fn.returns) {
+        columns.push({
+          table,
+          name: "RETURNS",
+          datatype: fn.returns.data_type || "",
+          can_lineage_expand: false,
+          description: fn.returns.description || "",
+        });
+      }
+      return {
+        id: table,
+        purpose: fn.description || "",
+        columns,
+      };
+    }
     const { nodeMetaMap } = event;
     const node = nodeMetaMap.get(tableName);
     if (!node) {
@@ -796,6 +858,22 @@ export class NewLineagePanel implements LineagePanelView {
         materialization: undefined,
         tests: [],
         isExternalProject: false,
+      };
+    }
+
+    if (nodeType === DBTProject.RESOURCE_TYPE_FUNCTION) {
+      const { functionMetaMap } = event;
+      const fn = functionMetaMap.get(table);
+      return {
+        table: key,
+        label: table,
+        url: tableUrl,
+        upstreamCount,
+        downstreamCount,
+        nodeType,
+        materialization: fn?.config?.type,
+        tests: [],
+        isExternalProject: fn?.is_external_project ?? false,
       };
     }
 


### PR DESCRIPTION
## Summary

Surfaces dbt 1.11 User-Defined Functions in the VS Code extension lineage panel so users can see UDF dependencies alongside models, sources, and other resources.

## Expected Functionality

- **Function nodes in lineage**: UDF nodes appear in the lineage graph as a distinct node type, visually differentiated from models and sources. Users can see which models depend on which functions.
- **Function detail panel**: Clicking a function node opens a details sidebar showing:
  - Function name and description
  - Arguments (name, type, default value)
  - Return type
  - Arguments displayed as pseudo-columns for consistency with the column list pattern
  - A RETURNS row showing the function return type
- **No column-level lineage for functions**: Functions intentionally do not participate in column-level lineage or isResourceNode/isResourceHasDbColumns checks, since UDFs have arguments and return types rather than materialized table columns.
- **Backward compatible**: Extensions connected to pre-1.11 dbt projects see no change.

## Dependencies

- Requires altimate-dbt-integration with FunctionParser types
- Requires altimate-components with function node rendering support

## Test Plan

- [ ] Open lineage panel on a dbt 1.11 project with UDFs - function nodes should appear
- [ ] Click a function node - details panel should show arguments and return type
- [ ] Verify function nodes do NOT show column-level lineage edges
- [ ] Open lineage on a pre-1.11 project - no errors, no function nodes
- [ ] Verify function node icon is visually distinct from model/source icons

Generated with Claude Code