### PR TITLE
fix: [AI-1759] target selector affects query execution and shows current target

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -649,7 +649,12 @@ export class VSCodeCommands implements Disposable {
       ),
       commands.registerCommand(
         "dbtPowerUser.openTargetSelector",
-        async (targets, project: DBTProject, statusBar) => {
+        async (
+          targets,
+          project: DBTProject,
+          statusBar,
+          currentTarget?: string,
+        ) => {
           try {
             if (!targets) {
               return;
@@ -659,10 +664,20 @@ export class VSCodeCommands implements Disposable {
               "Showing following targets",
               targets,
             );
-            const target = await window.showQuickPick(targets, {
+            const sortedTargets = (targets as string[]).sort((a, b) => {
+              if (a === currentTarget) return -1;
+              if (b === currentTarget) return 1;
+              return 0;
+            });
+            const items = sortedTargets.map((t) => ({
+              label: t,
+              description: t === currentTarget ? "(current)" : "",
+            }));
+            const selected = await window.showQuickPick(items, {
               title: "Select your target",
               canPickMany: false,
             });
+            const target = selected?.label;
             if (target) {
               await project.setSelectedTarget(target);
               await statusBar.updateStatusBar();

--- a/src/statusbar/targetStatusBar.ts
+++ b/src/statusbar/targetStatusBar.ts
@@ -52,7 +52,7 @@ export class TargetStatusBar implements Disposable {
         this.statusBar.command = {
           title: "Open Target selector",
           command: "dbtPowerUser.openTargetSelector",
-          arguments: [targets, currentProject, this],
+          arguments: [targets, currentProject, this, selectedTarget],
         };
         this.statusBar.show();
       }


### PR DESCRIPTION
## Summary

- Pass `selectedTarget` to the target picker command so the current target is shown first with a "(current)" label
- Sort picker items to place the active target at the top of the list

<img width="947" height="217" alt="image" src="https://github.com/user-attachments/assets/573b332d-b858-4424-be61-4467013e2ad2" />

## Context

Fixes https://github.com/AltimateAI/vscode-dbt-power-user/issues/1759

The target selector QuickPick always showed the first target (usually `dev`) as highlighted, regardless of which target was actually active. This made it unclear which target was currently selected.

**Companion PR**: AltimateAI/altimate-dbt-integration#37 (passes `target_name` to Python bridge for query execution)

## Test plan

- [x] Target picker shows current target first with "(current)" label
- [x] Switching targets updates the status bar
- [x] Diagnostics confirm target change propagates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
