### PR TITLE
feat: add support for risingwave adapter

### DIFF
--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -297,6 +297,7 @@ export class WalkthroughCommands {
         "trino",
         "synapse",
         "fabric",
+        "risingwave",
       ].map((value) => ({ label: value })),
       {
         title: "Select your adapter",
@@ -395,6 +396,8 @@ export class WalkthroughCommands {
         return "dbt-synapse";
       case "fabric":
         return "dbt-fabric";
+      case "risingwave":
+        return "dbt-risingwave";
     }
     throw new Error("Adapter is not supported" + adapter);
   }

--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -396,6 +396,8 @@ export class WalkthroughCommands {
         return "dbt-synapse";
       case "fabric":
         return "dbt-fabric";
+      case "risingwave":
+        return "dbt-risingwave";
     }
     throw new Error("Adapter is not supported" + adapter);
   }

--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -396,7 +396,6 @@ export class WalkthroughCommands {
         return "dbt-synapse";
       case "fabric":
         return "dbt-fabric";
-  const specialCases = ["trino", "athena", "postgres", "duckdb", "risingwave"];
     }
     throw new Error("Adapter is not supported" + adapter);
   }

--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -396,8 +396,7 @@ export class WalkthroughCommands {
         return "dbt-synapse";
       case "fabric":
         return "dbt-fabric";
-      case "risingwave":
-        return "dbt-risingwave";
+  const specialCases = ["trino", "athena", "postgres", "duckdb", "risingwave"];
     }
     throw new Error("Adapter is not supported" + adapter);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -200,7 +200,7 @@ export const isQuotedIdentifier = (columnName: string, adapter: string) => {
     return !new RegExp(regexFromConfig).test(columnName);
   }
 
-  const specialCases = ["trino", "athena", "postgres", "duckdb"];
+  const specialCases = ["trino", "athena", "postgres", "duckdb", "risingwave"];
   if (specialCases.includes(adapter)) {
     return !/^([_a-z]+[_a-z0-9$]*)$/.test(columnName);
   }


### PR DESCRIPTION
## Overview

### Problem

[There](https://github.com/risingwavelabs/dbt-risingwave) is risingwave dbt adaptor, but I can't install it during the walkthrough.

### Solution

Add risingwave as an adaptor option, and install related package when selected. Given that risingwave is using Postgres-like sql, so we need to handle case correctly

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RisingWave added to the dbt Core adapter selection — selectable in the UI and mapped to the correct adapter package.
* **Bug Fixes**
  * Improved identifier handling for RisingWave so quoted vs. unquoted identifiers are detected consistently with other adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->