### PR TITLE
fix: [#1754] resolve macros prefixed with their own project name in go-to-definition

### DIFF
--- a/src/definition_provider/macroDefinitionProvider.ts
+++ b/src/definition_provider/macroDefinitionProvider.ts
@@ -59,16 +59,36 @@ export class MacroDefinitionProvider implements DefinitionProvider, Disposable {
           document.uri,
         );
 
-        const macroName =
-          packageName !== undefined && !word.includes(".")
-            ? `${packageName}.${word}`
-            : word;
+        // Build the list of lookup candidates for the macro meta map. The map
+        // stores macros from the current dbt project under their bare name
+        // (e.g. `log_toto`) and macros from installed packages under
+        // `<package>.<name>` (e.g. `dbt_utils.pivot`). The editor word may
+        // already carry a package prefix, and — per issue #1754 — that prefix
+        // may be the current project's own name, which dbt accepts as a valid
+        // call even though the map is keyed by the bare name.
+        const lookupCandidates: string[] = [];
+        if (word.includes(".")) {
+          // Prefer the full `<pkg>.<name>` lookup first (cross-package call),
+          // then fall back to the bare `<name>` lookup, which matches macros
+          // defined in the current project (including self-prefixed calls).
+          lookupCandidates.push(word);
+          const dotIndex = word.indexOf(".");
+          lookupCandidates.push(word.substring(dotIndex + 1));
+        } else if (packageName !== undefined) {
+          // Inside an installed package: unprefixed calls resolve against
+          // that package's own macros, which are keyed as `<pkg>.<name>`.
+          lookupCandidates.push(`${packageName}.${word}`);
+        } else {
+          lookupCandidates.push(word);
+        }
 
-        const definition = this.getMacroDefinition(macroName, document.uri);
-        if (definition !== undefined) {
-          resolve(definition);
-          this.telemetry.sendTelemetryEvent("provideMacroDefinition");
-          return;
+        for (const candidate of lookupCandidates) {
+          const definition = this.getMacroDefinition(candidate, document.uri);
+          if (definition !== undefined) {
+            resolve(definition);
+            this.telemetry.sendTelemetryEvent("provideMacroDefinition");
+            return;
+          }
         }
       }
       resolve(undefined);

--- a/src/test/mock/vscode.ts
+++ b/src/test/mock/vscode.ts
@@ -53,6 +53,13 @@ export class Range {
   }
 }
 
+export class Location {
+  constructor(
+    public uri: typeof Uri | any,
+    public rangeOrPosition: Range | Position,
+  ) {}
+}
+
 export const DiagnosticSeverity = {
   Error: 0,
   Warning: 1,

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -89,6 +89,10 @@ jest.mock("vscode", () => ({
     line,
     character,
   })),
+  Location: jest.fn().mockImplementation((uri: any, rangeOrPosition: any) => ({
+    uri,
+    range: rangeOrPosition,
+  })),
   TreeItemCollapsibleState: {
     None: 0,
     Collapsed: 1,

--- a/src/test/suite/macroDefinitionProvider.test.ts
+++ b/src/test/suite/macroDefinitionProvider.test.ts
@@ -1,0 +1,207 @@
+import type { MacroMetaMap } from "@altimateai/dbt-integration";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { DBTProjectContainer } from "../../dbt_client/dbtProjectContainer";
+import { ManifestCacheChangedEvent } from "../../dbt_client/event/manifestCacheChangedEvent";
+import { MacroDefinitionProvider } from "../../definition_provider/macroDefinitionProvider";
+import { TelemetryService } from "../../telemetry";
+
+// A minimal text document mock tailored for MacroDefinitionProvider.
+// The provider only touches lineAt(position).text, getWordRangeAtPosition,
+// getText(range), and uri. It also calls isEnclosedWithinCodeBlock which
+// scans lineAt(i).text for '{'/'}' — wrapping each snippet in a jinja
+// statement block ({{ ... }}) is enough to satisfy that check.
+// The range is returned as a plain `{ start, end }` object because the
+// vscode mock's `Position` / `Range` are jest.fn() impls and we don't want
+// the `instanceof Position` check in isEnclosedWithinCodeBlock to match.
+const createMockDocument = (line: string, word: string) => {
+  const character = line.indexOf(word);
+  if (character === -1) {
+    throw new Error(`word "${word}" not found in line: ${line}`);
+  }
+  const range = {
+    start: { line: 0, character },
+    end: { line: 0, character: character + word.length },
+  };
+  return {
+    uri: { fsPath: "/workspace/project/macros/call_toto.sql" } as any,
+    lineAt: (_pos: any) => ({ text: line }),
+    lineCount: 1,
+    getWordRangeAtPosition: (_pos: any, _regex: RegExp) => range,
+    getText: (_range: any) => word,
+  } as any;
+};
+
+describe("MacroDefinitionProvider — issue #1754", () => {
+  const PROJECT_ROOT = "/workspace/project";
+  let mockContainer: jest.Mocked<DBTProjectContainer>;
+  let mockTelemetry: jest.Mocked<TelemetryService>;
+  let manifestHandlers: Array<(event: ManifestCacheChangedEvent) => void>;
+  let provider: MacroDefinitionProvider;
+
+  const fireManifest = (macroMetaMap: MacroMetaMap) => {
+    const event: ManifestCacheChangedEvent = {
+      added: [
+        {
+          project: {
+            projectRoot: { fsPath: PROJECT_ROOT } as any,
+          } as any,
+          macroMetaMap,
+        } as any,
+      ],
+      removed: undefined,
+    } as any;
+    for (const handler of manifestHandlers) {
+      handler(event);
+    }
+  };
+
+  beforeEach(() => {
+    manifestHandlers = [];
+    mockContainer = {
+      onManifestChanged: (handler: any) => {
+        manifestHandlers.push(handler);
+        return { dispose: jest.fn() };
+      },
+      getPackageName: jest.fn(),
+      getProjectRootpath: jest.fn().mockReturnValue({ fsPath: PROJECT_ROOT }),
+    } as any;
+
+    mockTelemetry = {
+      sendTelemetryEvent: jest.fn(),
+    } as any;
+
+    provider = new MacroDefinitionProvider(mockContainer, mockTelemetry);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const ownProjectMacro = {
+    path: "/workspace/project/macros/log_toto.sql",
+    line: 0,
+    character: 10,
+    unique_id: "macro.jaffle_shop.log_toto",
+    name: "log_toto",
+    description: "",
+    arguments: [],
+    depends_on: { macros: [] },
+  };
+
+  const dbtUtilsMacro = {
+    path: "/workspace/project/dbt_packages/dbt_utils/macros/pivot.sql",
+    line: 3,
+    character: 10,
+    unique_id: "macro.dbt_utils.pivot",
+    name: "pivot",
+    description: "",
+    arguments: [],
+    depends_on: { macros: [] },
+  };
+
+  it("resolves an unprefixed macro call inside the current project (existing behavior)", async () => {
+    const map: MacroMetaMap = new Map();
+    // Current-project macros are keyed by bare name — see macroParser.ts.
+    map.set("log_toto", ownProjectMacro as any);
+    fireManifest(map);
+
+    // packageName is undefined for files inside the current project (only
+    // returns a string when the file lives under dbt_packages/).
+    (mockContainer.getPackageName as jest.Mock).mockReturnValue(undefined);
+
+    const document = createMockDocument("    {{ log_toto() }}", "log_toto");
+    const result: any = await provider.provideDefinition(document, {
+      line: 0,
+      character: 10,
+    } as any);
+
+    expect(result).toBeDefined();
+    expect(result.uri.fsPath).toBe(ownProjectMacro.path);
+    expect(result.range.line).toBe(0);
+    expect(mockTelemetry.sendTelemetryEvent).toHaveBeenCalledWith(
+      "provideMacroDefinition",
+    );
+  });
+
+  it("resolves <current_project>.<macro> self-prefixed calls (issue #1754)", async () => {
+    const map: MacroMetaMap = new Map();
+    map.set("log_toto", ownProjectMacro as any);
+    fireManifest(map);
+
+    (mockContainer.getPackageName as jest.Mock).mockReturnValue(undefined);
+
+    const document = createMockDocument(
+      "    {{ jaffle_shop.log_toto() }}",
+      "jaffle_shop.log_toto",
+    );
+    const result: any = await provider.provideDefinition(document, {
+      line: 0,
+      character: 15,
+    } as any);
+
+    expect(result).toBeDefined();
+    expect(result.uri.fsPath).toBe(ownProjectMacro.path);
+    expect(mockTelemetry.sendTelemetryEvent).toHaveBeenCalledWith(
+      "provideMacroDefinition",
+    );
+  });
+
+  it("resolves cross-package <other_pkg>.<macro> calls", async () => {
+    const map: MacroMetaMap = new Map();
+    map.set("log_toto", ownProjectMacro as any);
+    // Cross-package macros are keyed as `<pkg>.<name>` — see macroParser.ts.
+    map.set("dbt_utils.pivot", dbtUtilsMacro as any);
+    fireManifest(map);
+
+    (mockContainer.getPackageName as jest.Mock).mockReturnValue(undefined);
+
+    const document = createMockDocument(
+      "    {{ dbt_utils.pivot() }}",
+      "dbt_utils.pivot",
+    );
+    const result: any = await provider.provideDefinition(document, {
+      line: 0,
+      character: 10,
+    } as any);
+
+    expect(result).toBeDefined();
+    expect(result.uri.fsPath).toBe(dbtUtilsMacro.path);
+    expect(result.range.line).toBe(3);
+  });
+
+  it("returns undefined for unknown macros without touching telemetry", async () => {
+    fireManifest(new Map());
+
+    (mockContainer.getPackageName as jest.Mock).mockReturnValue(undefined);
+
+    const document = createMockDocument(
+      "    {{ unknown_macro() }}",
+      "unknown_macro",
+    );
+    const result = await provider.provideDefinition(document, {
+      line: 0,
+      character: 10,
+    } as any);
+
+    expect(result).toBeUndefined();
+    expect(mockTelemetry.sendTelemetryEvent).not.toHaveBeenCalled();
+  });
+
+  it("resolves unprefixed calls from inside an installed package (preserves existing behavior)", async () => {
+    const map: MacroMetaMap = new Map();
+    map.set("dbt_utils.pivot", dbtUtilsMacro as any);
+    fireManifest(map);
+
+    // Files inside dbt_packages/dbt_utils/... report packageName = "dbt_utils"
+    (mockContainer.getPackageName as jest.Mock).mockReturnValue("dbt_utils");
+
+    const document = createMockDocument("    {{ pivot() }}", "pivot");
+    const result: any = await provider.provideDefinition(document, {
+      line: 0,
+      character: 9,
+    } as any);
+
+    expect(result).toBeDefined();
+    expect(result.uri.fsPath).toBe(dbtUtilsMacro.path);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1754. Self-prefixed macro calls like `{{ my_project.my_macro() }}` now navigate to the macro definition via Ctrl/Cmd+click. Hover was unaffected by the bug — only the definition provider mishandled the prefix.

## Repro

In a project named `jaffle_shop`:

```sql
-- macros/log_toto.sql
{% macro log_toto() %}
    {{ log("Toto", info=True) }}
{% endmacro %}

-- macros/call_toto.sql
{% macro call_toto() %}
    {{ jaffle_shop.log_toto() }}
{% endmacro %}
```

Before: Ctrl+click on `log_toto` in `call_toto.sql` does nothing (hover still shows name + description).
After: jumps to `log_toto.sql`.

## Root cause

`MacroDefinitionProvider.IS_MACRO` (`/\w+\.?\w+/`) captures the full `pkg.name` token under the cursor. Own-project macros are stored in `macroMetaMap` under the **bare** name (see `@altimateai/dbt-integration`'s `macroParser.ts`: `packageName === projectName ? name : \`${packageName}.${name}\``). A lookup for `jaffle_shop.log_toto` against a map keyed by `log_toto` never hit, so the provider returned no location.

Hover worked because the default `getWordRangeAtPosition` (no custom regex) returns just `log_toto`.

## Fix

Build an ordered list of lookup candidates. For a dotted word:

1. Try `<pkg>.<name>` first — covers cross-package calls (`dbt_utils.type_string`, etc.)
2. Fall back to the bare `<name>` — covers the own-project self-prefix case (#1754)

Unprefixed behavior preserved: bare name when `packageName` is undefined, `<pkg>.<name>` when the file being edited lives inside an installed package.

## Files changed

- `src/definition_provider/macroDefinitionProvider.ts` — candidate-based lookup
- `src/test/suite/macroDefinitionProvider.test.ts` — new 5-case Jest suite
- `src/test/mock/vscode.ts` — add `Location` to the mock (needed by the provider test)
- `src/test/setup.ts` — mirror `Location` in the inline `jest.mock("vscode", ...)` factory

## Verification

### Before/after against `origin/master` HEAD

Ran the new test file against both versions of `macroDefinitionProvider.ts` in the same worktree:

- **Master HEAD source**: 1 failure, exactly on the `<current_project>.<macro>` self-prefix case. The other four cases (unprefixed bare-name, cross-package `<pkg>.<name>`, unknown macro no-op, in-package unprefixed) pass because those branches were already correct on master.
- **Fix branch source**: 5/5 pass.

This isolates the behavior change to the self-prefix case — which is the #1754 bug. Full log in the follow-up comment on this PR.

### Full suite

```
PASS src/test/suite/macroDefinitionProvider.test.ts
  MacroDefinitionProvider — issue #1754
    ✓ resolves an unprefixed macro call inside the current project (existing behavior)
    ✓ resolves <current_project>.<macro> self-prefixed calls (issue #1754)
    ✓ resolves cross-package <other_pkg>.<macro> calls
    ✓ returns undefined for unknown macros without touching telemetry
    ✓ resolves unprefixed calls from inside an installed package (preserves existing behavior)
```

Full `npx jest` run: **21 suites, 262 passed, 1 skipped, 0 failing**. `tsc --noEmit` clean.

### Secondary code-path / regression checks

The candidate-based lookup has four branches:

| Scenario | Candidate order | Pre-fix behavior | Post-fix behavior |
|---|---|---|---|
| Unprefixed call, inside current project | `[word]` | works | works (identical) |
| Cross-package `<pkg>.<name>` | `[word, name]`, `<pkg>.<name>` hits first | works | works (identical) |
| **Self-prefix `<current_project>.<name>` (#1754)** | `[word, name]`, bare name hits | **broken** | **fixed** |
| Unprefixed call inside an installed package | `[${packageName}.${word}]` | works | works (identical) |
| Unknown macro (any branch) | walks all candidates, none hit, no telemetry | works | works (identical) |

The only behavior change is the self-prefix case. Every other branch either hits the first candidate (same as master's single-candidate lookup) or walks misses to the same no-op end state. `MacroHoverProvider` was never affected by this bug (default `getWordRangeAtPosition` returns just the macro name without the prefix) and is untouched by this PR.

## Test plan

- [x] `npx jest src/test/suite/macroDefinitionProvider.test.ts` — 5/5 pass on fix branch
- [x] Same test file run against master HEAD source — fails on exactly 1 case (the self-prefix case #1754 targets), others pass (see comment below)
- [x] Full Jest suite green (262 passing, 1 skipped)
- [x] `tsc --noEmit` clean
- [x] Regression paths covered by tests: unprefixed in-project, cross-package, unknown macro no-op, unprefixed in installed package — all behave identically on master and fix
- [ ] Manual verification on a real project: Ctrl+click on `<own_project>.<macro>`, `<other_pkg>.<macro>`, and `<bare_macro>` all navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved macro definition resolution to better support packaged and namespaced macros (e.g., `dbt_utils.pivot()`)
  * Enhanced lookup logic with intelligent fallback handling for both prefixed and unprefixed macro calls
  * Better cross-package macro definition discovery while preserving existing in-package resolution behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->