### PR TITLE
fix: guard hover provider against undefined data_type and macro type

### DIFF
--- a/src/hover_provider/utils.ts
+++ b/src/hover_provider/utils.ts
@@ -26,7 +26,7 @@ export function generateHoverMarkdownString(
     content.appendMarkdown(
       `<span style="color:#347890;">(column)&nbsp;</span><span>${column.name} &nbsp;</span>`,
     );
-    if (column.data_type !== null) {
+    if (column.data_type) {
       content.appendMarkdown(
         `<span>-&nbsp;${column.data_type.toLowerCase()}</span>`,
       );
@@ -60,7 +60,7 @@ export const generateMacroHoverMarkdown = (
     content.appendMarkdown(
       `<span style="color:#347890;">(argument)&nbsp;</span><span>${macroArg.name} &nbsp;</span>`,
     );
-    if (macroArg.type !== null) {
+    if (macroArg.type) {
       content.appendMarkdown(
         `<span>-&nbsp;${macroArg.type.toLowerCase()}</span>`,
       );


### PR DESCRIPTION
## Source

Found via the [error analysis monitoring dashboard](../tree/master/monitoring) (`monitoring/app.py`) querying `dbt-power-user-telemetry-staging` App Insights. Filtered `unhandlederror` events to 0.59.x/0.60.x over the last 14 days, clustered by stack signature. This was the #2 highest-volume crash (10 events).

## Summary

- Fix crash "Cannot read properties of undefined (reading 'toLowerCase')" in hover provider
- Change `!== null` guards to truthiness checks for `column.data_type` and `macroArg.type` in `src/hover_provider/utils.ts`
- The dbt manifest can have columns/macro arguments where these fields are `undefined`, not just `null`

## Telemetry evidence

**10 `unhandlederror` events** on 0.60.x in the last 14 days, all with this stack trace:
```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
  at exports.generateHoverMarkdownString (extension.js:31761:91)
  at ModelHoverProvider.getHoverMarkdownFor (extension.js:31690:60)
```

Versions affected: 0.60.1 (9 events), 0.60.4 (1 event)

## What changed

| Line | Before | After |
|------|--------|-------|
| `utils.ts:29` | `if (column.data_type !== null)` | `if (column.data_type)` |
| `utils.ts:63` | `if (macroArg.type !== null)` | `if (macroArg.type)` |

The truthiness check handles `null`, `undefined`, and empty string (which would display a meaningless `- ` anyway).

## Testing

### E2E: pre-fix vs post-fix (Jest regression tests)

See [E2E comment with full results](#issuecomment-4231343027).

| Test case | Master (pre-fix) | This branch (post-fix) |
|---|---|---|
| `data_type: null` | pass | pass |
| `data_type: undefined` | **CRASH** | pass |
| `data_type: ""` | pass | pass |
| `data_type: "NUMERIC"` | pass (shows `numeric`) | pass |
| `macroArg.type: null` | pass | pass |
| `macroArg.type: undefined` | **CRASH** | pass |
| `macroArg.type: "STRING"` | pass (shows `string`) | pass |

### Alternate code paths audited
- `newLineagePanel.ts:493` — already uses `c.data_type?.toLowerCase()` (safe)
- `newLineagePanel.ts:519,531` — no `.toLowerCase()` call (safe)
- `docsEditPanel.ts:968,1054` — uses `column.type?.toLowerCase()` (safe via optional chaining)
- `dbtProject.ts:1490-1497` — uses `?.toLowerCase()` (safe)
- **Only `utils.ts:29` and `utils.ts:63` had the `!== null` pattern**

### Regression check
- `npx tsc --noEmit` passes (only pre-existing unrelated errors in `inversify.config.ts`)
- No behavior change for valid data: non-empty strings still display type in hover
- Empty string edge case: now skipped instead of displaying bare `- ` (minor UI improvement)

## Fix placement
Confirmed this belongs in **power-user** (defensive guard), not in dbt-integration (where the type definition could be updated separately to make `data_type: string | null | undefined` truthful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hover text generation to prevent empty or null type information from being displayed in hover tooltips, resulting in cleaner and more relevant hover information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->