### PR TITLE
fix: compile preview ENOENT and race condition for untitled query files

### DIFF
--- a/src/commands/runModel.ts
+++ b/src/commands/runModel.ts
@@ -50,13 +50,20 @@ export class RunModel {
     if (!window.activeTextEditor) {
       return;
     }
-    const fullPath = window.activeTextEditor.document.uri;
-    if (fullPath.scheme === "untitled") {
+    // For untitled files, ensure a project is selected before capturing
+    // editor state — the await may show a picker, during which the user
+    // could switch editors.
+    if (window.activeTextEditor.document.uri.scheme === "untitled") {
       const resolved = await this.ensureProjectForUntitledUri();
       if (!resolved) {
         return;
       }
     }
+    // Re-read editor state after the await to avoid stale references
+    if (!window.activeTextEditor) {
+      return;
+    }
+    const fullPath = window.activeTextEditor.document.uri;
     const query = window.activeTextEditor.document.getText();
     if (query !== undefined) {
       this.compileDBTQuery(fullPath, query);
@@ -114,6 +121,19 @@ export class RunModel {
   }
 
   async executeQueryOnActiveWindow() {
+    if (!window.activeTextEditor) {
+      return;
+    }
+    // For untitled files, ensure a project is selected before capturing
+    // editor state — the await may show a picker, during which the user
+    // could switch editors.
+    if (window.activeTextEditor.document.uri.scheme === "untitled") {
+      const resolved = await this.ensureProjectForUntitledUri();
+      if (!resolved) {
+        return;
+      }
+    }
+    // Re-read editor state after the await to avoid stale references
     const query = this.getQuery();
     if (query === undefined) {
       return;
@@ -121,12 +141,6 @@ export class RunModel {
     const modelPath = window.activeTextEditor?.document.uri;
     if (!modelPath) {
       return;
-    }
-    if (modelPath.scheme === "untitled") {
-      const resolved = await this.ensureProjectForUntitledUri();
-      if (!resolved) {
-        return;
-      }
     }
     const modelName =
       modelPath.scheme === "untitled"

--- a/src/content_provider/sqlPreviewContentProvider.ts
+++ b/src/content_provider/sqlPreviewContentProvider.ts
@@ -32,13 +32,14 @@ export class SqlPreviewContentProvider
     this.subscriptions.push(
       workspace.onDidChangeTextDocument((e: TextDocumentChangeEvent) => {
         // Check if this document has an associated preview
-        const fileUriString = e.document.uri.toString();
         for (const [
           previewUriString,
           previewUri,
         ] of this.compilationDocs.entries()) {
-          const actualFileUri = previewUri.with({ scheme: "file" });
-          if (actualFileUri.toString() === fileUriString) {
+          const isSourceDocument =
+            e.document.uri.path === previewUri.path &&
+            e.document.uri.scheme !== SqlPreviewContentProvider.SCHEME;
+          if (isSourceDocument) {
             // Debounce the update
             const existingTimer = this.debounceTimers.get(previewUriString);
             if (existingTimer) {
@@ -116,21 +117,32 @@ export class SqlPreviewContentProvider
   private async requestCompilation(uri: Uri) {
     try {
       const fsPath = decodeURI(uri.fsPath);
-      const modelName = path.basename(fsPath, ".sql");
 
-      // Read from the active document if available, otherwise fall back to file
-      const actualFileUri = uri.with({ scheme: "file" });
+      // Find the source document by matching the path component.
+      // The preview URI preserves the original path (e.g. query-preview:Untitled-1
+      // came from untitled:Untitled-1), so matching by path works for any scheme.
+      const sourcePath = uri.path;
       const document = workspace.textDocuments.find(
-        (doc) => doc.uri.toString() === actualFileUri.toString(),
+        (doc) =>
+          doc.uri.path === sourcePath &&
+          doc.uri.scheme !== SqlPreviewContentProvider.SCHEME,
       );
+
+      const isUntitled = document?.uri.scheme === "untitled";
       const query = document
         ? document.getText()
         : readFileSync(fsPath, "utf8");
+      const modelName = isUntitled ? "untitled" : path.basename(fsPath, ".sql");
 
-      const project = this.dbtProjectContainer.findDBTProject(Uri.file(fsPath));
+      // findDBTProject handles untitled URIs internally via resolveProjectUri
+      const project = this.dbtProjectContainer.findDBTProject(
+        document?.uri ?? Uri.file(fsPath),
+      );
       if (project === undefined) {
         this.telemetry.sendTelemetryError("sqlPreviewNotLoadingError");
-        return "Still loading dbt project, please try again later...";
+        return isUntitled
+          ? "No dbt project selected. Please select a project first."
+          : "Still loading dbt project, please try again later...";
       }
       this.telemetry.sendTelemetryEvent("requestCompilation");
       await project.refreshProjectConfig();

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -61,6 +61,11 @@ jest.mock("vscode", () => ({
     file: jest.fn((f: string) => ({ fsPath: f })),
     parse: jest.fn(),
   },
+  ProgressLocation: {
+    SourceControl: 1,
+    Window: 10,
+    Notification: 15,
+  },
   DiagnosticSeverity: {
     Error: 0,
     Warning: 1,

--- a/src/test/suite/sqlPreviewContentProvider.test.ts
+++ b/src/test/suite/sqlPreviewContentProvider.test.ts
@@ -1,0 +1,207 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { Uri, window, workspace } from "vscode";
+import { SqlPreviewContentProvider } from "../../content_provider/sqlPreviewContentProvider";
+import { DBTProjectContainer } from "../../dbt_client/dbtProjectContainer";
+import { TelemetryService } from "../../telemetry";
+
+// SqlPreviewContentProvider registers listeners on construction —
+// add the missing workspace/window mocks before creating it
+(workspace as any).onDidChangeTextDocument = jest
+  .fn()
+  .mockReturnValue({ dispose: jest.fn() });
+(window as any).onDidChangeVisibleTextEditors = jest
+  .fn()
+  .mockReturnValue({ dispose: jest.fn() });
+(window as any).visibleTextEditors = [];
+(window as any).withProgress = jest
+  .fn()
+  .mockImplementation((_opts: any, task: any) => task());
+
+describe("SqlPreviewContentProvider", () => {
+  let provider: SqlPreviewContentProvider;
+  let mockContainer: jest.Mocked<DBTProjectContainer>;
+  let mockTelemetry: jest.Mocked<TelemetryService>;
+  let mockProject: any;
+
+  beforeEach(() => {
+    mockProject = {
+      refreshProjectConfig: jest
+        .fn<() => Promise<void>>()
+        .mockResolvedValue(undefined),
+      unsafeCompileQuery: jest
+        .fn<() => Promise<string>>()
+        .mockResolvedValue("SELECT * FROM dev.stg_customers"),
+    };
+
+    mockContainer = {
+      findDBTProject: jest.fn(),
+    } as unknown as jest.Mocked<DBTProjectContainer>;
+
+    mockTelemetry = {
+      sendTelemetryEvent: jest.fn(),
+      sendTelemetryError: jest.fn(),
+    } as unknown as jest.Mocked<TelemetryService>;
+
+    provider = new SqlPreviewContentProvider(mockContainer, mockTelemetry);
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    jest.clearAllMocks();
+  });
+
+  describe("provideTextDocumentContent with untitled files", () => {
+    it("should find untitled source document by path and compile successfully", async () => {
+      // Simulate an untitled document in the workspace
+      const untitledDoc = {
+        uri: {
+          path: "Untitled-1",
+          scheme: "untitled",
+          toString: () => "untitled:Untitled-1",
+        },
+        getText: jest
+          .fn()
+          .mockReturnValue("select * from {{ ref('stg_customers') }}"),
+      };
+      (workspace.textDocuments as any) = [untitledDoc];
+      mockContainer.findDBTProject.mockReturnValue(mockProject);
+
+      // Preview URI preserves the path from the original untitled URI
+      const previewUri = {
+        path: "Untitled-1",
+        scheme: SqlPreviewContentProvider.SCHEME,
+        fsPath: "Untitled-1",
+        toString: () => `${SqlPreviewContentProvider.SCHEME}:Untitled-1`,
+      } as unknown as Uri;
+
+      const result = await provider.provideTextDocumentContent(previewUri);
+
+      expect(untitledDoc.getText).toHaveBeenCalled();
+      expect(mockContainer.findDBTProject).toHaveBeenCalledWith(
+        untitledDoc.uri,
+      );
+      expect(mockProject.unsafeCompileQuery).toHaveBeenCalledWith(
+        "select * from {{ ref('stg_customers') }}",
+        "untitled",
+      );
+      expect(result).toBe("SELECT * FROM dev.stg_customers");
+    });
+
+    it("should return helpful message for untitled file when no project is selected", async () => {
+      const untitledDoc = {
+        uri: {
+          path: "Untitled-1",
+          scheme: "untitled",
+          toString: () => "untitled:Untitled-1",
+        },
+        getText: jest.fn().mockReturnValue("select 1"),
+      };
+      (workspace.textDocuments as any) = [untitledDoc];
+      mockContainer.findDBTProject.mockReturnValue(undefined);
+
+      const previewUri = {
+        path: "Untitled-1",
+        scheme: SqlPreviewContentProvider.SCHEME,
+        fsPath: "Untitled-1",
+        toString: () => `${SqlPreviewContentProvider.SCHEME}:Untitled-1`,
+      } as unknown as Uri;
+
+      const result = await provider.provideTextDocumentContent(previewUri);
+
+      expect(result).toBe(
+        "No dbt project selected. Please select a project first.",
+      );
+      expect(mockTelemetry.sendTelemetryError).toHaveBeenCalledWith(
+        "sqlPreviewNotLoadingError",
+      );
+    });
+
+    it("should return loading message for saved file when project is not found", async () => {
+      const savedDoc = {
+        uri: {
+          path: "/Users/test/project/model.sql",
+          scheme: "file",
+          toString: () => "file:///Users/test/project/model.sql",
+        },
+        getText: jest.fn().mockReturnValue("select 1"),
+      };
+      (workspace.textDocuments as any) = [savedDoc];
+      mockContainer.findDBTProject.mockReturnValue(undefined);
+
+      const previewUri = {
+        path: "/Users/test/project/model.sql",
+        scheme: SqlPreviewContentProvider.SCHEME,
+        fsPath: "/Users/test/project/model.sql",
+        toString: () =>
+          `${SqlPreviewContentProvider.SCHEME}:///Users/test/project/model.sql`,
+      } as unknown as Uri;
+
+      const result = await provider.provideTextDocumentContent(previewUri);
+
+      expect(result).toBe(
+        "Still loading dbt project, please try again later...",
+      );
+    });
+
+    it("should use 'untitled' as model name for untitled files", async () => {
+      const untitledDoc = {
+        uri: {
+          path: "Untitled-1",
+          scheme: "untitled",
+          toString: () => "untitled:Untitled-1",
+        },
+        getText: jest.fn().mockReturnValue("select 1"),
+      };
+      (workspace.textDocuments as any) = [untitledDoc];
+      mockContainer.findDBTProject.mockReturnValue(mockProject);
+
+      const previewUri = {
+        path: "Untitled-1",
+        scheme: SqlPreviewContentProvider.SCHEME,
+        fsPath: "Untitled-1",
+        toString: () => `${SqlPreviewContentProvider.SCHEME}:Untitled-1`,
+      } as unknown as Uri;
+
+      await provider.provideTextDocumentContent(previewUri);
+
+      expect(mockProject.unsafeCompileQuery).toHaveBeenCalledWith(
+        "select 1",
+        "untitled",
+      );
+    });
+
+    it("should not match preview documents as source documents", async () => {
+      // Only a preview document exists — no source document
+      const previewDoc = {
+        uri: {
+          path: "Untitled-1",
+          scheme: SqlPreviewContentProvider.SCHEME,
+          toString: () => `${SqlPreviewContentProvider.SCHEME}:Untitled-1`,
+        },
+        getText: jest.fn().mockReturnValue("compiled sql"),
+      };
+      (workspace.textDocuments as any) = [previewDoc];
+
+      const previewUri = {
+        path: "Untitled-1",
+        scheme: SqlPreviewContentProvider.SCHEME,
+        fsPath: "Untitled-1",
+        toString: () => `${SqlPreviewContentProvider.SCHEME}:Untitled-1`,
+      } as unknown as Uri;
+
+      // Should not use the preview doc as source — falls back to readFileSync
+      // which will fail, returning an error message
+      const result = await provider.provideTextDocumentContent(previewUri);
+
+      expect(previewDoc.getText).not.toHaveBeenCalled();
+      expect(typeof result).toBe("string");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

### Before (not project specific. It selected the first one):
<img width="1632" height="445" alt="image" src="https://github.com/user-attachments/assets/ac8ead9d-d4dc-46e3-9323-c0333e84a47c" />

### After: 
<img width="1669" height="678" alt="image" src="https://github.com/user-attachments/assets/4f4e2054-81d4-490d-915a-debee54ce46c" />


Fixes "Compiled dbt Preview" (Cmd+') failing for untitled query files in **multi-project workspaces**. Follow-up to #1842.

### Broken flow

Multi-project workspace → untitled file with project selected → Cmd+' → **ENOENT error** or "Still loading dbt project..."

`SqlPreviewContentProvider.requestCompilation()` assumes `file:` scheme when looking up the source document. For untitled files the scheme is `untitled:`, so the lookup fails, falls back to `readFileSync("Untitled-1")` → ENOENT. Project resolution also fails because `findDBTProject(Uri.file("Untitled-1"))` can't match in multi-project.

Single-project works on `main` because the CWD-relative path resolution happens to land inside the only workspace folder.

### Changes

- `requestCompilation()` finds the source document by matching URI path (scheme-agnostic) and passes `document.uri` to `findDBTProject` which handles untitled resolution internally (#1842)
- Live-update handler uses the same path-based matching so edits refresh the preview
- `compileQueryOnActiveWindow` and `executeQueryOnActiveWindow` capture editor state after async project picker to prevent stale references (defensive)