### PR TITLE
feat: show What's New panel on extension update

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,11 @@
             "description": "Enable Datapilot notebooks feature",
             "default": true
           },
+          "dbt.showChangelogOnUpdate": {
+            "type": "boolean",
+            "description": "Automatically show the What's New page when the extension is updated to a new version.",
+            "default": true
+          },
           "dbt.lineage.showSelectEdges": {
             "type": "boolean",
             "description": "Show select edges in lineage panel.",
@@ -499,6 +504,11 @@
         "command": "dbtPowerUser.openOnboarding",
         "category": "dbt Power User",
         "title": "Get Started with dbt Power User"
+      },
+      {
+        "command": "dbtPowerUser.showWhatsNew",
+        "category": "dbt Power User",
+        "title": "Show What's New"
       },
       {
         "command": "dbtPowerUser.sqlQuickPick",

--- a/resources/whats-new.html
+++ b/resources/whats-new.html
@@ -1,0 +1,88 @@
+<!--
+  Hand-authored "What's New" content. Edit this file each release cycle to
+  highlight notable changes from the previous ~3 months.
+
+  Conventions:
+    - This file ships in the VSIX and is rendered by WhatsNewPanel.
+    - Only include the body content here; the panel wraps it with theming.
+    - Group entries under the existing Develop / Test / Collaborate phases
+      so users can map highlights to the marketing surface they already know.
+    - Link to PR numbers (#1234) where useful — they render as plain text but
+      help maintainers cross-reference history.
+-->
+
+<p class="whats-new-intro">
+  Highlights from the last few months. Toggle the checkbox below if you'd rather
+  see this only when you open it manually.
+</p>
+
+<h2>🔧 Develop</h2>
+<ul>
+  <li>
+    <strong>CTE Profiler</strong> — see per-CTE timing and row counts as inline
+    decorations while a query runs, so you can spot expensive sub-queries
+    without rewriting them. (#1863)
+  </li>
+  <li>
+    <strong>YAML schema codelenses</strong> — Run/Test actions and model info
+    hovers now appear directly on YAML schema files, not just on SQL. (#1872)
+  </li>
+  <li>
+    <strong>RisingWave adapter support</strong> — first-class detection for
+    projects using the RisingWave adapter. (#1889)
+  </li>
+  <li>
+    <strong>Macro go-to-definition</strong> — resolves macros prefixed with
+    their own project name (e.g. <code>my_project.my_macro()</code>). (#1881)
+  </li>
+</ul>
+
+<h2>🧪 Test</h2>
+<ul>
+  <li>
+    <strong>Singular data tests</strong> — the “Run Test” action now recognises
+    singular data tests, not just generic schema tests. (#1879)
+  </li>
+  <li>
+    <strong>Docs editor schema fix</strong> — stops writing both
+    <code>tests:</code> and <code>data_tests:</code> for the same column,
+    keeping schema YAML clean. (#1899)
+  </li>
+</ul>
+
+<h2>🤝 Collaborate &amp; AI</h2>
+<ul>
+  <li>
+    <strong>Altimate Code product hook</strong> — Query Results welcome tab now
+    points to Altimate Code chat for context-aware help. (#1907, #1909)
+  </li>
+  <li>
+    <strong>Troubleshoot with Altimate</strong> — when a query fails, jump
+    straight from the error into a guided troubleshooting flow. (#1906)
+  </li>
+  <li>
+    <strong>MCP tool schemas</strong> — schemas now strip <code>$schema</code>
+    so Gemini and other strict consumers accept them. (#1891)
+  </li>
+</ul>
+
+<h2>🛠️ Reliability &amp; internals</h2>
+<ul>
+  <li>
+    Telemetry crash-paths hardened against undefined <code>uri.fsPath</code> /
+    <code>range.start</code>, fixing several Sentry reports. (#1890)
+  </li>
+  <li>
+    Azure telemetry restored by passing the connection string through to
+    <code>TelemetryReporter</code>. (#1912)
+  </li>
+  <li>
+    Build system migrated from webpack to rsbuild — faster compiles in
+    development and CI. (#1762)
+  </li>
+</ul>
+
+<p class="whats-new-footer">
+  Full release notes are available on the
+  <a href="https://marketplace.visualstudio.com/items/innoverio.vscode-dbt-power-user/changelog">VS Code Marketplace</a>.
+</p>

--- a/src/dbtPowerUserExtension.ts
+++ b/src/dbtPowerUserExtension.ts
@@ -16,6 +16,7 @@ import { TelemetryService } from "./telemetry";
 import { TreeviewProviders } from "./treeview_provider";
 import { ValidationProvider } from "./validation_provider";
 import { WebviewViewProviders } from "./webview_provider";
+import { WhatsNewPanel } from "./webview_provider/whatsNewPanel";
 
 enum PromptAnswer {
   YES = "Yes",
@@ -60,6 +61,7 @@ export class DBTPowerUserExtension implements Disposable {
     private commentProviders: CommentProviders,
     private notebookProviders: NotebookProviders,
     private mcpServer: DbtPowerUserMcpServer,
+    private whatsNewPanel: WhatsNewPanel,
   ) {
     this.disposables.push(
       this.dbtProjectContainer,
@@ -79,6 +81,10 @@ export class DBTPowerUserExtension implements Disposable {
       this.commentProviders,
       this.notebookProviders,
       this.mcpServer,
+      this.whatsNewPanel,
+      commands.registerCommand("dbtPowerUser.showWhatsNew", () =>
+        this.whatsNewPanel.show("manual"),
+      ),
     );
   }
 
@@ -96,6 +102,7 @@ export class DBTPowerUserExtension implements Disposable {
       await this.mcpServer.updateMcpExtensionApi();
       this.dbtProjectContainer.setContext(context);
       this.dbtProjectContainer.initializeWalkthrough();
+      await this.dbtProjectContainer.checkAndShowWhatsNew(this.whatsNewPanel);
       await this.dbtProjectContainer.detectDBT();
       await this.dbtProjectContainer.initializeDBTProjects();
       await this.statusBars.initialize();

--- a/src/dbt_client/dbtProjectContainer.ts
+++ b/src/dbt_client/dbtProjectContainer.ts
@@ -167,6 +167,50 @@ export class DBTProjectContainer implements Disposable {
     }
   }
 
+  async checkAndShowWhatsNew(panel: {
+    show: (reason: "manual" | "update") => void | Promise<void>;
+  }) {
+    const currentVersion = this.extensionVersion;
+    const lastSeenVersion = this.getFromGlobalState("lastSeenVersion") as
+      | string
+      | undefined;
+
+    if (lastSeenVersion === currentVersion) {
+      return;
+    }
+
+    // Persist the new version regardless of whether we end up showing the
+    // panel; otherwise users who opt out would be re-prompted every restart
+    // until they update again.
+    this.setToGlobalState("lastSeenVersion", currentVersion);
+
+    if (lastSeenVersion === undefined) {
+      // Fresh install: defer to the existing setup walkthrough.
+      this.dbtTerminal.debug(
+        "dbtProjectContainer:whatsNewSkipped",
+        "fresh install, skipping What's New panel",
+      );
+      return;
+    }
+
+    const showChangelog = workspace
+      .getConfiguration("dbt")
+      .get<boolean>("showChangelogOnUpdate", true);
+    if (!showChangelog) {
+      this.dbtTerminal.debug(
+        "dbtProjectContainer:whatsNewSkipped",
+        `dbt.showChangelogOnUpdate is false (was ${lastSeenVersion}, now ${currentVersion})`,
+      );
+      return;
+    }
+
+    this.dbtTerminal.debug(
+      "dbtProjectContainer:whatsNewDisplayed",
+      `showing What's New panel (was ${lastSeenVersion}, now ${currentVersion})`,
+    );
+    await panel.show("update");
+  }
+
   get extensionUri() {
     return this.context!.extensionUri;
   }

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -158,6 +158,7 @@ import { NewLineagePanel } from "./webview_provider/newLineagePanel";
 import { OnboardingPanel } from "./webview_provider/onboardingPanel";
 import { QueryResultPanel } from "./webview_provider/queryResultPanel";
 import { SQLLineagePanel } from "./webview_provider/sqlLineagePanel";
+import { WhatsNewPanel } from "./webview_provider/whatsNewPanel";
 
 export const container = new Container();
 
@@ -1849,6 +1850,17 @@ container
   })
   .inSingletonScope();
 
+container
+  .bind(WhatsNewPanel)
+  .toDynamicValue((context) => {
+    return new WhatsNewPanel(
+      context.container.get(DBTProjectContainer),
+      context.container.get(TelemetryService),
+      context.container.get("DBTTerminal"),
+    );
+  })
+  .inSingletonScope();
+
 // Bind DbtPowerUserActionsCenter
 container
   .bind(DbtPowerUserActionsCenter)
@@ -1894,6 +1906,7 @@ container
       context.container.get(CommentProviders),
       context.container.get("NotebookProviders"),
       context.container.get(DbtPowerUserMcpServer),
+      context.container.get(WhatsNewPanel),
     );
   })
   .inSingletonScope();

--- a/src/test/suite/dbtProjectContainer.test.ts
+++ b/src/test/suite/dbtProjectContainer.test.ts
@@ -745,6 +745,92 @@ describe("DBTProjectContainer Tests", () => {
     });
   });
 
+  describe("checkAndShowWhatsNew", () => {
+    let mockGlobalState: any;
+    let mockPanel: any;
+
+    const setupContext = (
+      version: string,
+      lastSeenVersion: string | undefined,
+    ) => {
+      mockGlobalState = {
+        get: jest.fn((key: unknown) =>
+          key === "lastSeenVersion" ? lastSeenVersion : undefined,
+        ),
+        update: jest.fn(),
+      };
+      const mockContext = {
+        workspaceState: { get: jest.fn(), update: jest.fn() },
+        globalState: mockGlobalState,
+        extension: { id: "test-extension", packageJSON: { version } },
+      } as unknown as ExtensionContext;
+      container.setContext(mockContext);
+    };
+
+    const setShowChangelogSetting = (value: boolean) => {
+      const mockConfig = {
+        get: jest.fn((key: unknown, defaultValue?: unknown) => {
+          if (key === "showChangelogOnUpdate") {
+            return value;
+          }
+          return defaultValue;
+        }),
+      };
+      (workspace.getConfiguration as any) = jest.fn(() => mockConfig);
+    };
+
+    beforeEach(() => {
+      mockPanel = { show: jest.fn(() => Promise.resolve()) };
+      setShowChangelogSetting(true);
+    });
+
+    it("does nothing when the version has not changed", async () => {
+      setupContext("0.60.6", "0.60.6");
+
+      await container.checkAndShowWhatsNew(mockPanel);
+
+      expect(mockPanel.show).not.toHaveBeenCalled();
+      expect(mockGlobalState.update).not.toHaveBeenCalled();
+    });
+
+    it("persists the version on first install but does not show the panel", async () => {
+      setupContext("0.60.6", undefined);
+
+      await container.checkAndShowWhatsNew(mockPanel);
+
+      expect(mockPanel.show).not.toHaveBeenCalled();
+      expect(mockGlobalState.update).toHaveBeenCalledWith(
+        "lastSeenVersion",
+        "0.60.6",
+      );
+    });
+
+    it("shows the panel and persists the version on a real update", async () => {
+      setupContext("0.60.6", "0.60.5");
+
+      await container.checkAndShowWhatsNew(mockPanel);
+
+      expect(mockGlobalState.update).toHaveBeenCalledWith(
+        "lastSeenVersion",
+        "0.60.6",
+      );
+      expect(mockPanel.show).toHaveBeenCalledWith("update");
+    });
+
+    it("skips showing the panel when the user has opted out, but still persists the version", async () => {
+      setupContext("0.60.6", "0.60.5");
+      setShowChangelogSetting(false);
+
+      await container.checkAndShowWhatsNew(mockPanel);
+
+      expect(mockGlobalState.update).toHaveBeenCalledWith(
+        "lastSeenVersion",
+        "0.60.6",
+      );
+      expect(mockPanel.show).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Project Registration Events", () => {
     it("should set up project registration event handler", () => {
       // The project registration event handler is set up in the constructor

--- a/src/webview_provider/whatsNewPanel.ts
+++ b/src/webview_provider/whatsNewPanel.ts
@@ -1,0 +1,230 @@
+import { DBTTerminal } from "@altimateai/dbt-integration";
+import { inject, injectable } from "inversify";
+import {
+  ConfigurationTarget,
+  Disposable,
+  Uri,
+  ViewColumn,
+  WebviewPanel,
+  window,
+  workspace,
+} from "vscode";
+import { DBTProjectContainer } from "../dbt_client/dbtProjectContainer";
+import { TelemetryService } from "../telemetry";
+
+type ShowReason = "manual" | "update";
+
+@injectable()
+export class WhatsNewPanel implements Disposable {
+  public static readonly viewType = "dbtPowerUser.WhatsNew";
+
+  private panel: WebviewPanel | undefined;
+  private disposables: Disposable[] = [];
+
+  public constructor(
+    private dbtProjectContainer: DBTProjectContainer,
+    private telemetry: TelemetryService,
+    @inject("DBTTerminal") private dbtTerminal: DBTTerminal,
+  ) {}
+
+  public async show(reason: ShowReason): Promise<void> {
+    if (this.panel) {
+      this.panel.reveal(ViewColumn.One);
+      return;
+    }
+
+    let bodyHtml: string;
+    try {
+      bodyHtml = await this.readContent();
+    } catch (err) {
+      this.dbtTerminal.error(
+        "whatsNewPanel:readContent",
+        "Failed to read whats-new.html",
+        err,
+      );
+      return;
+    }
+
+    const version = this.dbtProjectContainer.extensionVersion;
+    const showOnUpdate = workspace
+      .getConfiguration("dbt")
+      .get<boolean>("showChangelogOnUpdate", true);
+
+    this.panel = window.createWebviewPanel(
+      WhatsNewPanel.viewType,
+      "What's New in dbt Power User",
+      ViewColumn.One,
+      { enableScripts: true, retainContextWhenHidden: true },
+    );
+
+    this.panel.webview.html = this.renderHtml(bodyHtml, version, showOnUpdate);
+
+    this.panel.webview.onDidReceiveMessage(
+      (message) => this.handleMessage(message),
+      null,
+      this.disposables,
+    );
+
+    this.panel.onDidDispose(
+      () => {
+        this.panel = undefined;
+      },
+      null,
+      this.disposables,
+    );
+
+    this.telemetry.sendTelemetryEvent("whatsNewShown", {
+      reason,
+      version,
+    });
+  }
+
+  private async readContent(): Promise<string> {
+    const uri = Uri.joinPath(
+      this.dbtProjectContainer.extensionUri,
+      "resources",
+      "whats-new.html",
+    );
+    const bytes = await workspace.fs.readFile(uri);
+    return Buffer.from(bytes).toString("utf8");
+  }
+
+  private async handleMessage(message: {
+    command?: string;
+    value?: boolean;
+  }): Promise<void> {
+    if (message?.command !== "setShowOnUpdate") {
+      return;
+    }
+    const value = message.value !== false;
+    try {
+      await workspace
+        .getConfiguration("dbt")
+        .update("showChangelogOnUpdate", value, ConfigurationTarget.Global);
+      this.telemetry.sendTelemetryEvent("whatsNewToggled", {
+        showOnUpdate: String(value),
+      });
+    } catch (err) {
+      this.dbtTerminal.error(
+        "whatsNewPanel:setShowOnUpdate",
+        "Failed to update dbt.showChangelogOnUpdate",
+        err,
+      );
+    }
+  }
+
+  private renderHtml(
+    bodyHtml: string,
+    version: string,
+    showOnUpdate: boolean,
+  ): string {
+    const checkedAttr = showOnUpdate ? "checked" : "";
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';" />
+<title>What's New in dbt Power User</title>
+<style>
+  body {
+    font-family: var(--vscode-font-family);
+    color: var(--vscode-editor-foreground);
+    background: var(--vscode-editor-background);
+    line-height: 1.55;
+    padding: 24px 36px 48px;
+    max-width: 820px;
+    margin: 0 auto;
+  }
+  h1 {
+    margin-bottom: 4px;
+  }
+  h2 {
+    margin-top: 28px;
+    border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,0.3));
+    padding-bottom: 4px;
+  }
+  ul { padding-left: 22px; }
+  li { margin-bottom: 8px; }
+  code {
+    font-family: var(--vscode-editor-font-family);
+    background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15));
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+  a {
+    color: var(--vscode-textLink-foreground);
+    text-decoration: none;
+  }
+  a:hover { text-decoration: underline; }
+  .version-tag {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 12px;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    vertical-align: middle;
+  }
+  .opt-out {
+    margin-top: 32px;
+    padding-top: 16px;
+    border-top: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,0.3));
+    font-size: 13px;
+    opacity: 0.85;
+  }
+  .opt-out label { cursor: pointer; }
+  .whats-new-intro { opacity: 0.85; }
+  .whats-new-footer {
+    margin-top: 24px;
+    font-size: 13px;
+    opacity: 0.8;
+  }
+</style>
+</head>
+<body>
+  <h1>What's New<span class="version-tag">v${escapeHtml(version)}</span></h1>
+  ${bodyHtml}
+  <div class="opt-out">
+    <label>
+      <input id="showOnUpdate" type="checkbox" ${checkedAttr} />
+      Show this page automatically when the extension is updated
+    </label>
+  </div>
+  <script>
+    (function () {
+      const vscode = acquireVsCodeApi();
+      const cb = document.getElementById('showOnUpdate');
+      cb.addEventListener('change', function () {
+        vscode.postMessage({
+          command: 'setShowOnUpdate',
+          value: cb.checked,
+        });
+      });
+    })();
+  </script>
+</body>
+</html>`;
+  }
+
+  public dispose(): void {
+    while (this.disposables.length) {
+      const d = this.disposables.pop();
+      if (d) {
+        d.dispose();
+      }
+    }
+    this.panel?.dispose();
+    this.panel = undefined;
+  }
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}


### PR DESCRIPTION
## Summary
- Show a hand-authored What's New webview the first time the user activates the extension after a version bump. Content lives in `resources/whats-new.html` so it's curated, not auto-generated.
- New `dbt.showChangelogOnUpdate` setting (default `true`) plus an in-panel checkbox to opt out.
- New `dbtPowerUser.showWhatsNew` command so users can re-open the page on demand.
- Skips the auto-open on fresh install — defers to the existing setup walkthrough.

## Implementation
- `WhatsNewPanel` (`src/webview_provider/whatsNewPanel.ts`) creates a one-off `WebviewPanel`, reads the HTML fragment, wraps it in a themed shell, and handles the opt-out checkbox via webview messages → `workspace.getConfiguration("dbt").update("showChangelogOnUpdate", value, ConfigurationTarget.Global)`.
- `DBTProjectContainer.checkAndShowWhatsNew` mirrors the existing `initializeWalkthrough()` pattern: compares `extension.packageJSON.version` against `globalState.lastSeenVersion`, persists the new version unconditionally (so opt-outs stick), and only calls `panel.show("update")` for true upgrades.
- Wired through the existing Inversify container; not registered as a sidebar view because the panel opens in the editor area on demand.

## Test plan
- [x] `npm run compile` clean
- [x] `npm run lint` clean
- [x] `npm test` — 460 tests pass, including 4 new cases covering same-version no-op, first-install skip, real-update show, and opt-out skip
- [x] `rsbuild build` produces a working extension bundle
- [ ] Manual smoke test in Extension Host:
  - Bump local `package.json` version, reload window, confirm panel auto-opens
  - Toggle the in-panel checkbox, verify `dbt.showChangelogOnUpdate` flips in user `settings.json`
  - Run `dbt Power User: Show What's New` from the command palette
  - Reload window after auto-open completes, confirm it does not re-open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "What's New" panel automatically displayed when the extension updates.
  * Added a command to manually open the "What's New" page anytime.
  * Added configuration setting to control auto-display behavior on update.
  * Included opt-out option within the panel to disable future auto-displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->