### PR TITLE
chore: bump `@altimateai/dbt-integration` to ^0.2.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.60.2",
+  "version": "0.60.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.60.2",
+      "version": "0.60.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.2.12",
+        "@altimateai/dbt-integration": "^0.2.13",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -177,7 +177,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.2.12",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.2.13.tgz",
+      "integrity": "sha512-mN6jTl/W+2YW989Qntu3LEOBh0Tfobz2ZfFsTNmzr1aX0FoPGxMh6A7OmW4Ek1YR3zeWwby+URV6le+v8k4MtA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1346,7 +1346,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.2.12",
+    "@altimateai/dbt-integration": "^0.2.13",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",


### PR DESCRIPTION
## Summary

Bumps `@altimateai/dbt-integration` from `^0.2.12` to `^0.2.13`.

Picks up the fixes shipped in the new release:

- `fix: [#1706] partition NodeMetaMap bare-name lookup by resource_type`
- `fix: [#1747] serialize binary columns as hex strings`
- `fix: [#1676, #1737] evict stale adapter on target switch`

Incidentally reconciles `package-lock.json`'s `version` field with `package.json` (`0.60.2` → `0.60.4`) — pre-existing drift on `master` that `npm install --package-lock-only` cleans up.

## Test plan

- [ ] `npm install` resolves `@altimateai/dbt-integration@0.2.13` without conflicts
- [ ] `npm run webpack` succeeds
- [ ] Smoke test: open a dbt project, verify model parse / lineage / query preview still work
- [ ] Verify the three upstream fixes land correctly in the extension (NodeMetaMap resource_type, hex BLOB serialization, target switch adapter eviction)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->