### PR TITLE
fix: [#1706] disambiguate model and snapshot sharing the same name in docs editor

### DIFF
--- a/src/services/docGenService.ts
+++ b/src/services/docGenService.ts
@@ -121,13 +121,55 @@ export class DocGenService {
     };
   }
 
-  private getCurrentNode(modelName: string): NodeMetaData | undefined {
+  /**
+   * Resolve the manifest node backing a .sql file for the documentation editor.
+   *
+   * The underlying `nodeMetaMap` stores both models and snapshots in a single
+   * name-keyed map, so `lookupByBaseName` cannot disambiguate when a model and
+   * snapshot share a filename (e.g. `orders.sql` exists as both). To guarantee
+   * the model is returned (never the snapshot), we iterate the node list and
+   * match on the file path AND `resource_type === "model"`.
+   *
+   * We fall back to `lookupByBaseName` only when no node has a matching `path`
+   * (e.g. dbt Cloud, where packaged nodes may have `path === undefined`), so
+   * existing behaviour is preserved for setups without a local path.
+   */
+  private getCurrentNode(
+    modelName: string,
+    filePath: string,
+  ): NodeMetaData | undefined {
     const eventResult = this.queryManifestService.getEventByCurrentProject();
     if (!eventResult || !eventResult.event) {
       return undefined;
     }
 
     const { event } = eventResult;
+
+    // Primary resolution: match by full file path AND model resource type so
+    // a snapshot sharing the same filename never shadows the model.
+    let pathMatchFound = false;
+    for (const node of event.nodeMetaMap.nodes()) {
+      if (node.path !== filePath) {
+        continue;
+      }
+      pathMatchFound = true;
+      if (node.resource_type === RESOURCE_TYPE_MODEL) {
+        return node;
+      }
+    }
+
+    // If any node matched the path but none was a model (e.g. only a snapshot
+    // lives at this path), return the first path-matched node so the caller's
+    // downstream `resource_type` guard can produce an accurate error message.
+    if (pathMatchFound) {
+      for (const node of event.nodeMetaMap.nodes()) {
+        if (node.path === filePath) {
+          return node;
+        }
+      }
+    }
+
+    // Fallback: dbt Cloud / remote manifests may not populate `path`.
     return event.nodeMetaMap.lookupByBaseName(modelName);
   }
 
@@ -354,8 +396,9 @@ export class DocGenService {
       };
     }
 
-    // Node validation
-    const currentNode = this.getCurrentNode(modelName);
+    // Node validation - resolve by file path to disambiguate models from
+    // snapshots that share the same filename.
+    const currentNode = this.getCurrentNode(modelName, filePath);
     if (!currentNode) {
       return {
         documentation: undefined,

--- a/src/test/suite/docGenService.test.ts
+++ b/src/test/suite/docGenService.test.ts
@@ -1,0 +1,176 @@
+import {
+  NodeMetaData,
+  NodeMetaMap,
+  RESOURCE_TYPE_MODEL,
+} from "@altimateai/dbt-integration";
+import { describe, expect, it, jest } from "@jest/globals";
+import { DocGenService } from "../../services/docGenService";
+
+/**
+ * Regression tests for https://github.com/AltimateAI/vscode-dbt-power-user/issues/1706
+ *
+ * The documentation editor resolved manifest nodes by bare filename via
+ * `nodeMetaMap.lookupByBaseName(modelName)`. Because both models and snapshots
+ * populate the same name-keyed lookup map, a snapshot sharing a filename with
+ * a model (e.g. `orders.sql` existing as both) would shadow the model and the
+ * editor either showed snapshot metadata or refused to load with
+ * "This file appears to be a snapshot". The fix routes resolution through the
+ * file path AND resource_type so the collision can never occur.
+ */
+describe("DocGenService - model/snapshot name collision (#1706)", () => {
+  const MODEL_PATH = "/workspace/project/models/marts/orders.sql";
+  const SNAPSHOT_PATH = "/workspace/project/snapshots/orders.sql";
+
+  const modelNode: NodeMetaData = {
+    unique_id: "model.project.orders",
+    path: MODEL_PATH,
+    database: "db",
+    schema: "schema",
+    alias: "orders",
+    name: "orders",
+    package_name: "project",
+    description: "The canonical orders model",
+    patch_path: "",
+    columns: {
+      order_id: {
+        name: "order_id",
+        description: "PK",
+        data_type: "integer",
+        meta: {},
+      },
+    },
+    config: { materialized: "table" },
+    resource_type: RESOURCE_TYPE_MODEL,
+    depends_on: { nodes: [], macros: [] } as any,
+    is_external_project: false,
+    compiled_path: "",
+    meta: {},
+  };
+
+  const snapshotNode: NodeMetaData = {
+    unique_id: "snapshot.project.orders",
+    path: SNAPSHOT_PATH,
+    database: "db",
+    schema: "snapshots",
+    alias: "orders",
+    name: "orders",
+    package_name: "project",
+    description: "Orders snapshot",
+    patch_path: "",
+    columns: {
+      order_id: {
+        name: "order_id",
+        description: "PK (snapshot)",
+        data_type: "integer",
+        meta: {},
+      },
+    },
+    config: { materialized: "snapshot" },
+    resource_type: "snapshot",
+    depends_on: { nodes: [], macros: [] } as any,
+    is_external_project: false,
+    compiled_path: "",
+    meta: {},
+  };
+
+  /**
+   * Build a NodeMetaMap stub that mirrors the real `NodeMetaMapImpl`
+   * collision behaviour: `lookupByBaseName("orders")` returns whichever node
+   * was registered last (last-write-wins on the shared name map).
+   */
+  function buildNodeMetaMap(
+    nodes: NodeMetaData[],
+    baseNameWinner: NodeMetaData,
+  ): NodeMetaMap {
+    return {
+      lookupByBaseName: (modelBaseName: string) =>
+        modelBaseName === baseNameWinner.name ? baseNameWinner : undefined,
+      lookupByUniqueId: (uniqueId: string) =>
+        nodes.find((n) => n.unique_id === uniqueId),
+      nodes: () => nodes[Symbol.iterator](),
+    };
+  }
+
+  function buildService(nodeMetaMap: NodeMetaMap): DocGenService {
+    const service = Object.create(DocGenService.prototype) as DocGenService;
+    (service as any).queryManifestService = {
+      getEventByCurrentProject: jest.fn().mockReturnValue({
+        event: { nodeMetaMap },
+      }),
+    };
+    return service;
+  }
+
+  it("returns the model when the snapshot is iterated last (would previously shadow it)", () => {
+    const nodes = [modelNode, snapshotNode];
+    const nodeMetaMap = buildNodeMetaMap(nodes, snapshotNode);
+    const service = buildService(nodeMetaMap);
+
+    // Simulate opening the model file.
+    const result = (service as any).getCurrentNode("orders", MODEL_PATH) as
+      | NodeMetaData
+      | undefined;
+
+    expect(result).toBeDefined();
+    expect(result!.unique_id).toBe("model.project.orders");
+    expect(result!.resource_type).toBe(RESOURCE_TYPE_MODEL);
+  });
+
+  it("returns the model when the model is iterated last", () => {
+    const nodes = [snapshotNode, modelNode];
+    const nodeMetaMap = buildNodeMetaMap(nodes, modelNode);
+    const service = buildService(nodeMetaMap);
+
+    const result = (service as any).getCurrentNode("orders", MODEL_PATH) as
+      | NodeMetaData
+      | undefined;
+
+    expect(result).toBeDefined();
+    expect(result!.unique_id).toBe("model.project.orders");
+  });
+
+  it("returns the snapshot when the active file is actually the snapshot path", () => {
+    // Opening the snapshot file should still resolve a node so downstream
+    // code can show an accurate "this is a snapshot, not a model" message.
+    const nodes = [modelNode, snapshotNode];
+    const nodeMetaMap = buildNodeMetaMap(nodes, modelNode);
+    const service = buildService(nodeMetaMap);
+
+    const result = (service as any).getCurrentNode("orders", SNAPSHOT_PATH) as
+      | NodeMetaData
+      | undefined;
+
+    expect(result).toBeDefined();
+    expect(result!.unique_id).toBe("snapshot.project.orders");
+    expect(result!.resource_type).toBe("snapshot");
+  });
+
+  it("falls back to lookupByBaseName when no node has a matching path (dbt Cloud)", () => {
+    // dbt Cloud / remote manifests may not populate `path`.
+    const cloudModelNode: NodeMetaData = {
+      ...modelNode,
+      path: undefined,
+    };
+    const nodes = [cloudModelNode];
+    const nodeMetaMap = buildNodeMetaMap(nodes, cloudModelNode);
+    const service = buildService(nodeMetaMap);
+
+    const result = (service as any).getCurrentNode("orders", MODEL_PATH) as
+      | NodeMetaData
+      | undefined;
+
+    expect(result).toBeDefined();
+    expect(result!.unique_id).toBe("model.project.orders");
+  });
+
+  it("returns undefined when there is no manifest event", () => {
+    const service = Object.create(DocGenService.prototype) as DocGenService;
+    (service as any).queryManifestService = {
+      getEventByCurrentProject: jest.fn().mockReturnValue(undefined),
+    };
+
+    const result = (service as any).getCurrentNode("orders", MODEL_PATH);
+
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1706. When a dbt project has a model and a snapshot that share the same filename (e.g. `models/marts/orders.sql` and `snapshots/orders.sql`), the Documentation editor either refused to load with *"This file appears to be a snapshot, macro, test, or other dbt resource type which is not supported"* or silently showed the snapshot's metadata when opening the model file.

## Root cause

`DocGenService.getCurrentNode` resolved the manifest node via `nodeMetaMap.lookupByBaseName(modelName)`, which is keyed by bare filename. The underlying `NodeMetaMapImpl` (in `@altimateai/dbt-integration`) builds `modelNameLookupMap` from `path.parse(fullPath).name` for **every** `isResourceNode` entry — and `isResourceNode` returns `true` for **both** models and snapshots. As a result, a snapshot with the same filename as a model last-write-wins the name map, shadowing the model. The extension then either:

1. Returned the snapshot, tripped the `resource_type !== "model"` guard in `getDocumentation`, and surfaced the snapshot error message — even though the user opened the model file, or
2. Returned whichever was iterated last non-deterministically across reloads.

## Fix

Resolve the current node by iterating `nodeMetaMap.nodes()` and matching on the full file `path` **AND** `resource_type === "model"`. A snapshot can never win the tie because its resource_type is `"snapshot"`. Falls back to `lookupByBaseName` only when no node has a matching `path` (e.g. dbt Cloud manifests, where packaged nodes may have `path === undefined`), preserving existing behaviour for cloud setups.

## Files changed

- `src/services/docGenService.ts` — rewrite `getCurrentNode` to accept `filePath` and resolve via `path` + `resource_type` with a dbt-Cloud fallback. Update the single caller in `getDocumentation`.
- `src/test/suite/docGenService.test.ts` — new Jest regression suite (5 cases) covering both manifest iteration orders, snapshot-path resolution, cloud fallback, and missing-event guard.

## Verification

### Unit tests (passing)

```
PASS src/test/suite/docGenService.test.ts
  DocGenService - model/snapshot name collision (#1706)
    ✓ returns the model when the snapshot is iterated last (would previously shadow it)
    ✓ returns the model when the model is iterated last
    ✓ returns the snapshot when the active file is actually the snapshot path
    ✓ falls back to lookupByBaseName when no node has a matching path (dbt Cloud)
    ✓ returns undefined when there is no manifest event
```

Full `npx jest` run: **21 suites, 262 passed, 1 skipped**. ESLint clean. `tsc --noEmit` clean.

### Docker runtime verification ✅

Reproduced the collision end-to-end against the real `@altimateai/dbt-integration@0.2.12` package and a real `target/manifest.json` inside `dbtpu-1706` (jaffle-shop-duckdb + a `snapshots/orders.sql` alongside the existing `models/orders.sql`):

- `NodeParser.createNodeMetaMap` returns a 9-node map containing both `model.jaffle_shop.orders` and `snapshot.jaffle_shop.orders` with their correct file paths
- This PR's `getCurrentNode` logic returns the **model** (`unique_id: model.jaffle_shop.orders`) when queried with `/home/coder/jaffle-shop-duckdb/models/orders.sql`
- The **old** `lookupByBaseName("orders")` path still returns the **snapshot** — reproducing the reported bug against the same package version

Full evidence (script, output, manifest snippet) in a follow-up comment on this PR.

## Test plan

- [x] `npx jest src/test/suite/docGenService.test.ts` — all 5 cases pass
- [x] Full `npx jest` green (262 passing, 1 skipped)
- [x] ESLint clean on `src/services/docGenService.ts` and the new test file
- [x] `tsc --noEmit` clean
- [x] Docker repro on jaffle-shop-duckdb with a conflicting `snapshots/orders.sql` — verified against real `NodeParser` + real manifest (see comment below)
- [ ] Regression check: opening a standalone model (no conflicting snapshot) still loads its doc
- [ ] Regression check: opening a standalone snapshot still produces the "snapshot is not supported" warning (not a silent pass)
- [ ] dbt Cloud smoke test (if available): doc editor still works when `path === undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)