### PR TITLE
ci: skip bundle-size status and PR comment on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           VSCE_TARGET: ${{ matrix.vsce-target }}
       - name: Set commit status
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |
@@ -92,7 +92,7 @@ jobs:
   bundle-size-report:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary
- Fork PRs get a read-only `GITHUB_TOKEN`, so the `Set commit status` step (calling `repos.createCommitStatus`) and the `bundle-size-report` job's `issues.createComment` call fail with `HttpError: Resource not accessible by integration` — failing CI on every fork PR (e.g. #1889).
- Gate both write-bound steps on `github.event.pull_request.head.repo.full_name == github.repository` so fork PRs still build and analyze the VSIX but skip reporting that requires write access.
- Same-repo branch PRs are unaffected — they continue to post the commit status and PR comment as before.

## Test plan
- [ ] CI on this (same-repo) branch PR still posts the `Bundle Size (*)` commit status and the `<!-- bundle-size-report -->` PR comment.
- [ ] Re-run #1889 and confirm the build jobs go green (status/comment steps cleanly skipped on fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow conditions to ensure proper gating of workflow steps during pull request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->