### PR TITLE
feat: add Altimate integration creation step to onboarding wizard

### DIFF
--- a/src/altimate.ts
+++ b/src/altimate.ts
@@ -501,43 +501,22 @@ export class AltimateRequest {
   }
 
   async createDbtIntegration(
-    instanceName: string,
-    apiKey: string,
     name: string,
     environment: string,
     integrationType: "dbt_core" | "dbt_cloud",
   ) {
-    const url = `${this.getAltimateUrl()}/dbt/v1/project_integration`;
-    const response = await fetch(url, {
+    return this.fetch<{
+      dbt_core_integration_id?: number;
+      dbt_cloud_integration_id?: number;
+      integration_type: string;
+    }>("dbt/v1/project_integration", {
       method: "POST",
-      headers: {
-        "x-tenant": instanceName,
-        Authorization: "Bearer " + apiKey,
-        "Content-Type": "application/json",
-      },
       body: JSON.stringify({
         name,
         environment,
         integration_type: integrationType,
       }),
     });
-
-    if (!response.ok) {
-      const errorData = (await response.json().catch(() => ({}))) as Record<
-        string,
-        unknown
-      >;
-      throw new Error(
-        (errorData.message as string) ||
-          `Failed to create dbt integration: ${response.statusText}`,
-      );
-    }
-
-    return (await response.json()) as {
-      dbt_core_integration_id?: number;
-      dbt_cloud_integration_id?: number;
-      integration_type: string;
-    };
   }
 
   async checkApiConnectivity() {

--- a/src/webview_provider/onboardingPanel.ts
+++ b/src/webview_provider/onboardingPanel.ts
@@ -368,9 +368,10 @@ export class OnboardingPanel extends AltimateWebviewProvider {
               backendURL,
             );
 
-          if (!validationResult || validationResult.error) {
+          if (!validationResult?.ok) {
             const errorMessage =
               validationResult?.error ||
+              validationResult?.detail ||
               "Invalid credentials. Please check your API key and instance name.";
             this.dbtTerminal.error(
               "saveAltimateKey",
@@ -655,20 +656,8 @@ export class OnboardingPanel extends AltimateWebviewProvider {
             throw new Error("Missing required parameters");
           }
 
-          const config = workspace.getConfiguration("dbt");
-          const instanceName = config.get<string>("altimateInstanceName");
-          const apiKey = config.get<string>("altimateAiKey");
-
-          if (!instanceName || !apiKey) {
-            throw new Error(
-              "Altimate API key and instance name must be configured first",
-            );
-          }
-
           // Call Altimate API to create the integration
           const response = await this.altimateRequest.createDbtIntegration(
-            instanceName,
-            apiKey,
             name,
             environment,
             integrationType,

--- a/webview_panels/src/modules/onboarding/AltimateSetupStep.tsx
+++ b/webview_panels/src/modules/onboarding/AltimateSetupStep.tsx
@@ -517,7 +517,7 @@ const AltimateSetupStep = ({
 
     if (hasCompletedSync) return 3; // API key + synced integration = 3 stars
     if (existingIntegrations.length > 0) return 2; // API key + integration (not synced) = 2 stars
-    return 2; // API key only = 2 stars
+    return 1; // API key only, no integration yet = 1 star
   };
 
   const renderProgressCard = () => {
@@ -945,10 +945,7 @@ const AltimateSetupStep = ({
           className={classes.alertMessage}
         />
         <Stack direction="row" className={classes.altimateKeyActions}>
-          <Button
-            size="large"
-            onClick={() => setIsEditing(true)}
-          >
+          <Button size="large" onClick={() => setIsEditing(true)}>
             Edit Configuration
           </Button>
         </Stack>

--- a/webview_panels/src/modules/onboarding/SetupWizard.tsx
+++ b/webview_panels/src/modules/onboarding/SetupWizard.tsx
@@ -358,9 +358,7 @@ const SetupWizard = forwardRef<
                 >
                   {currentStepData.id === "prerequisites"
                     ? "Validate Setup"
-                    : currentStepData.id === "validation"
-                      ? "Tutorials"
-                      : "Next"}
+                    : "Next"}
                 </Button>
               ) : (
                 <div />


### PR DESCRIPTION
## Summary
- Adds "Create Integration" substep under the "Setup Altimate AI" parent group
- Full integration management: create new dbt integrations, view existing ones with environment selector and sync status
- Datapilot CLI command generation with copy-to-clipboard
- Progress card ("Your Analytics Engineering Journey") with 3-star progression (API key → integration → synced)
- Backend handlers: `createDbtIntegration`, `getIntegrations`, `getIntegrationSyncStatus`, `checkDatapilotInstalled`, `installDatapilot`, `getAltimateConfig`, `openUrl`

**Part 2 of 2** — depends on #1847 being merged first. Only touches 4 files on top of PR 1.

## Test plan
- [ ] After configuring API key, "Create Integration" substep appears
- [ ] Can create a new dbt integration (core or cloud type)
- [ ] Existing integrations listed with environment selector and sync status
- [ ] Datapilot CLI command generated correctly with user's credentials
- [ ] Copy command button works
- [ ] Datapilot install/check functionality works
- [ ] Progress card reflects correct star level (1→2→3)
- [ ] Full wizard flow: Prerequisites → Validate → API Key → Integration → Tutorials
- [ ] Timer cleanup on unmount (no orphaned callbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)