### PR TITLE
fix: [#1585] stop docs editor from writing both `tests:` and `data_tests:`

### DIFF
--- a/src/webview_provider/docsEditPanel.ts
+++ b/src/webview_provider/docsEditPanel.ts
@@ -281,7 +281,12 @@ export class DocsEditViewPanel implements WebviewViewProvider {
     await this.resolveWebviewView(this.panel!, this.context!, this.token!);
   };
 
-  private getTestDataByModel(message: any, modelName: string) {
+  private getTestDataByModel(
+    message: any,
+    modelName: string,
+    project?: DBTProject,
+    existingModel?: any,
+  ) {
     const tests = message.updatedTests as undefined | TestMetaData[];
 
     if (!tests?.length) {
@@ -320,7 +325,23 @@ export class DocsEditViewPanel implements WebviewViewProvider {
       })
       .filter((t) => Boolean(t));
     const filteredTests = this.dbtTestService.removeDuplicateTests(finalTests);
-    return filteredTests.length ? filteredTests : undefined;
+    if (!filteredTests.length) {
+      return;
+    }
+
+    // dbt >= 1.8 renamed model-level `tests:` to `data_tests:`. Mirror the
+    // column-level selection logic: prefer `data_tests` on new dbt versions,
+    // but preserve `tests` if the user's YAML already uses that key.
+    const dbtVersion = project?.getDBTVersion();
+    if (
+      dbtVersion &&
+      gte(dbtVersion.join("."), "1.8.0") &&
+      existingModel?.tests === undefined
+    ) {
+      return { data_tests: filteredTests };
+    }
+
+    return { tests: filteredTests };
   }
 
   private getTestMetadataKwArgs(
@@ -1001,8 +1022,15 @@ export class DocsEditViewPanel implements WebviewViewProvider {
         const modelTests = this.getTestDataByModel(
           message,
           model.get("name") as string,
+          project,
+          model.toJSON(),
         );
-        this.setOrDeleteInParsedDocument(model, "tests", modelTests);
+        this.setOrDeleteInParsedDocument(model, "tests", modelTests?.tests);
+        this.setOrDeleteInParsedDocument(
+          model,
+          "data_tests",
+          modelTests?.data_tests,
+        );
         if (!model.get("columns")) {
           model.set("columns", new YAMLSeq<DocumentationSchemaColumn>());
         }


### PR DESCRIPTION
## Summary

When a `schema.yml` already has model-level `data_tests:` (dbt >= 1.8), any subsequent column edit through the Documentation Editor re-serializes the YAML with **both** `tests:` and `data_tests:` blocks, and `dbt compile` then fails with `Invalid test config: cannot have both 'tests' and 'data_tests' defined`.

Mirror the column-level selection logic in `getTestDataByModel`/`saveDocumentation`: return either `{tests: [...]}` or `{data_tests: [...]}` based on dbt version + existing key, and have the caller write one + delete the opposite. Columns already use this pattern — the model-level path was the only remaining gap.

Fixes #1585.

## Test plan

Reproduced on `master` and verified side-by-side against the fix using the `test-fixtures/schema-yml-data-tests-duplication/` fixture (jaffle-shop-duckdb + `dbt_utils.unique_combination_of_columns` model-level `data_tests:` block, dbt 1.11.8 in docker).

- [x] **Before (master logic):** `schema.yml` gets both `tests:` and `data_tests:` after simulated save → `dbt compile --select orders` errors with `cannot have both 'tests' and 'data_tests' defined`.
- [x] **After (this diff):** `schema.yml` retains only `data_tests:` → `dbt compile --select orders` succeeds.
- [x] Regression: column-level `tests:`/`data_tests:` handling unchanged (same pattern it already used).
- [x] `tsc --noEmit` clean on the edited file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation editor now correctly handles test data in dbt 1.8+ projects while maintaining backward compatibility with earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->