### PR TITLE
fix: restore Azure telemetry by passing connection string to TelemetryReporter

### DIFF
--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 export class TelemetryService implements vscode.Disposable {
   private customAttributes: { [key: string]: string } = {};
   private telemetryReporter: TelemetryReporter = new TelemetryReporter(
-    "50598369-dd83-4f9a-9a65-ca1fa6f1785c",
+    "InstrumentationKey=50598369-dd83-4f9a-9a65-ca1fa6f1785c;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://westus.livediagnostics.monitor.azure.com/;ApplicationId=429da6f5-e7b0-40e6-a602-adaa8dcde8b9",
   );
   private eventMeasurements = new Map();
 


### PR DESCRIPTION
## Summary

`@vscode/extension-telemetry@0.9.7` (introduced via #1482) silently broke all Azure telemetry from the extension. Every `sendTelemetryEvent` and `sendTelemetryError` call has been a no-op in `0.60.6` since release. The fix is one line at the `TelemetryReporter` call site: pass a full Application Insights **connection string** instead of a bare instrumentation-key GUID.

## Root cause

`@vscode/extension-telemetry@0.9.7` changed the `TelemetryReporter` constructor parameter from `key: string` (instrumentation-key GUID) to `connectionString: string` (e.g. `"InstrumentationKey=…;IngestionEndpoint=…"`). Bare-GUID call sites against 0.9.7 silently parse to `InstrumentationKey=null`; the SDK still POSTs to `dc.services.visualstudio.com/v2/track`, but the server responds `{"itemsReceived":0,"itemsAccepted":0,"appId":null,"errors":[]}` and nothing lands in App Insights.

This is a known upstream regression: [microsoft/vscode-extension-telemetry#214](https://github.com/microsoft/vscode-extension-telemetry/issues/214) — *"Extension telemetry client v0.9.7 does not report any events"*. Library maintainer (`@lramos15`) acknowledged the breaking change and restored bare-key support in `0.9.8`. We didn't bump past `0.9.7` here because (a) the connection-string form works on `0.9.7`, and (b) `0.9.8`/`0.9.9` introduced a separate transitive-dep packaging issue ([#244](https://github.com/microsoft/vscode-extension-telemetry/issues/244)) that breaks bundling.

## Evidence

**Before (master at `0.60.6`):**

| version | events (7d) | machines |
|---|---|---|
| 0.60.5 | 5,873,977 | 23,402 |
| 0.60.4 | 575,209 | 2,958 |
| **0.60.6** | **0** | **0** |

`0.60.6` was published to the marketplace on 2026-04-23 (validated, non-prerelease, all 5 platform builds). Marketplace serves it as latest. Auto-update has been propagating for 4.5 days, yet zero machines report telemetry from it.

**After (this PR, verified in a docker code-server with the published `0.60.6` VSIX patched in-place to use a connection string):**

```
2026-04-27T15:58:39  innoverio.vscode-dbt-power-user/dbtCommand                      m=7ea8ada3 intMode='core'
2026-04-27T15:58:39  innoverio.vscode-dbt-power-user/discoverProjects                m=7ea8ada3 intMode='core'
2026-04-27T15:58:39  innoverio.vscode-dbt-power-user/nonExistingAllowListFolders     m=7ea8ada3 intMode='core'
```

Events land in App Insights with the existing custom dimensions intact. (`dbtCloudVariant` is empty here only because the test container has no `dbt` Python package installed; the field-stamping path itself is unchanged.)

## Scope notes

- **`vscode-altimate-mcp-server` is unaffected.** Its `package.json` declares `^0.9.8` (caret), which yarn-resolves to `0.9.9` — a version that accepts both bare keys and connection strings. Last-7d events confirm it's flowing normally (~110k machines across recent versions, last_seen within seconds of "now"). It still passes a bare GUID and is one Snyk auto-bump away from the same trap, so a defensive parity follow-up is worth filing — but it's not broken today, so it's out of scope here.
- **CI guard test is a follow-up.** Power-user's jest suite isn't currently wired into CI (only build/package/bundle-size analysis runs), and the existing test runner has a pre-existing mock gap on `@vscode/extension-telemetry` that needs its own fix before a static call-site assertion can run. Tracking separately.

## Test plan

- [ ] Build the extension and install the resulting VSIX in a code-server / VS Code instance with telemetry enabled
- [ ] Open any dbt project and confirm activation completes
- [ ] Wait ~30s, then query App Insights:
  ```kql
  customEvents
  | where timestamp > ago(15m) and tostring(customDimensions.['common.extversion']) == "<this-build-version>"
  | take 25
  ```
- [ ] Confirm events appear with `dbtIntegrationMode`, `dbtCloudVariant`, `dbtCloudRawVersion` populated

## References

- Inadvertent cause: #1482 (Snyk auto-bump 0.9.6 → 0.9.7, merged by @mdesmet)
- Upstream regression report: [microsoft/vscode-extension-telemetry#214](https://github.com/microsoft/vscode-extension-telemetry/issues/214)
- Sibling packaging bug we sidestep by staying on 0.9.7: [microsoft/vscode-extension-telemetry#244](https://github.com/microsoft/vscode-extension-telemetry/issues/244)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated telemetry infrastructure to use enhanced configuration settings for improved data collection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->