### PR TITLE
fix: [AI-1773] improve sqlfmt discovery for uv tool install locations

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -24,11 +24,10 @@ import { extendErrorWithSupportLinks, getFirstWorkspacePath } from "../utils";
 
 const execAsync = promisify(exec);
 
-export class DbtDocumentFormattingEditProvider
-  implements DocumentFormattingEditProvider
-{
+// prettier-ignore
+export class DbtDocumentFormattingEditProvider implements DocumentFormattingEditProvider {
   private cachedSqlFmtPath: string | undefined;
-  private sqlFmtPathResolved = false;
+  private cachedPythonPath: string | undefined;
 
   constructor(
     private commandProcessExecutionFactory: CommandProcessExecutionFactory,
@@ -117,10 +116,12 @@ export class DbtDocumentFormattingEditProvider
   }
 
   private async findSqlFmtPath(): Promise<string | undefined> {
-    // Return cached result if still valid
+    const currentPythonPath = this.pythonEnvironment.pythonPath;
+
+    // Return cached result if still valid (same interpreter + binary exists)
     if (
-      this.sqlFmtPathResolved &&
       this.cachedSqlFmtPath &&
+      this.cachedPythonPath === currentPythonPath &&
       fs.existsSync(this.cachedSqlFmtPath)
     ) {
       return this.cachedSqlFmtPath;
@@ -128,7 +129,7 @@ export class DbtDocumentFormattingEditProvider
 
     const result = await this.discoverSqlFmtPath();
     this.cachedSqlFmtPath = result;
-    this.sqlFmtPathResolved = true;
+    this.cachedPythonPath = currentPythonPath;
     return result;
   }
 


### PR DESCRIPTION
## Summary

- Add well-known tool binary locations to sqlfmt discovery (`~/.local/bin/`, Windows uv/pipx paths)
- Respect `UV_TOOL_BIN_DIR` and `PIPX_BIN_DIR` environment variable overrides
- Use async `exec` instead of blocking `execSync` for `uv tool dir` lookup
- Cache discovered sqlfmt path with existence validation (re-discovers if binary is deleted)
- Use correct uv package name (`shandy-sqlfmt`, not `sqlfmt`) for tool directory paths
- Improve error message with actionable guidance

## Context

Fixes https://github.com/AltimateAI/vscode-dbt-power-user/issues/1773

When sqlfmt is installed via `uv tool install "shandy-sqlfmt[jinjafmt]"`, the extension couldn't find it. The binary is placed at `~/.local/bin/sqlfmt` but VS Code's process PATH is frozen at launch time.

**Discovery order:**
1. Python venv bin directory (existing)
2. `UV_TOOL_BIN_DIR` / `PIPX_BIN_DIR` env var overrides (new)
3. `~/.local/bin/sqlfmt` — default for uv/pipx on Linux/Mac (new)
4. Windows-specific paths for uv/pipx (new)
5. `uv tool dir` async discovery for custom locations (new, non-blocking)
6. System PATH via `which` (existing)

**Risk mitigations:**
- `uv tool dir` uses async exec (non-blocking) with 3s timeout
- Discovered path is cached with `fs.existsSync` validation — cache auto-invalidates if binary is removed
- `UV_TOOL_BIN_DIR` and `PIPX_BIN_DIR` respected for users with custom tool locations
- Correct package name `shandy-sqlfmt` used in uv tool directory paths
- Multi-layer discovery is robust: hiding `~/.local/bin/sqlfmt` symlink still finds the binary via `uv tool dir` fallback

## Test plan

- [x] Install sqlfmt via `uv tool install` — Format Document works
- [x] `uv tool uninstall shandy-sqlfmt` — formatting fails with improved error message
- [x] Reinstall sqlfmt — formatting works again without restarting F5 (cache re-discovers)
- [x] Webpack builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the sqlfmt formatter across multiple installation locations and platforms for more reliable resolution.
  * Added one-time caching and a multi-step discovery flow to speed up and stabilize subsequent formatter lookups.
  * Expanded user-facing error messages with concrete installation examples, guidance to set the formatter path explicitly, and a reminder to restart the editor to refresh PATH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->