### PR TITLE
fix: handle NoCredentialsError in InsightsPanel handleCommand

### DIFF
--- a/src/webview_provider/insightsPanel.ts
+++ b/src/webview_provider/insightsPanel.ts
@@ -605,33 +605,37 @@ export class InsightsPanel extends AltimateWebviewProvider {
 
     switch (command) {
       case "getNotebooks":
-        this.sendResponseToWebview({
-          command: "response",
-          syncRequestId: message.syncRequestId,
-          // TODO: add other params here later
-          data: await this.altimateRequest.getNotebooks(
-            "",
-            [],
-            params.privacy as string,
-          ),
-        });
+        this.handleSyncRequestFromWebview(
+          syncRequestId,
+          async () =>
+            await this.altimateRequest.getNotebooks(
+              "",
+              [],
+              params.privacy as string,
+            ),
+          command,
+          true,
+        );
         break;
       case "getPreConfiguredNotebooks":
-        this.sendResponseToWebview({
-          command: "response",
-          syncRequestId: message.syncRequestId,
-          data: await this.altimateRequest.getPreConfiguredNotebooks(),
-        });
+        this.handleSyncRequestFromWebview(
+          syncRequestId,
+          async () => await this.altimateRequest.getPreConfiguredNotebooks(),
+          command,
+          true,
+        );
         break;
       case "updateNotebookPrivacy":
-        this.sendResponseToWebview({
-          command: "response",
-          syncRequestId: message.syncRequestId,
-          data: await this.altimateRequest.updateNotebookPrivacy(
-            params.notebookId as number,
-            params.privacy as string,
-          ),
-        });
+        this.handleSyncRequestFromWebview(
+          syncRequestId,
+          async () =>
+            await this.altimateRequest.updateNotebookPrivacy(
+              params.notebookId as number,
+              params.privacy as string,
+            ),
+          command,
+          true,
+        );
         break;
       case "selectDirectoryForManifest":
         this.selectDirectoryForManifest(syncRequestId);
@@ -719,9 +723,17 @@ export class InsightsPanel extends AltimateWebviewProvider {
         await this.getProjects(syncRequestId);
         break;
       case "logDBTHealthcheckConfig":
-        await this.altimateRequest.logDBTHealthcheckConfig(
-          params.configId as string,
-        );
+        try {
+          await this.altimateRequest.logDBTHealthcheckConfig(
+            params.configId as string,
+          );
+        } catch (err) {
+          this.dbtTerminal.error(
+            "InsightsPanel",
+            "Error logging healthcheck config",
+            err,
+          );
+        }
         break;
       case "getInsightConfigs":
         await this.handleSyncRequestFromWebview(

--- a/src/webview_provider/insightsPanel.ts
+++ b/src/webview_provider/insightsPanel.ts
@@ -729,7 +729,7 @@ export class InsightsPanel extends AltimateWebviewProvider {
           );
         } catch (err) {
           this.dbtTerminal.error(
-            "InsightsPanel",
+            "InsightsPanelError",
             "Error logging healthcheck config",
             err,
           );


### PR DESCRIPTION
## Source

Found via the [error analysis monitoring dashboard](../tree/master/monitoring) (`monitoring/app.py`) querying `dbt-power-user-telemetry-staging` App Insights. Filtered `unhandlederror` events to 0.59.x/0.60.x over the last 14 days, clustered by stack signature. This was the #3 highest-volume crash (3 events).

## Summary

- Wrap 3 unguarded `await` calls in `InsightsPanel.handleCommand` with `handleSyncRequestFromWebview` (the established error-handling pattern in the codebase)
- Add try/catch for the fire-and-forget `logDBTHealthcheckConfig` call
- Previously, users without an API key triggered unhandled `NoCredentialsError` when the Insights panel loaded

## Telemetry evidence

**3 `unhandlederror` events** on 0.60.4 in the last 14 days:
```
Error: Missing API credentials
  at AltimateHttpClient.fetch (extension.js:1894:20)
  at AltimateRequest.getNotebooks (extension.js:26474:18)
  at InsightsPanel.handleCommand (extension.js:36913:41)
```

## What changed

| Case | Before | After |
|------|--------|-------|
| `getNotebooks` | Direct `await` inside `sendResponseToWebview` | `handleSyncRequestFromWebview` |
| `getPreConfiguredNotebooks` | Direct `await` inside `sendResponseToWebview` | `handleSyncRequestFromWebview` |
| `updateNotebookPrivacy` | Direct `await` inside `sendResponseToWebview` | `handleSyncRequestFromWebview` |
| `logDBTHealthcheckConfig` | Bare `await` (fire-and-forget) | Wrapped in try/catch with `dbtTerminal.error` |

## Testing

### E2E: pre-fix vs post-fix

See [E2E comment with full results](#issuecomment-4231343501).

Tests confirm `NoCredentialsError` IS thrown by `getNotebooks` / `getPreConfiguredNotebooks` when API key is missing, and CAN be caught by the `handleSyncRequestFromWebview` pattern used in the fix.

### Full `handleCommand` case audit

See E2E comment for the complete 14-case audit table. All cases are now either:
- Using `handleSyncRequestFromWebview` (error-safe)
- Delegating to methods with their own try/catch
- Sync operations that can't throw async errors
- Fire-and-forget with try/catch (logDBTHealthcheckConfig)

### Regression check
- `npx tsc --noEmit` passes (only pre-existing unrelated errors)
- `handleSyncRequestFromWebview` adds `status: true` to success responses — backwards compatible (additive field)
- On error: webview now receives `{ status: false, error: "Missing API credentials" }` instead of getting nothing (promise hung forever from the webview's perspective)
- Error notification shown to user via `window.showErrorMessage` (matches other commands)

## Fix placement
Confirmed this belongs in **power-user** (`insightsPanel.ts`). The dbt-integration library correctly throws `NoCredentialsError` — the consumer is responsible for handling it. The base class already provides `handleSyncRequestFromWebview` for exactly this purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal request handling consistency
  * Enhanced error handling and diagnostics logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->