### PR TITLE
fix: resolve lineage rendering in multi-root workspaces and cap expansion

### DIFF
--- a/src/dbt_client/dbtProjectContainer.ts
+++ b/src/dbt_client/dbtProjectContainer.ts
@@ -471,6 +471,7 @@ export class DBTProjectContainer implements Disposable {
     }
     this.dbtWorkspaceFolders.splice(
       this.dbtWorkspaceFolders.indexOf(folderToDelete),
+      1,
     );
     folderToDelete.dispose();
   }

--- a/src/test/suite/dbtProjectContainer.test.ts
+++ b/src/test/suite/dbtProjectContainer.test.ts
@@ -223,4 +223,35 @@ describe("DBTProjectContainer Tests", () => {
       );
     });
   });
+
+  describe("unregisterWorkspaceFolder (via workspace event)", () => {
+    it("should remove only the targeted folder, not subsequent ones", () => {
+      // Access the internal dbtWorkspaceFolders array directly to verify
+      // splice removes exactly one element (not all from index onward).
+      const folders = (container as any).dbtWorkspaceFolders as any[];
+
+      const createMockFolder = (fsPath: string) => ({
+        contains: (uri: any) => uri.fsPath.startsWith(fsPath),
+        dispose: jest.fn(),
+        workspaceFolder: { uri: { fsPath } },
+      });
+
+      const folder1 = createMockFolder("/workspace/project-a");
+      const folder2 = createMockFolder("/workspace/project-b");
+      const folder3 = createMockFolder("/workspace/project-c");
+      folders.push(folder1, folder2, folder3);
+
+      expect(folders).toHaveLength(3);
+
+      // Call the private unregisterWorkspaceFolder via its internal name
+      (container as any).unregisterWorkspaceFolder({
+        uri: { fsPath: "/workspace/project-b" },
+      });
+
+      expect(folders).toHaveLength(2);
+      expect(folders[0]).toBe(folder1);
+      expect(folders[1]).toBe(folder3);
+      expect(folder2.dispose).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/test/suite/newLineagePanel.test.ts
+++ b/src/test/suite/newLineagePanel.test.ts
@@ -1,0 +1,142 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { workspace } from "vscode";
+import { NewLineagePanel } from "../../webview_provider/newLineagePanel";
+
+describe("NewLineagePanel", () => {
+  let panel: NewLineagePanel;
+  let mockPostMessage: jest.Mock;
+
+  beforeEach(() => {
+    mockPostMessage = jest.fn();
+
+    // Create a minimal instance by bypassing the constructor DI.
+    // We only need the methods under test and the _panel webview stub.
+    panel = Object.create(NewLineagePanel.prototype);
+
+    // Stub the internal webview panel so postMessage is captured.
+    (panel as any)._panel = {
+      webview: { postMessage: mockPostMessage },
+    };
+
+    // Stub dependencies used by getStartingNode / renderStartingNode
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest.fn().mockReturnValue(undefined),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    (panel as any).altimate = { enabled: jest.fn().mockReturnValue(false) };
+    (panel as any).dbtTerminal = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    };
+  });
+
+  describe("eventMapChanged", () => {
+    it("should re-render the starting node when the event map updates", () => {
+      const eventMap = new Map();
+
+      panel.eventMapChanged(eventMap);
+
+      // renderStartingNode posts a "render" command to the webview
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "render" }),
+      );
+    });
+
+    it("should not throw when panel is not visible", () => {
+      (panel as any)._panel = undefined;
+      const eventMap = new Map();
+
+      expect(() => panel.eventMapChanged(eventMap)).not.toThrow();
+    });
+  });
+
+  describe("getLineageSettings — defaultExpansion cap", () => {
+    it("should cap defaultExpansion at 5 when user sets a higher value", async () => {
+      const mockConfig = {
+        get: jest.fn<any>().mockImplementation((key: string, defaultVal: unknown) => {
+          if (key === "defaultExpansion") return 10;
+          return defaultVal;
+        }),
+      };
+      (workspace.getConfiguration as jest.Mock).mockReturnValue(mockConfig);
+
+      // Call handleCommand with getLineageSettings
+      await (panel as any).handleCommand({
+        command: "getLineageSettings",
+        args: {},
+        syncRequestId: "test-sync-1",
+      });
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "response",
+          args: expect.objectContaining({
+            body: expect.objectContaining({
+              defaultExpansion: 5,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should pass through defaultExpansion when within limit", async () => {
+      const mockConfig = {
+        get: jest.fn<any>().mockImplementation((key: string, defaultVal: unknown) => {
+          if (key === "defaultExpansion") return 3;
+          return defaultVal;
+        }),
+      };
+      (workspace.getConfiguration as jest.Mock).mockReturnValue(mockConfig);
+
+      await (panel as any).handleCommand({
+        command: "getLineageSettings",
+        args: {},
+        syncRequestId: "test-sync-2",
+      });
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "response",
+          args: expect.objectContaining({
+            body: expect.objectContaining({
+              defaultExpansion: 3,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it("should use default value of 1 when setting is not configured", async () => {
+      const mockConfig = {
+        get: jest.fn<any>().mockImplementation((_key: string, defaultVal: unknown) => {
+          return defaultVal;
+        }),
+      };
+      (workspace.getConfiguration as jest.Mock).mockReturnValue(mockConfig);
+
+      await (panel as any).handleCommand({
+        command: "getLineageSettings",
+        args: {},
+        syncRequestId: "test-sync-3",
+      });
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "response",
+          args: expect.objectContaining({
+            body: expect.objectContaining({
+              defaultExpansion: 1,
+            }),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -89,6 +89,7 @@ export class NewLineagePanel
 
   eventMapChanged(eventMap: Map<string, ManifestCacheProjectAddedEvent>): void {
     this.eventMap = eventMap;
+    this.renderStartingNode();
   }
 
   changedActiveColorTheme() {
@@ -276,7 +277,10 @@ export class NewLineagePanel
           body: {
             showSelectEdges: config.get("showSelectEdges", true),
             showNonSelectEdges: config.get("showNonSelectEdges", false),
-            defaultExpansion: config.get("defaultExpansion", 1),
+            defaultExpansion: Math.min(
+              config.get<number>("defaultExpansion", 1),
+              5,
+            ),
           },
         },
       });


### PR DESCRIPTION
## Summary
- **#1850 / #1793**: Re-render lineage when manifest parsing completes — fixes race condition where panel opens before manifest is ready (multi-root workspaces, Cursor)
- **#1699**: Cap `defaultExpansion` at 5 — prevents silent webview crash on large projects with high expansion values
- **Splice bug**: Fix `unregisterWorkspaceFolder` removing all subsequent folders instead of just one (off-by-one in `splice()`)

All three fixes are 1-line production changes. 6 unit tests added.

Closes #1850
Closes #1793
Closes #1699

## Test plan
- [ ] Open a `.code-workspace` with a dbt project as one of multiple workspace folders → lineage should render
- [ ] Open lineage panel before manifest finishes parsing → should auto-populate when ready
- [ ] Set `dbt.lineage.defaultExpansion` to 10 → graph should cap at 5 levels
- [ ] Remove a workspace folder from multi-root workspace → remaining folders stay functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed workspace folder removal logic to remove exactly one folder as intended.

* **New Features**
  * Lineage panel now automatically refreshes when manifest data changes.
  * Default expansion depth for lineage is now capped at a maximum of 5 levels.

* **Tests**
  * Added comprehensive test coverage for workspace folder management and lineage panel configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->