### PR TITLE
fix: harden `resolveSettingsVariables` against Sentry findings on #1871

### DIFF
--- a/src/test/suite/resolveSettingsVariables.test.ts
+++ b/src/test/suite/resolveSettingsVariables.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import type { Uri } from "vscode";
+import { resolveSettingsVariables } from "../../utils";
+
+// The vscode mock's `Uri` re-imports from "vscode" recursively, so construct
+// a minimal shape instead. `resolveSettingsVariables` only reads `.fsPath`.
+const mockUri = (fsPath: string): Uri => ({ fsPath }) as unknown as Uri;
+
+describe("resolveSettingsVariables", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("resolves a single ${env:VAR} placeholder", () => {
+    process.env.FOO = "hello";
+    expect(resolveSettingsVariables("--vars=${env:FOO}")).toBe("--vars=hello");
+  });
+
+  it("resolves MULTIPLE ${env:VAR} placeholders in one string", () => {
+    // Regression: the previous implementation used a stateful global regex
+    // with a mutating string, so the second placeholder was skipped.
+    process.env.FOO = "alpha";
+    process.env.BAR = "beta";
+    expect(
+      resolveSettingsVariables("--vars='a=${env:FOO},b=${env:BAR}'"),
+    ).toBe("--vars='a=alpha,b=beta'");
+  });
+
+  it("resolves repeated occurrences of the same ${env:VAR}", () => {
+    process.env.FOO = "x";
+    expect(resolveSettingsVariables("${env:FOO}/${env:FOO}")).toBe("x/x");
+  });
+
+  it("leaves unresolved ${env:VAR} placeholders untouched", () => {
+    delete process.env.NOT_SET;
+    expect(resolveSettingsVariables("before ${env:NOT_SET} after")).toBe(
+      "before ${env:NOT_SET} after",
+    );
+  });
+
+  it("treats env values containing $ characters as literal", () => {
+    // Regression: passing a raw value to String.replace() causes patterns
+    // like `$1`, `$&`, `$$` to be interpreted as backreferences, silently
+    // corrupting paths like `/home/$USER/project`.
+    process.env.WEIRD = "/home/$USER/$1/$&";
+    expect(resolveSettingsVariables("path=${env:WEIRD}")).toBe(
+      "path=/home/$USER/$1/$&",
+    );
+  });
+
+  it("resolves ${workspaceFolder} using the provided Uri", () => {
+    const folder = mockUri("/workspace/project");
+    expect(
+      resolveSettingsVariables("${workspaceFolder}/models", folder),
+    ).toBe("/workspace/project/models");
+  });
+
+  it("treats workspace folder paths containing $ characters as literal", () => {
+    // Windows paths can legitimately contain `$` (e.g. hidden admin shares).
+    const folder = mockUri("/weird/$1/path");
+    expect(
+      resolveSettingsVariables("${workspaceFolder}/models", folder),
+    ).toBe("/weird/$1/path/models");
+  });
+
+  it("handles mixed ${env:VAR} and ${workspaceFolder} substitutions", () => {
+    process.env.PROFILE = "dev";
+    const folder = mockUri("/ws");
+    expect(
+      resolveSettingsVariables(
+        "--profile ${env:PROFILE} --project-dir ${workspaceFolder}",
+        folder,
+      ),
+    ).toBe("--profile dev --project-dir /ws");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(resolveSettingsVariables("")).toBe("");
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -445,26 +445,26 @@ export function resolveSettingsVariables(
   }
 
   // Resolve ${env:VAR_NAME}
-  const regexEnv = /\$\{env:(.*?)\}/gm;
-  let match;
-  while ((match = regexEnv.exec(value)) !== null) {
-    if (match.index === regexEnv.lastIndex) {
-      regexEnv.lastIndex++;
-    }
-    const envValue = process.env[match[1]];
-    if (envValue !== undefined) {
-      value = value.replace(
-        new RegExp(`\\$\\{env:${match[1]}\\}`, "gm"),
-        envValue,
-      );
-    }
-  }
+  // Use a callback-based replace to:
+  // 1. Avoid desynchronizing a stateful global regex with the mutating string
+  //    (the previous while-loop skipped subsequent placeholders in strings
+  //    containing multiple `${env:VAR}` references).
+  // 2. Treat the replacement as a literal string — passing an env value
+  //    directly to replace() causes `$1`, `$&`, etc. in the value to be
+  //    interpreted as backreferences, silently corrupting paths like
+  //    `/home/$USER/project`.
+  // Unresolved placeholders (env var not set) are left as-is.
+  value = value.replace(/\$\{env:(.*?)\}/g, (match, varName) => {
+    const envValue = process.env[varName];
+    return envValue !== undefined ? envValue : match;
+  });
 
   // Resolve ${workspaceFolder}
-  const folder =
-    workspaceFolder ?? workspace.workspaceFolders?.[0]?.uri;
+  // Also use a callback for the same `$`-interpretation reason: workspace
+  // paths can legitimately contain `$` on Windows.
+  const folder = workspaceFolder ?? workspace.workspaceFolders?.[0]?.uri;
   if (folder) {
-    value = value.replace(/\$\{workspaceFolder\}/g, folder.fsPath);
+    value = value.replace(/\$\{workspaceFolder\}/g, () => folder.fsPath);
   }
 
   return value;


### PR DESCRIPTION
## Summary

Addresses two MEDIUM bugs Sentry flagged on #1871 three minutes after that PR merged, in `src/utils.ts::resolveSettingsVariables`. Both are silent data-corruption bugs — they return wrong strings instead of throwing, so users experience them as "my dbt command didn't get the vars I configured".

## Bugs

### Bug 1 — multi-placeholder iteration failure (`src/utils.ts`, L448–461)

The prior implementation used `regexEnv.exec()` in a `while` loop while simultaneously mutating `value` with `value.replace()` inside the loop body. The regex's `lastIndex` is not rewound after the string shrinks, so any string containing more than one `${env:VAR}` placeholder had every placeholder after the first **silently skipped**.

**Repro in Docker E2E container** (`TEST_VAR1=alpha`, `TEST_VAR2=beta`):
```
Input:  "a=${env:TEST_VAR1},b=${env:TEST_VAR2}"
OLD:    "a=alpha,b=${env:TEST_VAR2}"   ← second placeholder lost
NEW:    "a=alpha,b=beta"                ← fixed
```

### Bug 2 — `$` interpretation in replacement string (`src/utils.ts`, L456–459)

Passing the raw env value as the second argument to `String.replace()` causes sequences like `$&`, `$'`, `$\``, `$$` to be interpreted as [backreferences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement). If an env value contained any of those, the substituted string was silently corrupted.

**Repro in Docker E2E container** (`WEIRD=/tmp/$&/backup`):
```
Input:  "path=${env:WEIRD}"
OLD:    "path=/tmp/${env:WEIRD}/backup"   ← $& expanded to the whole match
NEW:    "path=/tmp/$&/backup"              ← fixed
```

## Fix

Single callback-based `.replace()` pass. The callback:
1. Receives the original (non-mutating) string in one shot → no stateful-regex / mutating-string interaction
2. Returns the env value as a literal string → no backreference interpretation

Unresolved placeholders (env var not set) are left in place — matches prior behavior.

The same callback form is applied to `${workspaceFolder}` for the same `$`-interpretation reason. Windows paths can legitimately contain `$` characters (hidden admin shares), so the prior raw-string substitution had the same latent bug there.

## Tests

Adds `src/test/suite/resolveSettingsVariables.test.ts` with 9 regression cases:

- ✅ Bug 1 guard: multiple `${env:VAR}` placeholders in one string
- ✅ Bug 2 guard: env value contains `$` characters
- ✅ Single placeholder resolution
- ✅ Repeated occurrences of same var
- ✅ Unresolved placeholders preserved
- ✅ Workspace folder with `$` characters
- ✅ Mixed `${env:VAR}` + `${workspaceFolder}`
- ✅ Empty string handling
- ✅ Basic workspace folder resolution

All 9 pass locally.

## Docker E2E

Parity with #1871's Docker E2E testing. Code-server container recreated with test env vars (`TEST_VAR1=alpha`, `TEST_VAR2=beta`, `WEIRD=/tmp/$&/backup`, `REPEATED=x`). `.vscode/settings.json` in the jaffle-shop-duckdb test project configured with `dbt.runModelCommandAdditionalParams` exercising all three scenarios (multi-placeholder, `$`-char value, repeated same var). Standalone verification script run inside the container confirmed:

- **OLD code**: 1/6 params corrupted (multi-placeholder case), Bug 2 reproduced separately via `$&` env value
- **NEW code**: 6/6 params resolved correctly, both bug scenarios preserved as literal

## Why follow-up instead of amending #1871

#1871 was already merged and in `v0.60.3` / `v0.60.4` releases on master. Sentry's review landed 3 minutes after the merge. A new PR is the clean path.

## Sentry review references

- Bug 1: https://github.com/AltimateAI/vscode-dbt-power-user/pull/1871#discussion_r_ref_12970438_0 (stateful regex iteration)
- Bug 2: https://github.com/AltimateAI/vscode-dbt-power-user/pull/1871#discussion_r_ref_12970438_1 (`$` interpretation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed placeholder resolution to correctly handle `$` characters in environment variable values and workspace folder paths as literal content.

* **Tests**
  * Added comprehensive test suite for placeholder resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->