### PR TITLE
docs: update setup wizard demo links for Core, Cloud & Fusion

### DIFF
--- a/documentation/docs/setup/reqdConfig.md
+++ b/documentation/docs/setup/reqdConfig.md
@@ -14,7 +14,8 @@ You can start the setup wizard by clicking on dbt status icon in bottom status b
 
 <interactive demo for setup wizard>
 
-<div style="position: relative; padding-bottom: calc(75.08376963350786% + 42px); height: 0;"><iframe src="https://app.supademo.com/embed/clsvee2nn062bpekcffkgv0sv" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+<div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.50; padding: 40px 0 40px 0;">
+  <iframe src="https://app.supademo.com/embed/cmnsywfgw4brfcr4j1npz9esr?embed_v=2&utm_source=embed" loading="lazy" title="dbt Power User Setup guide-Core" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
 **Here are steps covered in the setup wizard**
 

--- a/documentation/docs/setup/reqdConfigCloud.md
+++ b/documentation/docs/setup/reqdConfigCloud.md
@@ -39,7 +39,8 @@ This method will save a bunch of time for you, and you can also validate your co
 
 You can start the setup wizard by clicking on dbt status icon in bottom status bar, and performing following necessary steps as shown in the recorded demo below:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/NagRG2uV5m8?si=dO9ox-VLciCBgCUh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.50; padding: 40px 0 40px 0;">
+  <iframe src="https://app.supademo.com/embed/cmnt0ivy300g4w80j5zufa5p7?embed_v=2&utm_source=embed" loading="lazy" title="dbt Power User Setup guide-Cloud" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
 **Here are the steps covered in the setup wizard**
 
@@ -63,10 +64,6 @@ If there are some issues, it will tell you exactly what's wrong as well.
 /// admonition | If you still can't get the extension setup correctly, please check the [troubleshooting page](../troubleshooting.md)
     type: tip
 ///
-
-## Recorded Demo
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/NagRG2uV5m8?si=dO9ox-VLciCBgCUh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Questions and Answers
 

--- a/documentation/docs/setup/reqdConfigFusion.md
+++ b/documentation/docs/setup/reqdConfigFusion.md
@@ -27,6 +27,9 @@ This method will save a bunch of time for you, and you can also validate your co
 
 You can start the setup wizard by clicking on the dbt status icon in the bottom status bar, and perform the following necessary steps:
 
+<div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.50; padding: 40px 0 40px 0;">
+  <iframe src="https://app.supademo.com/embed/cmnt1t4jz4hj3cr4j3knosm74?embed_v=2&utm_source=embed" loading="lazy" title="dbt Power User Setup guide-Fusion" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+
 **Here are the steps covered in the setup wizard**
 
 **Select dbt Integration Type**


### PR DESCRIPTION
## Summary
- Replace outdated supademo/YouTube embeds with new responsive supademo demos (embed_v=2) for dbt Core, Cloud, and Fusion setup wizard pages
- Update iframe styling to use consistent responsive layout (`aspect-ratio`, `max-height: 80vh`) across all three config docs
- Remove duplicate "Recorded Demo" section from dbt Cloud config page

## Test plan
- [ ] Verify demos load correctly on each page at http://127.0.0.1:8000/setup/reqdConfig/
- [ ] Verify demos load correctly at http://127.0.0.1:8000/setup/reqdConfigCloud/
- [ ] Verify demos load correctly at http://127.0.0.1:8000/setup/reqdConfigFusion/
- [ ] Confirm responsive layout works on different viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup wizard demonstrations across configuration documentation.
  * Replaced YouTube recordings with interactive SupaDemo walkthroughs.
  * Improved responsive design for embedded demo content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->