### PR TITLE
feat: drop legacy welcome copy above Altimate Code hook

### DIFF
--- a/webview_panels/src/modules/queryPanel/QueryPanelDefaultView.tsx
+++ b/webview_panels/src/modules/queryPanel/QueryPanelDefaultView.tsx
@@ -4,42 +4,7 @@ import HelpContent from "./components/help/HelpContent";
 const QueryPanelDefaultView = (): JSX.Element => {
   return (
     <Stack style={{ gap: 30, paddingTop: "1rem" }}>
-      <div>
-        <div>
-          <h2>
-            Upcoming Feature Alert: Enhanced Support for dbt SQL Execution in
-            Notebooks
-          </h2>
-          <p>
-            We&apos;re excited to announce that soon, you&apos;ll be able to
-            execute dbt SQL directly within notebooks. This new feature will
-            empower you to create data-driven stories, streamline debugging
-            processes, and optimize your workflows—all within VSCode. Stay tuned
-            for more updates and{" "}
-            <a href="https://app.myaltimate.com/contactus">contact us</a> if you
-            would like an early access!
-          </p>
-          <h2>Query History, Bookmarks, and More</h2>
-          {/* TODO: get the actual text from Pradnesh */}
-          <p>
-            <br />
-            Execute any SQL query with the &quot;+ New Query&quot; button. Every
-            query you run in the current VSCode session is stored in your query
-            history, accessible for later use.
-            <br />
-            Bookmark your favorite or frequently used queries for easy access
-            and share them with your team.
-            <br />
-            You can also rerun queries directly from your history or bookmarks.
-            <br />
-            For more information, check out the{" "}
-            <a href="https://docs.myaltimate.com/govern/querybookmarks/">
-              documentation
-            </a>
-          </p>
-        </div>
-        <HelpContent />
-      </div>
+      <HelpContent />
     </Stack>
   );
 };


### PR DESCRIPTION
The Query Results welcome tab was still rendering the "Upcoming Feature Alert" and "Query History, Bookmarks, and More" blocks above the new Altimate Code product hook (HelpContent), so users saw both the old multi-section copy and the new one-liner + CTAs. Remove the outer <div> stack and render HelpContent alone, matching the tightened copy approved for the welcome tab.

## Overview

### Problem

Describe the problem you are solving. Mention the ticket/issue if applicable.

### Solution

Describe the implemented solution. Add external references if needed.

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Simplified the default query panel view to reduce visual clutter and focus the display on core help content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->