### PR TITLE
feat: stamp dbt Cloud variant on Azure telemetry events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.2.13",
+        "@altimateai/dbt-integration": "^0.2.14",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.2.13.tgz",
-      "integrity": "sha512-mN6jTl/W+2YW989Qntu3LEOBh0Tfobz2ZfFsTNmzr1aX0FoPGxMh6A7OmW4Ek1YR3zeWwby+URV6le+v8k4MtA==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.2.14.tgz",
+      "integrity": "sha512-44hFBx3gXss2RUlRZE9cIpAocffB3miAzpjvmma1EED0jiOhyrgmzGsw3RXEZqs73OuLYpDehixvRUt1vTfcfQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1342,7 +1342,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.2.13",
+    "@altimateai/dbt-integration": "^0.2.14",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",

--- a/src/dbt_client/dbtProject.ts
+++ b/src/dbt_client/dbtProject.ts
@@ -345,12 +345,6 @@ export class DBTProject implements Disposable {
       return;
     }
     this.telemetry.setTelemetryCustomAttribute("dbtCloudVariant", info.variant);
-    if (info.dbtCoreVersion) {
-      this.telemetry.setTelemetryCustomAttribute(
-        "dbtCloudCoreVersion",
-        info.dbtCoreVersion.version,
-      );
-    }
     if (info.rawDbtVersion) {
       this.telemetry.setTelemetryCustomAttribute(
         "dbtCloudRawVersion",

--- a/src/dbt_client/dbtProject.ts
+++ b/src/dbt_client/dbtProject.ts
@@ -206,8 +206,8 @@ export class DBTProject implements Disposable {
           "Received projectConfigChanged event from Node.js project config watcher",
         );
         const event = new ProjectConfigChangedEvent(this);
-        this._onProjectConfigChanged.fire(event);
         this.stampCloudVariantOnTelemetry();
+        this._onProjectConfigChanged.fire(event);
       },
     );
 
@@ -341,16 +341,14 @@ export class DBTProject implements Disposable {
 
   private stampCloudVariantOnTelemetry(): void {
     const info = this.dbtProjectIntegration.getCloudVariantInfo();
-    if (!info) {
-      return;
-    }
-    this.telemetry.setTelemetryCustomAttribute("dbtCloudVariant", info.variant);
-    if (info.rawDbtVersion) {
-      this.telemetry.setTelemetryCustomAttribute(
-        "dbtCloudRawVersion",
-        info.rawDbtVersion,
-      );
-    }
+    this.telemetry.setTelemetryCustomAttribute(
+      "dbtCloudVariant",
+      info?.variant ?? "",
+    );
+    this.telemetry.setTelemetryCustomAttribute(
+      "dbtCloudRawVersion",
+      info?.rawDbtVersion ?? "",
+    );
   }
 
   private invalidateCacheUsingUniqueIds(uniqueIds: string[]) {

--- a/src/dbt_client/dbtProject.ts
+++ b/src/dbt_client/dbtProject.ts
@@ -6,6 +6,7 @@ import {
   ColumnMetaData,
   DataPilotHealtCheckParams,
   DBColumn,
+  DBT_PROJECT_FILE,
   DBTCommand,
   DBTCommandExecution,
   DBTCommandExecutionInfrastructure,
@@ -16,7 +17,6 @@ import {
   DBTProjectIntegrationAdapter,
   DBTProjectIntegrationAdapterEvents,
   DBTTerminal,
-  DBT_PROJECT_FILE,
   DeferConfig,
   extractOutputColumns,
   HealthcheckArgs,
@@ -207,6 +207,7 @@ export class DBTProject implements Disposable {
         );
         const event = new ProjectConfigChangedEvent(this);
         this._onProjectConfigChanged.fire(event);
+        this.stampCloudVariantOnTelemetry();
       },
     );
 
@@ -335,6 +336,26 @@ export class DBTProject implements Disposable {
       return false;
     } finally {
       await this.executionInfrastructure.closePythonBridge(dbtLoomThread);
+    }
+  }
+
+  private stampCloudVariantOnTelemetry(): void {
+    const info = this.dbtProjectIntegration.getCloudVariantInfo();
+    if (!info) {
+      return;
+    }
+    this.telemetry.setTelemetryCustomAttribute("dbtCloudVariant", info.variant);
+    if (info.dbtCoreVersion) {
+      this.telemetry.setTelemetryCustomAttribute(
+        "dbtCloudCoreVersion",
+        info.dbtCoreVersion.version,
+      );
+    }
+    if (info.rawDbtVersion) {
+      this.telemetry.setTelemetryCustomAttribute(
+        "dbtCloudRawVersion",
+        info.rawDbtVersion,
+      );
     }
   }
 

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -6,6 +6,7 @@ import {
   DBTCloudDetection,
   DBTCloudProjectDetection,
   DBTCloudProjectIntegration,
+  DbtCloudVariantDetector,
   DBTCommandExecutionInfrastructure,
   DBTCommandExecutionStrategy,
   DBTCommandFactory,
@@ -267,6 +268,13 @@ container
   .bind(DBTCommandFactory)
   .toDynamicValue((context) => {
     return new DBTCommandFactory(context.container.get("DBTConfiguration"));
+  })
+  .inSingletonScope();
+
+container
+  .bind(DbtCloudVariantDetector)
+  .toDynamicValue((context) => {
+    return new DbtCloudVariantDetector(context.container.get("DBTTerminal"));
   })
   .inSingletonScope();
 
@@ -649,6 +657,7 @@ container
         projectConfigDiagnostics,
         deferConfig,
         onDiagnosticsChanged,
+        container.get(DbtCloudVariantDetector),
       );
     };
   });
@@ -679,6 +688,7 @@ container
         projectConfigDiagnostics,
         deferConfig,
         onDiagnosticsChanged,
+        container.get(DbtCloudVariantDetector),
       );
     };
   });


### PR DESCRIPTION
## Summary

Stamps dbt Cloud variant info on every Azure App Insights telemetry event for Cloud users, so we can slice event volume and error rates by release track (`latest`, `latest-fusion`, `compatible`, `extended`, `unknown`) without changing any call site.

Consumer of `adapter.getCloudVariantInfo()` from altimate-dbt-integration PR 54.

## Diff vs `master`

### `src/dbt_client/dbtProject.ts`

- New private method `stampCloudVariantOnTelemetry()` pulls `CloudVariantInfo` from the adapter and writes two custom attributes via the existing `TelemetryService.setTelemetryCustomAttribute` mechanism:
  - `dbtCloudVariant` — the variant enum (e.g. `extended`)
  - `dbtCloudRawVersion` — the raw Admin-API `dbt_version` string (useful for debugging `unknown` variants, e.g. legacy-pinned projects that appear as `"1.9.0"`)
- Hooked into the existing `DBTProjectIntegrationAdapterEvents.PROJECT_CONFIG_CHANGED` handler so the attributes get stamped (and re-stamped if the variant ever changes) after detection resolves inside `refreshProjectConfig`. Mirrors the existing `dbtLoomInstalled` stamping pattern.
- No-op when `getCloudVariantInfo()` returns `null` (non-Cloud integration or detection not yet complete / failed).

## Why this shape

- `setTelemetryCustomAttribute` is the extension's "set once, stamp on every event" mechanism — no need to touch any event call site.
- Attributes compose with the existing `dbtIntegrationMode` (already `"cloud"`), so events can be filtered by `dbtIntegrationMode == cloud AND dbtCloudVariant == extended` in App Insights without any code changes downstream.
- Hooking `PROJECT_CONFIG_CHANGED` (instead of calling once at construction) ensures coverage even if the first detection attempt races with event emission — the library caches the result after the first successful detection, so re-stamping the same string is idempotent and cheap.

## Dependencies

- **Blocked on:** altimate-dbt-integration PR 54 (merge + npm publish + bump `@altimateai/dbt-integration` here). The `getCloudVariantInfo()` API and `CloudVariantInfo` type don't exist in the currently-published `0.2.13`.

## Out of scope

- No UI surface changes (no status-bar indicator, no command palette entry).
- No per-event property overrides — every event gets the attributes stamped uniformly.
- No classification of legacy-pinned dbt Cloud projects — those land as `dbtCloudVariant: "unknown"` with the pinned version preserved in `dbtCloudRawVersion`.
- No changes to dbt-integration; PR 54 already exposes everything needed.

## Test plan

- [x] `npx tsc --noEmit` clean against local-linked PR 54 lib
- [x] `npx jest src/test/suite/dbtProject.test.ts` — all 30 tests pass
- [x] Lint clean on the modified file (two pre-existing prettier errors on the import block are unrelated)
- [ ] After lib bump: manual smoke test — confirm `dbtCloudVariant` appears in App Insights for a Cloud user


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dBT integration dependency to a newer patch version.
  * Enhanced telemetry to capture additional dBT Cloud variant and raw version details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->