### PR TITLE
chore: bump `@altimateai/ui-components` to `0.0.82-beta.4`

### DIFF
--- a/webview_panels/package-lock.json
+++ b/webview_panels/package-lock.json
@@ -8,7 +8,7 @@
       "name": "webview_panels",
       "version": "0.0.0",
       "dependencies": {
-        "@altimateai/ui-components": "0.0.82-beta.3",
+        "@altimateai/ui-components": "0.0.82-beta.4",
         "@ant-design/pro-chat": "^1.15.2",
         "@finos/perspective": "^2.10.0",
         "@finos/perspective-viewer": "^2.10.0",
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@altimateai/ui-components": {
-      "version": "0.0.82-beta.3",
-      "resolved": "https://registry.npmjs.org/@altimateai/ui-components/-/ui-components-0.0.82-beta.3.tgz",
-      "integrity": "sha512-YSw8gYmCNztxduy7ZS6LK6zztqVMClSzQ541ANPxQrOH7655Dnzb+wkKrBoPY9+m5pI6I63r5OblWtwSv8eGgQ==",
+      "version": "0.0.82-beta.4",
+      "resolved": "https://registry.npmjs.org/@altimateai/ui-components/-/ui-components-0.0.82-beta.4.tgz",
+      "integrity": "sha512-AEJ5UsUoWiotRLvrmkAhLp6Dz9o1Ine6uo0HmoISufELzb1WHNtpB/8y/RLTKaZ7jdVL3JndqZRBocW6x8nmSQ==",
       "dependencies": {
         "@ai-sdk/react": "^3.0.14",
         "@floating-ui/react": "^0.27.16",

--- a/webview_panels/package.json
+++ b/webview_panels/package.json
@@ -18,7 +18,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@altimateai/ui-components": "0.0.82-beta.3",
+    "@altimateai/ui-components": "0.0.82-beta.4",
     "@ant-design/pro-chat": "^1.15.2",
     "@finos/perspective": "^2.10.0",
     "@finos/perspective-viewer": "^2.10.0",


### PR DESCRIPTION
## Summary

Bumps `@altimateai/ui-components` from `0.0.82-beta.3` → `0.0.82-beta.4` to pick up the force left-to-right lineage edge direction fix.

## Context — correction on prior assumption

The previous bump PR (#1873, merged to `0.0.82-beta.3`) was made under the mistaken certainty that the force-LTR fix had already landed in `altimate-frontend`. It had not.

What actually happened:
- `@altimateai/ui-components@0.0.82-beta.3` was published via a `workflow_dispatch` run against the (still-unmerged) `fix/AI-5930-lego-ci-build` branch on 2026-04-07. That run only contained the `@altimateai/lego` bundling fix from AltimateAI/altimate-frontend#2425 — **not** the LTR change.
- The LTR fix (AltimateAI/altimate-frontend#2476) was only merged into `altimate-frontend/main` today (2026-04-09).
- `0.0.82-beta.4` was then published via a fresh `workflow_dispatch` against `fix/AI-0000-lego-ci-build` (AltimateAI/altimate-frontend#2513, still unmerged — its lego build-order CI fix is still needed because the upstream workflow on `main` doesn't yet build `@altimateai/lego` before `@altimateai/ui-components`).
- Net result: `beta.4` is `main` at #2476 merge + the lego build-order workflow fix. It **does** contain the LTR fix. `beta.3` did not.

Closes #1808 (pending release of this extension version).

## What changed in ui-components

`packages/ui-components/src/components/lineage/utils.ts::getSourceTargetHandles` was rewritten so horizontal-mode edges unconditionally return `["right", "left"]` (force LTR), instead of the prior 4-branch conditional that allowed `["left", "right"]`, `["left", "left"]`, and `["right", "right"]` depending on level ordering.

## Follow-up

- AltimateAI/altimate-frontend#2513 should be merged to fix the publish workflow on `main` — until then, anyone dispatching against `main` will hit the same lego-not-built failure that occurred on 2026-04-07 19:20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
