### PR TITLE
chore: release 0.60.7 and guard publish jobs against tag/version drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,15 @@ jobs:
         uses: ./.github/actions/common-build
         with:
           vsce-target: ${{ matrix.target }}
+      - name: Verify package.json version matches release tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match release tag ($TAG_VERSION). Bump package.json before tagging — vsce publishes the version from package.json, not the tag."
+            exit 1
+          fi
+          echo "package.json version $PKG_VERSION matches tag $TAG_VERSION"
       - name: Publish Visual Studio Marketplace
         run: |
           PRE_RELEASE=""
@@ -206,6 +215,15 @@ jobs:
         uses: ./.github/actions/common-build
         with:
           vsce-target: ${{ matrix.target }}
+      - name: Verify package.json version matches release tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match release tag ($TAG_VERSION). Bump package.json before tagging — ovsx publishes the version from package.json, not the tag."
+            exit 1
+          fi
+          echo "package.json version $PKG_VERSION matches tag $TAG_VERSION"
       - name: Publish OpenVSX Marketplace
         run: |
           PRE_RELEASE=""

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/AltimateAI/vscode-dbt-power-user/issues"
   },
-  "version": "0.60.6",
+  "version": "0.60.7",
   "engines": {
     "vscode": "^1.95.0"
   },


### PR DESCRIPTION
## Summary

The `0.60.7` release tag was pushed yesterday on top of master HEAD (#1912), but `package.json` was never bumped from `0.60.6`. CI ran the publish jobs successfully — but `vsce` built `vscode-dbt-power-user-linux-x64-0.60.6.vsix`, hit `--skip-duplicate` because `0.60.6` was already on the marketplace, and exited 0. **Nothing landed on the marketplace, and 0.60.6 with the broken Azure telemetry SDK call site is still what users run.**

This PR does two things in parallel:

1. **Bump `package.json` to `0.60.7`** so the next push of the `0.60.7` tag actually ships a new VSIX with the connection-string fix from #1912.
2. **Add a tag/version sanity check** before each `vsce publish` / `ovsx publish` step. If `package.json.version` does not equal `GITHUB_REF_NAME`, the publish job fails loudly instead of silently no-op'ing. Eliminates the silent-skip class of failure that hid this regression.

## Evidence the release silently no-op'd

From the `release-vsstudio-marketplace (linux-x64)` job logs on the `0.60.7` tag run (`25030038361`):

```
Files included in the VSIX:
vscode-dbt-power-user-linux-x64-0.60.6.vsix    ← named 0.60.6, not 0.60.7
…
Publishing 'innoverio.vscode-dbt-power-user (linux-x64) v0.60.6'...
Version 0.60.6 is already published. Skipping publish.    ← --skip-duplicate swallowed the error
```

Marketplace currently serves `0.60.6` (verified via the gallery API). Telemetry from `0.60.7` in App Insights: zero events.

## Why this happened

Prior `0.60.x` releases each had a `chore: bump version to 0.60.x` commit landed on master *before* the tag was cut (visible in `git log --oneline | grep "bump version to 0.60"`). The `0.60.7` tag was placed directly on the merged telemetry-fix commit without that step. The CI workflow uses `vsce publish --skip-duplicate`, which intentionally treats "already exists" as success — useful for benign re-runs of a same-version tag, dangerous when paired with a tag/version mismatch.

## Recovery (after this merges)

```bash
git tag -d 0.60.7
git push --delete origin 0.60.7
git fetch origin master
git tag 0.60.7 origin/master       # now points at the bump commit
git push origin 0.60.7
```

CI will re-run; the new sanity-check step confirms `package.json.version (0.60.7) == GITHUB_REF_NAME (0.60.7)` and `vsce publish` actually uploads.

The existing GitHub Release object for `0.60.7` will need to be re-pointed at the new commit (or deleted and re-created) so its source-tarball asset matches what shipped.

## Test plan

- [ ] Diff is two files: `package.json` (one line) + `.github/workflows/ci.yml` (two new "Verify package.json version" steps)
- [ ] After merging, retag `0.60.7` per the recovery steps above
- [ ] Confirm the next CI run on the retagged `0.60.7`:
  - [ ] Both `release-vsstudio-marketplace` and `release-openvsx-marketplace` matrices pass the new "Verify" step (logs print `package.json version 0.60.7 matches tag 0.60.7`)
  - [ ] `vsce publish` actually uploads (logs no longer show `Version … is already published. Skipping publish.`)
  - [ ] Marketplace API returns `0.60.7` as latest
- [ ] Within ~5 minutes of marketplace serving `0.60.7`, App Insights starts seeing events with `customDimensions['common.extversion'] == "0.60.7"`

## Future-proofing notes (out of scope)

To eliminate the manual bump entirely, the publish jobs could stamp `package.json.version` from `GITHUB_REF_NAME` at build time, making the tag the single source of truth. That's a follow-up — keeping this PR focused on un-breaking the immediate release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version incremented to 0.60.7.
  * Improved continuous integration workflow with enhanced validation step in marketplace publishing path that checks version consistency between package metadata and release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->