### PR TITLE
chore: support isolated docker deploys for parallel PR testing

### DIFF
--- a/docker-setup/deploy-isolated.sh
+++ b/docker-setup/deploy-isolated.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# deploy-isolated.sh — deploy the code-server container with a unique
+# compose project name, container name, and host port so multiple
+# PR branches can run side-by-side.
+#
+# Usage:
+#   ISSUE_NUM=1720 HOST_PORT=3020 ./docker-setup/deploy-isolated.sh
+#
+# Required env vars:
+#   ISSUE_NUM       Issue / PR number (used for the compose project + container slug)
+#   HOST_PORT       Host port to publish code-server on
+#
+# Optional env vars:
+#   CONTAINER_NAME  Override the container name (defaults to dbtpu-<ISSUE_NUM>)
+#   DBT_PROJECT_PATH  Host path to a custom dbt project (defaults to built-in)
+#   NO_BUILD        If set, skip `npm run webpack` (use an already-built dist/)
+#
+# Unlike deploy.sh, this script starts the container detached and returns
+# immediately — it does not block on `npm run watch`. Rebuild manually
+# between test runs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+: "${ISSUE_NUM:?ISSUE_NUM is required (e.g. ISSUE_NUM=1720)}"
+: "${HOST_PORT:?HOST_PORT is required (e.g. HOST_PORT=3020)}"
+
+export CONTAINER_NAME="${CONTAINER_NAME:-dbtpu-${ISSUE_NUM}}"
+export COMPOSE_PROJECT_NAME="dbtpu-${ISSUE_NUM}"
+export HOST_PORT
+
+if docker compose version &>/dev/null; then
+    DC="docker compose -f docker-setup/docker-compose.yml"
+else
+    DC="docker-compose -f docker-setup/docker-compose.yml"
+fi
+
+# Load .env overrides if present
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    echo "Loading .env from docker-setup/.env"
+    set -a
+    . "$SCRIPT_DIR/.env"
+    set +a
+fi
+
+echo "Isolated deploy config:"
+echo "  ISSUE_NUM           = $ISSUE_NUM"
+echo "  COMPOSE_PROJECT_NAME= $COMPOSE_PROJECT_NAME"
+echo "  CONTAINER_NAME      = $CONTAINER_NAME"
+echo "  HOST_PORT           = $HOST_PORT"
+echo "  DBT_PROJECT_PATH    = ${DBT_PROJECT_PATH:-<built-in jaffle_shop_duckdb>}"
+
+if [ -z "${NO_BUILD:-}" ]; then
+    echo ""
+    echo "Building extension with webpack..."
+    npm run webpack
+else
+    echo ""
+    echo "NO_BUILD set — skipping webpack build"
+fi
+
+echo ""
+echo "Building and starting code-server container (detached)..."
+$DC up --build -d
+
+echo ""
+echo "Waiting for code-server to be ready on port $HOST_PORT..."
+MAX_WAIT=60
+WAITED=0
+until curl -sf "http://localhost:${HOST_PORT}/healthz" > /dev/null 2>&1; do
+    if [ $WAITED -ge $MAX_WAIT ]; then
+        echo "Timed out waiting for code-server after ${MAX_WAIT}s"
+        echo "Logs:  $DC logs --tail=100"
+        exit 1
+    fi
+    sleep 2
+    WAITED=$((WAITED + 2))
+    echo "  Waiting... (${WAITED}s)"
+done
+
+echo ""
+echo "Ready: http://localhost:${HOST_PORT}/?folder=/home/coder/project"
+echo ""
+echo "To tear down:"
+echo "  COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME CONTAINER_NAME=$CONTAINER_NAME HOST_PORT=$HOST_PORT \\"
+echo "    $DC down"

--- a/docker-setup/docker-compose.yml
+++ b/docker-setup/docker-compose.yml
@@ -3,8 +3,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: ${CONTAINER_NAME:-dbtpu-codeserver}
     ports:
-      - "3001:3001"
+      - "${HOST_PORT:-3001}:3001"
     environment:
       - PORT=3001
     volumes:


### PR DESCRIPTION
## Summary

- Adds optional `CONTAINER_NAME` and `HOST_PORT` env-var overrides to `docker-setup/docker-compose.yml` so multiple code-server containers can run side-by-side without colliding. Defaults unchanged — existing `npm run docker:deploy` flows are unaffected.
- Adds `docker-setup/deploy-isolated.sh` as a companion to `deploy.sh`. Takes `ISSUE_NUM` + `HOST_PORT`, derives `COMPOSE_PROJECT_NAME` + `CONTAINER_NAME`, builds the extension, and starts the container detached (no blocking `npm run watch` tail).

## Why

Unblocks parallel verification of triage-bug PRs: each issue gets its own worktree, branch, container name, and host port, so multiple PRs can be tested concurrently in code-server without tearing each other down.

## Test plan

- [x] `docker compose -f docker-setup/docker-compose.yml config` still resolves with defaults (`dbtpu-codeserver` on `3001`)
- [x] Same command with `COMPOSE_PROJECT_NAME=dbtpu-smoke CONTAINER_NAME=dbtpu-smoke HOST_PORT=3099` resolves to the overridden values
- [ ] Full end-to-end container boot verified on first triage-issue PR stacked on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)