### PR TITLE
chore: bump reactstrap from 9.2.1 to 9.2.3

### DIFF
--- a/webview_panels/package-lock.json
+++ b/webview_panels/package-lock.json
@@ -37,7 +37,7 @@
         "react-select": "^5.8.0",
         "react-syntax-highlighter": "^15.5.0",
         "react-textarea-autosize": "^8.5.3",
-        "reactstrap": "^9.2.1",
+        "reactstrap": "^9.2.3",
         "remark-gfm": "^4.0.0",
         "use-debounce": "^10.0.1",
         "vite-plugin-css-injected-by-js": "^3.5.1",
@@ -25019,9 +25019,10 @@
       }
     },
     "node_modules/reactstrap": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.2.tgz",
-      "integrity": "sha512-4KroiGOdqZLAnMGzHjpErW3G7bLB+QbKzzMLIDXydPIV0y74lpdL7WtXHkLWAGInd97WCPNx4+R0NQDPyzIfhw==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
+      "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",

--- a/webview_panels/package.json
+++ b/webview_panels/package.json
@@ -47,7 +47,7 @@
     "react-select": "^5.8.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-textarea-autosize": "^8.5.3",
-    "reactstrap": "^9.2.1",
+    "reactstrap": "^9.2.3",
     "remark-gfm": "^4.0.0",
     "use-debounce": "^10.0.1",
     "vite-plugin-css-injected-by-js": "^3.5.1",


### PR DESCRIPTION
## Summary
- Bump `reactstrap` from `^9.2.1` (resolved 9.2.2) to `^9.2.3` in `webview_panels/` to pick up the upstream fix for a bug in `UncontrolledAccordion`.
- Lockfile updated accordingly.

## Test plan
- [ ] `npm install` in `webview_panels/` resolves cleanly
- [ ] Build webview panels and smoke-test any UI using `UncontrolledAccordion`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated UI library dependency to the latest patch version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->