### PR TITLE
feat: add Troubleshoot with Altimate action on query failure

### DIFF
--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -1621,6 +1621,7 @@ container
       context.container.get(QueryManifestService),
       context.container.get(UsersService),
       context.container.get(AltimateAuthService),
+      context.container.get(AltimateCodeChatService),
     );
   })
   .inSingletonScope();

--- a/src/services/altimateCodeChatService.ts
+++ b/src/services/altimateCodeChatService.ts
@@ -7,7 +7,7 @@ export class AltimateCodeChatService implements Disposable {
   async openChat(options: {
     initialMessage: string;
     title: string;
-  }): Promise<void> {
+  }): Promise<boolean> {
     const altimateExt = extensions.getExtension(
       "altimateai.vscode-altimate-mcp-server",
     );
@@ -15,7 +15,7 @@ export class AltimateCodeChatService implements Disposable {
       window.showErrorMessage(
         "Datamates extension is not installed or not active.",
       );
-      return;
+      return false;
     }
     if (!altimateExt.isActive) {
       await altimateExt.activate();
@@ -25,7 +25,7 @@ export class AltimateCodeChatService implements Disposable {
       window.showErrorMessage(
         "Datamates extension is out of date, please update to the latest version.",
       );
-      return;
+      return false;
     }
     // createSession opens the panel, starts the server, creates the session,
     // and sends the initial message — all handled by the Datamates extension's
@@ -34,6 +34,7 @@ export class AltimateCodeChatService implements Disposable {
       initialMessage: options.initialMessage,
       title: options.title,
     });
+    return true;
   }
 
   getEditorContext(): {

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -543,11 +543,15 @@ export class QueryResultPanel extends AltimateWebviewProvider {
             const title = troubleshoot.fileName
               ? `Troubleshoot: ${troubleshoot.fileName}`
               : "Troubleshoot: query error";
-            this.telemetry.sendTelemetryEvent("TroubleshootQueryWithAltimate");
-            await this.altimateCodeChatService.openChat({
+            const opened = await this.altimateCodeChatService.openChat({
               initialMessage,
               title,
             });
+            if (opened) {
+              this.telemetry.sendTelemetryEvent(
+                "TroubleshootQueryWithAltimate",
+              );
+            }
             break;
           }
           case InboundCommand.SetContext:

--- a/src/webview_provider/queryResultPanel.ts
+++ b/src/webview_provider/queryResultPanel.ts
@@ -26,6 +26,7 @@ import { PythonException } from "python-bridge";
 import { AltimateRequest } from "../altimate";
 import { DBTProjectContainer } from "../dbt_client/dbtProjectContainer";
 import { AltimateAuthService } from "../services/altimateAuthService";
+import { AltimateCodeChatService } from "../services/altimateCodeChatService";
 import { QueryManifestService } from "../services/queryManifestService";
 import { SharedStateService } from "../services/sharedStateService";
 import { UsersService } from "../services/usersService";
@@ -100,6 +101,7 @@ enum InboundCommand {
   ViewResultSet = "viewResultSet",
   OpenCodeInEditor = "openCodeInEditor",
   ClearQueryHistory = "clearQueryHistory",
+  TroubleshootWithAltimate = "troubleshootWithAltimate",
 }
 
 interface RecInfo {
@@ -108,6 +110,13 @@ interface RecInfo {
 
 interface RecSummary {
   compiledSql: string;
+}
+
+interface RecTroubleshoot {
+  compiledSql: string;
+  rawSql: string;
+  errorMessage: string;
+  fileName?: string;
 }
 
 interface RecError {
@@ -159,6 +168,7 @@ export class QueryResultPanel extends AltimateWebviewProvider {
     protected queryManifestService: QueryManifestService,
     protected usersService: UsersService,
     protected altimateAuthService: AltimateAuthService,
+    private altimateCodeChatService: AltimateCodeChatService,
   ) {
     super(
       dbtProjectContainer,
@@ -522,6 +532,24 @@ export class QueryResultPanel extends AltimateWebviewProvider {
               },
             });
             break;
+          case InboundCommand.TroubleshootWithAltimate: {
+            const troubleshoot = message as RecTroubleshoot;
+            const sql = troubleshoot.compiledSql || troubleshoot.rawSql;
+            const initialMessage =
+              `I ran this query and it failed.\n\n` +
+              `Query:\n\`\`\`sql\n${sql}\n\`\`\`\n\n` +
+              `Error:\n\`\`\`\n${troubleshoot.errorMessage}\n\`\`\`\n\n` +
+              `Help me troubleshoot and fix this.`;
+            const title = troubleshoot.fileName
+              ? `Troubleshoot: ${troubleshoot.fileName}`
+              : "Troubleshoot: query error";
+            this.telemetry.sendTelemetryEvent("TroubleshootQueryWithAltimate");
+            await this.altimateCodeChatService.openChat({
+              initialMessage,
+              title,
+            });
+            break;
+          }
           case InboundCommand.SetContext:
             this.dbtProjectContainer.setToGlobalState(
               message.key,

--- a/webview_panels/src/assets/icons/index.tsx
+++ b/webview_panels/src/assets/icons/index.tsx
@@ -1,37 +1,37 @@
 import { HTMLAttributes } from "react";
+import LineageGif from "./lineage.gif";
+import LoadingSpinnerUrl from "./spinner.gif";
+import "./styles.css";
 export { default as AddOutlineIcon } from "./add-outline.svg?react";
-export { default as LikeIcon } from "./like.svg?react";
-export { default as DislikeIcon } from "./dislike.svg?react";
-export { default as ShinesIcon } from "./shines.svg?react";
-export { default as PreviewIcon } from "./preview.svg?react";
-export { default as HelpIcon } from "./help.svg?react";
-export { default as FeedbackIcon } from "./feedback.svg?react";
 export { default as AltimateIcon } from "./altimate.svg?react";
-export { default as CheckBlueIcon } from "./check-blue.svg?react";
-export { default as UncheckIcon } from "./uncheck.svg?react";
-export { default as SelectUncheckedIcon } from "./select-unchecked.svg?react";
-export { default as SelectCheckedIcon } from "./select-checked.svg?react";
-export { default as UserIcon } from "./user.svg?react";
 export { default as BlogIcon } from "./blog.svg?react";
-export { default as ContactUsIcon } from "./contact.svg?react";
-export { default as DocsIcon } from "./docs.svg?react";
-export { default as SlackIcon } from "./slack.svg?react";
-export { default as EditIcon } from "./edit.svg?react";
-export { default as EmptySquareIcon } from "./square.svg?react";
+export { default as CheckBlueIcon } from "./check-blue.svg?react";
 export { default as CheckedSquareIcon } from "./checked-square.svg?react";
-export { default as TestsIcon } from "./tests.svg?react";
+export { default as CoachAIIcon } from "./coachAi.svg?react";
+export { default as ContactUsIcon } from "./contact.svg?react";
+export { default as DislikeIcon } from "./dislike.svg?react";
+export { default as DocsIcon } from "./docs.svg?react";
+export { default as EditIcon } from "./edit.svg?react";
+export { default as ErrorIcon } from "./error.svg?react";
+export { default as FeedbackIcon } from "./feedback.svg?react";
 export { default as FolderIcon } from "./folder.svg?react";
+export { default as HelpIcon } from "./help.svg?react";
+export { default as LikeIcon } from "./like.svg?react";
+export { default as LoaderIcon } from "./loader.svg?react";
 export { default as NoBookmarksIcon } from "./no-bookmarks.svg?react";
 export { default as NoHistoryIcon } from "./no-history.svg?react";
 export { default as NoNotebooksIcon } from "./notebook.svg?react";
-export { default as ThinkingIcon } from "./thinking.svg?react";
-export { default as CoachAIIcon } from "./coachAi.svg?react";
-export { default as ErrorIcon } from "./error.svg?react";
+export { default as PreviewIcon } from "./preview.svg?react";
 export { default as PropagateIcon } from "./propagate.svg?react";
-export { default as LoaderIcon } from "./loader.svg?react";
-import LoadingSpinnerUrl from "./spinner.gif";
-import LineageGif from "./lineage.gif";
-import "./styles.css";
+export { default as SelectCheckedIcon } from "./select-checked.svg?react";
+export { default as SelectUncheckedIcon } from "./select-unchecked.svg?react";
+export { default as ShinesIcon } from "./shines.svg?react";
+export { default as SlackIcon } from "./slack.svg?react";
+export { default as EmptySquareIcon } from "./square.svg?react";
+export { default as TestsIcon } from "./tests.svg?react";
+export { default as ThinkingIcon } from "./thinking.svg?react";
+export { default as UncheckIcon } from "./uncheck.svg?react";
+export { default as UserIcon } from "./user.svg?react";
 
 interface Props {
   icon: string;
@@ -179,3 +179,7 @@ export const FileCodeIcon = (
 export const OpenNewIcon = (
   props: HTMLAttributes<HTMLElement>,
 ): JSX.Element => <Icon icon="link-external" {...props} />;
+
+export const SparkleIcon = (
+  props: HTMLAttributes<HTMLElement>,
+): JSX.Element => <Icon icon="sparkle" {...props} />;

--- a/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
+++ b/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
@@ -1,5 +1,5 @@
 import { AltimateIcon } from "@assets/icons";
-import { executeRequestInSync } from "@modules/app/requestExecutor";
+import { executeRequestInAsync } from "@modules/app/requestExecutor";
 import PreTag from "@modules/markdown/PreTag";
 import useQueryPanelState from "@modules/queryPanel/useQueryPanelState";
 import { Button, CodeBlock, Stack } from "@uicore";
@@ -9,7 +9,7 @@ const QueryPanelError = (): JSX.Element => {
     useQueryPanelState();
 
   const handleTroubleshoot = () => {
-    void executeRequestInSync("troubleshootWithAltimate", {
+    executeRequestInAsync("troubleshootWithAltimate", {
       compiledSql: compiledCodeMarkup ?? "",
       rawSql: activeEditor?.query ?? "",
       errorMessage: queryResultsError?.message ?? "",

--- a/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
+++ b/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
@@ -32,7 +32,7 @@ const QueryPanelError = (): JSX.Element => {
           icon={<SparkleIcon />}
           showTextAlways
         >
-          Troubleshoot with Altimate
+          Troubleshoot with Altimate Code
         </Button>
       </Stack>
       <details>

--- a/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
+++ b/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
@@ -1,4 +1,4 @@
-import { AltimateIcon } from "@assets/icons";
+import { SparkleIcon } from "@assets/icons";
 import { executeRequestInAsync } from "@modules/app/requestExecutor";
 import PreTag from "@modules/markdown/PreTag";
 import useQueryPanelState from "@modules/queryPanel/useQueryPanelState";
@@ -27,15 +27,9 @@ const QueryPanelError = (): JSX.Element => {
       </h4>
       <Stack className="mt-2 mb-2">
         <Button
-          color="primary"
+          outline
           onClick={handleTroubleshoot}
-          icon={
-            <AltimateIcon
-              width={16}
-              height={16}
-              style={{ verticalAlign: "-3px", marginRight: 6 }}
-            />
-          }
+          icon={<SparkleIcon />}
           showTextAlways
         >
           Troubleshoot with Altimate

--- a/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
+++ b/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
@@ -1,9 +1,21 @@
-import { CodeBlock } from "@uicore";
+import { AltimateIcon } from "@assets/icons";
+import { executeRequestInSync } from "@modules/app/requestExecutor";
 import PreTag from "@modules/markdown/PreTag";
 import useQueryPanelState from "@modules/queryPanel/useQueryPanelState";
+import { Button, CodeBlock, Stack } from "@uicore";
 
 const QueryPanelError = (): JSX.Element => {
-  const { queryResultsError } = useQueryPanelState();
+  const { queryResultsError, compiledCodeMarkup, activeEditor } =
+    useQueryPanelState();
+
+  const handleTroubleshoot = () => {
+    void executeRequestInSync("troubleshootWithAltimate", {
+      compiledSql: compiledCodeMarkup ?? "",
+      rawSql: activeEditor?.query ?? "",
+      errorMessage: queryResultsError?.message ?? "",
+      fileName: activeEditor?.filepath?.split(/[\\/]/).pop(),
+    });
+  };
 
   return (
     <div>
@@ -13,7 +25,16 @@ const QueryPanelError = (): JSX.Element => {
       <h4>
         {queryResultsError?.message?.split(/\r?\n/).slice(1).join(" ") ?? ""}
       </h4>
-      <br />
+      <Stack className="mt-2 mb-2">
+        <Button
+          color="primary"
+          onClick={handleTroubleshoot}
+          icon={<AltimateIcon />}
+          showTextAlways
+        >
+          Troubleshoot with Altimate
+        </Button>
+      </Stack>
       <details>
         <summary>View Detailed Error 🚨</summary>
         <div style={{ width: "fit-content", maxWidth: "90%" }}>

--- a/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
+++ b/webview_panels/src/modules/queryPanel/components/QueryPanelContents/QueryPanelError.tsx
@@ -29,7 +29,13 @@ const QueryPanelError = (): JSX.Element => {
         <Button
           color="primary"
           onClick={handleTroubleshoot}
-          icon={<AltimateIcon />}
+          icon={
+            <AltimateIcon
+              width={16}
+              height={16}
+              style={{ verticalAlign: "-3px", marginRight: 6 }}
+            />
+          }
           showTextAlways
         >
           Troubleshoot with Altimate


### PR DESCRIPTION
## Summary
- Adds a **Troubleshoot with Altimate Code** button to the query-results error view (`QueryPanelError`) so a failed query becomes actionable in one click.
- The button opens Altimate Code with a prefilled prompt containing the compiled SQL + error message, via the existing `AltimateCodeChatService.openChat` pathway already used by `explainWithAltimate`, `optimizeWithAltimate`, and `reviewCodeWithAltimate`.
- Wires a new `troubleshootWithAltimate` inbound message from the query panel webview to `QueryResultPanel`, which injects `AltimateCodeChatService` via inversify.
- Button uses the same outline + codicon styling as the sibling query-panel toolbar buttons (Clear results, Open in Tab, New query, New notebook).

## Screenshots

| Query error with troubleshoot action | After click — Altimate Code opens |
| --- | --- |
| ![Error view with Troubleshoot with Altimate Code button](https://raw.githubusercontent.com/AltimateAI/vscode-dbt-power-user/0e100e0f/troubleshoot-error-state.png) | ![Altimate Code chat opens with failure context](https://raw.githubusercontent.com/AltimateAI/vscode-dbt-power-user/0e100e0f/troubleshoot-chat-opened.png) |

> The right screenshot shows the "Install Altimate Code" welcome tab because the Datamates MCP server extension is not preinstalled in the test container. When the extension **is** installed, `chat.createSession(...)` opens a chat panel titled `Troubleshoot: <filename>` with the prefilled prompt.

## Bot feedback addressed
- **Sentry — memory leak** (commit `094fb2f`): the webview called `executeRequestInSync` but the extension-side handler never responded, so each click leaked a promise entry in `requestMap`. Switched the dispatch to `executeRequestInAsync` (fire-and-forget) since no response is expected.
- **CodeRabbit — telemetry overcount** (commit `094fb2f`): `telemetry.sendTelemetryEvent("TroubleshootQueryWithAltimate")` fired even when Datamates was missing/outdated. Changed `AltimateCodeChatService.openChat` to return `Promise<boolean>` (true only when `chat.createSession` actually runs) and now emit telemetry only when `openChat` returns true.
- **Button styling** (commit `2b63758`): switched from the branded `AltimateIcon` SVG + solid-primary button to the `outline` variant with the `sparkle` codicon wrapped as `SparkleIcon`, so the button matches the visual language of the sibling query-panel toolbar buttons.
- **Label rename** (commit `fb1c150`): button now reads **Troubleshoot with Altimate Code** to match the product name used elsewhere in the extension (Altimate Code tab, Install Altimate Code welcome page, Open Altimate Code Chat toolbar button).

## Test plan
- [x] Extension and webview panels build clean (`yarn compile`, `yarn panel:webviews`)
- [x] Lint clean on all modified files
- [x] Deployed to Docker code-server via `npm run docker:deploy`
- [x] Injected `renderError` into the query panel — button renders with the sparkle codicon next to the label (screenshot #1)
- [x] Clicked the button — extension receives the inbound command and `openChat` fires; in the test container the Datamates extension isn't preinstalled, so the "Install Altimate Code" welcome tab opens (screenshot #2 — chain verified)
- [x] `executeRequestInAsync` path confirmed; `requestMap` no longer grows per click
- [ ] End-to-end test with Datamates MCP extension installed (chat session titled `Troubleshoot: <file>` opens with the prefilled prompt)
- [ ] Manual verification that telemetry no longer fires when the Datamates extension is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a troubleshooting button to error panels to start an integrated chat that includes query text, error details, and file context.
  * New decorative "sparkle" icon used on the troubleshoot button and updated icon assets across the UI.

* **Bug Fixes / Reliability**
  * Improved handling when the external chat service is unavailable; telemetry is recorded only when a chat is successfully opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->