### PR TITLE
fix: guard MCP extension exports undefined when MCP server disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.60.6",
+  "version": "0.60.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.60.6",
+      "version": "0.60.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -43,8 +43,8 @@ export class DbtPowerUserMcpServer implements Disposable {
       if (!extension) {
         this.dbtTerminal.error(
           "DbtPowerUserMcpServer: enableMcpExtensionIntegration",
-          "Failed to install MCP extension",
-          { message: "Failed to install Altimate MCP Server extension" },
+          "Failed to install Altimate MCP Server extension",
+          undefined,
         );
         return;
       }
@@ -89,7 +89,7 @@ export class DbtPowerUserMcpServer implements Disposable {
       this.dbtTerminal.error(
         "DbtPowerUserMcpServer:updateMcpExtensionApiError",
         "Error updating MCP extension API",
-        { message: (error as Error).message },
+        error,
       );
     }
   }
@@ -132,7 +132,7 @@ export class DbtPowerUserMcpServer implements Disposable {
       this.dbtTerminal.error(
         "DbtPowerUserMcpServer:registerToolsInMcpExtensionError",
         "Error registering tools in MCP extension",
-        { message: (error as Error).message },
+        error,
       );
     }
   }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -52,7 +52,18 @@ export class DbtPowerUserMcpServer implements Disposable {
       if (!extension.isActive) {
         await extension.activate();
       }
-      await extension.exports.ready;
+      // The MCP server's activate() returns undefined when
+      // `altimate.disableMcpServer = true`, leaving exports unset.
+      if (!extension.exports) {
+        this.dbtTerminal.info(
+          "DbtPowerUserMcpServer: updateMcpExtensionApi",
+          "MCP extension is installed but not exporting an API (likely disabled via altimate.disableMcpServer); skipping integration",
+        );
+        return;
+      }
+      if (extension.exports.ready) {
+        await extension.exports.ready;
+      }
       this.mcpExtensionApi = extension.exports as ToolRegistry;
 
       await this.mcpExtensionApi.addMcpIntegrationConfig([

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -42,7 +42,7 @@ export class DbtPowerUserMcpServer implements Disposable {
 
       if (!extension) {
         this.dbtTerminal.info(
-          "DbtPowerUserMcpServer: enableMcpExtensionIntegration",
+          "DbtPowerUserMcpServer:enableMcpExtensionIntegration",
           "Altimate MCP Server extension is not installed",
         );
         return;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -41,10 +41,9 @@ export class DbtPowerUserMcpServer implements Disposable {
       );
 
       if (!extension) {
-        this.dbtTerminal.error(
+        this.dbtTerminal.info(
           "DbtPowerUserMcpServer: enableMcpExtensionIntegration",
-          "Failed to install Altimate MCP Server extension",
-          undefined,
+          "Altimate MCP Server extension is not installed",
         );
         return;
       }

--- a/src/test/suite/mcpServer.test.ts
+++ b/src/test/suite/mcpServer.test.ts
@@ -68,26 +68,21 @@ describe("DbtPowerUserMcpServer.updateMcpExtensionApi", () => {
     jest.clearAllMocks();
   });
 
-  it("logs an error and returns when the MCP extension is not installed", async () => {
+  it("logs info and returns when the MCP extension is not installed", async () => {
     getExtensionMock.mockReturnValue(undefined);
     const terminal = buildTerminal();
     const server = newServer(terminal);
 
     await server.updateMcpExtensionApi();
 
-    expect(terminal.error).toHaveBeenCalledTimes(1);
-    expect(terminal.error.mock.calls[0][0]).toBe(
+    expect(terminal.error).not.toHaveBeenCalled();
+    expect(terminal.info).toHaveBeenCalledTimes(1);
+    expect(terminal.info.mock.calls[0][0]).toBe(
       "DbtPowerUserMcpServer: enableMcpExtensionIntegration",
     );
-    // The message arg must carry the user-visible explanation directly —
-    // previously the second arg was a generic "Failed to install MCP extension"
-    // and the third was `{ message: "..." }`, which rendered as
-    // `[object Object]` in the dbt output channel.
-    expect(terminal.error.mock.calls[0][1]).toBe(
-      "Failed to install Altimate MCP Server extension",
+    expect(terminal.info.mock.calls[0][1]).toBe(
+      "Altimate MCP Server extension is not installed",
     );
-    expect(terminal.error.mock.calls[0][2]).toBeUndefined();
-    expect(terminal.info).not.toHaveBeenCalled();
   });
 
   it("forwards the real Error to dbtTerminal.error when integration registration throws", async () => {

--- a/src/test/suite/mcpServer.test.ts
+++ b/src/test/suite/mcpServer.test.ts
@@ -79,7 +79,44 @@ describe("DbtPowerUserMcpServer.updateMcpExtensionApi", () => {
     expect(terminal.error.mock.calls[0][0]).toBe(
       "DbtPowerUserMcpServer: enableMcpExtensionIntegration",
     );
+    // The message arg must carry the user-visible explanation directly —
+    // previously the second arg was a generic "Failed to install MCP extension"
+    // and the third was `{ message: "..." }`, which rendered as
+    // `[object Object]` in the dbt output channel.
+    expect(terminal.error.mock.calls[0][1]).toBe(
+      "Failed to install Altimate MCP Server extension",
+    );
+    expect(terminal.error.mock.calls[0][2]).toBeUndefined();
     expect(terminal.info).not.toHaveBeenCalled();
+  });
+
+  it("forwards the real Error to dbtTerminal.error when integration registration throws", async () => {
+    // Regression guard for the `[object Object]` log corruption: catch blocks
+    // used to wrap `error` in `{ message: e.message }`, which then stringified
+    // as `[object Object]` in the dbt output channel and stripped the stack
+    // from `sendTelemetryError`. The catch must forward the original Error.
+    const thrown = new Error("addMcpIntegrationConfig blew up");
+    const addMcpIntegrationConfig = jest
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(thrown);
+    getExtensionMock.mockReturnValue({
+      isActive: true,
+      activate: jest.fn(),
+      exports: { addMcpIntegrationConfig },
+    });
+    const terminal = buildTerminal();
+    const server = newServer(terminal);
+
+    await server.updateMcpExtensionApi();
+
+    expect(terminal.error).toHaveBeenCalledTimes(1);
+    expect(terminal.error.mock.calls[0][0]).toBe(
+      "DbtPowerUserMcpServer:updateMcpExtensionApiError",
+    );
+    expect(terminal.error.mock.calls[0][2]).toBe(thrown);
+    // The third arg must be an actual Error instance, not a plain
+    // `{ message }` wrapper that serializes as `[object Object]`.
+    expect(terminal.error.mock.calls[0][2]).toBeInstanceOf(Error);
   });
 
   it("logs info and returns without throwing when MCP server is disabled (exports undefined)", async () => {

--- a/src/test/suite/mcpServer.test.ts
+++ b/src/test/suite/mcpServer.test.ts
@@ -78,7 +78,7 @@ describe("DbtPowerUserMcpServer.updateMcpExtensionApi", () => {
     expect(terminal.error).not.toHaveBeenCalled();
     expect(terminal.info).toHaveBeenCalledTimes(1);
     expect(terminal.info.mock.calls[0][0]).toBe(
-      "DbtPowerUserMcpServer: enableMcpExtensionIntegration",
+      "DbtPowerUserMcpServer:enableMcpExtensionIntegration",
     );
     expect(terminal.info.mock.calls[0][1]).toBe(
       "Altimate MCP Server extension is not installed",

--- a/src/test/suite/mcpServer.test.ts
+++ b/src/test/suite/mcpServer.test.ts
@@ -1,0 +1,157 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { extensions } from "vscode";
+import { DbtPowerUserMcpServer } from "../../mcp";
+
+const getExtensionMock = extensions.getExtension as jest.Mock;
+
+interface MockTerminal {
+  info: jest.Mock;
+  error: jest.Mock;
+  debug: jest.Mock;
+  warn: jest.Mock;
+  log: jest.Mock;
+  trace: jest.Mock;
+  show: jest.Mock;
+  dispose: jest.Mock;
+}
+
+function buildTerminal(): MockTerminal {
+  return {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    log: jest.fn(),
+    trace: jest.fn(),
+    show: jest.fn(),
+    dispose: jest.fn(),
+  };
+}
+
+function buildEventEmitter(): { eventEmitter: { event: jest.Mock } } {
+  return {
+    eventEmitter: {
+      event: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+    },
+  };
+}
+
+function newServer(terminal: MockTerminal) {
+  // Cast through unknown — we only exercise the dependencies the method under
+  // test actually touches.
+  return new DbtPowerUserMcpServer(
+    {} as unknown as ConstructorParameters<typeof DbtPowerUserMcpServer>[0],
+    terminal as unknown as ConstructorParameters<
+      typeof DbtPowerUserMcpServer
+    >[1],
+    {} as unknown as ConstructorParameters<typeof DbtPowerUserMcpServer>[2],
+    buildEventEmitter() as unknown as ConstructorParameters<
+      typeof DbtPowerUserMcpServer
+    >[3],
+    {} as unknown as ConstructorParameters<typeof DbtPowerUserMcpServer>[4],
+  );
+}
+
+describe("DbtPowerUserMcpServer.updateMcpExtensionApi", () => {
+  beforeEach(() => {
+    getExtensionMock.mockReset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("logs an error and returns when the MCP extension is not installed", async () => {
+    getExtensionMock.mockReturnValue(undefined);
+    const terminal = buildTerminal();
+    const server = newServer(terminal);
+
+    await server.updateMcpExtensionApi();
+
+    expect(terminal.error).toHaveBeenCalledTimes(1);
+    expect(terminal.error.mock.calls[0][0]).toBe(
+      "DbtPowerUserMcpServer: enableMcpExtensionIntegration",
+    );
+    expect(terminal.info).not.toHaveBeenCalled();
+  });
+
+  it("logs info and returns without throwing when MCP server is disabled (exports undefined)", async () => {
+    // Reproduces the 0.60.7 telemetry signal:
+    // 27 events / 17 machines hitting "Cannot read properties of undefined
+    // (reading 'ready')" because the MCP server's activate() returns undefined
+    // when `altimate.disableMcpServer === true`.
+    const activate = jest
+      .fn<() => Promise<void>>()
+      .mockResolvedValue(undefined);
+    getExtensionMock.mockReturnValue({
+      isActive: false,
+      activate,
+      exports: undefined,
+    });
+    const terminal = buildTerminal();
+    const server = newServer(terminal);
+
+    await expect(server.updateMcpExtensionApi()).resolves.toBeUndefined();
+
+    expect(activate).toHaveBeenCalledTimes(1);
+    expect(terminal.error).not.toHaveBeenCalled();
+    expect(terminal.info).toHaveBeenCalledTimes(1);
+    expect(terminal.info.mock.calls[0][0]).toBe(
+      "DbtPowerUserMcpServer: updateMcpExtensionApi",
+    );
+    expect(terminal.info.mock.calls[0][1]).toContain("disableMcpServer");
+  });
+
+  it("awaits exports.ready and registers integration when MCP exports an API", async () => {
+    let readyResolved = false;
+    const ready = new Promise<void>((resolve) =>
+      setTimeout(() => {
+        readyResolved = true;
+        resolve();
+      }, 0),
+    );
+    const addMcpIntegrationConfig = jest
+      .fn<() => Promise<void>>()
+      .mockResolvedValue(undefined);
+    getExtensionMock.mockReturnValue({
+      isActive: true,
+      activate: jest.fn(),
+      exports: { ready, addMcpIntegrationConfig },
+    });
+    const terminal = buildTerminal();
+    const server = newServer(terminal);
+
+    await server.updateMcpExtensionApi();
+
+    expect(readyResolved).toBe(true);
+    expect(addMcpIntegrationConfig).toHaveBeenCalledTimes(1);
+    expect(terminal.error).not.toHaveBeenCalled();
+    expect(terminal.info).not.toHaveBeenCalled();
+  });
+
+  it("registers integration without awaiting when exports has no ready promise", async () => {
+    const addMcpIntegrationConfig = jest
+      .fn<() => Promise<void>>()
+      .mockResolvedValue(undefined);
+    getExtensionMock.mockReturnValue({
+      isActive: true,
+      activate: jest.fn(),
+      exports: { addMcpIntegrationConfig },
+    });
+    const terminal = buildTerminal();
+    const server = newServer(terminal);
+
+    await server.updateMcpExtensionApi();
+
+    expect(addMcpIntegrationConfig).toHaveBeenCalledTimes(1);
+    expect(terminal.error).not.toHaveBeenCalled();
+    expect(terminal.info).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

Surfaced by `/telemetry-report` on dbt-power-user **0.60.7** (2026-04-29):

- **27 events / 17 distinct machines / 7 days, 0.60.7-only** for `DbtPowerUserMcpServer:updateMcpExtensionApiError`
- Single error message across all stacks: `Cannot read properties of undefined (reading 'ready')`

Clean regression from 0.60.5 → 0.60.7. No machines on 0.60.5 hit it.

While digging into the repro, also noticed a separate cosmetic bug in the same handler that mangles every emitted error log into `[object Object]`. Both are folded into this PR.

## Root cause — the `.ready` crash

`vscode-altimate-mcp-server/src/extension.ts:42-45` returns bare `undefined` when the user has `altimate.disableMcpServer = true`:

```ts
if (disableMcpServer) {
  logger.log("MCP Server is disabled via configuration");
  return;
}
```

In dbt-power-user, `src/mcp/index.ts:55` then accesses `extension.exports.ready` without a guard:

```ts
if (!extension.isActive) { await extension.activate(); }
await extension.exports.ready;            // crashes when exports is undefined
```

The throw is caught by the surrounding `try/catch`, so activation continues — but every disabled-MCP machine emits an `[error]` log + a telemetry error event on every startup.

`vscode-altimate-mcp-server/src/pythonEnvironment.ts:64` already uses the right pattern reading dbt-power-user's exports — this PR mirrors it.

## Root cause — the `[object Object]` log corruption

The three `dbtTerminal.error` calls in `mcp/index.ts` wrap the error in `{ message: ... }` before passing it as the third arg:

```ts
this.dbtTerminal.error(
  "DbtPowerUserMcpServer:updateMcpExtensionApiError",
  "Error updating MCP extension API",
  { message: (error as Error).message },  // ← wrapper
);
```

`vscodeTerminal.error` falls into the unknown branch and `${e}`-stringifies the wrapper, producing `[object Object]` in both the dbt output channel and `console.error`. `sendTelemetryError(name, e, { message })` also receives the wrapper, so App Insights stack traces are impoverished too.

## Fix

Three small changes in `src/mcp/index.ts`:

1. Early-return with `info` log when `extension.exports` is undefined (the `.ready` crash).
2. Make `await extension.exports.ready` conditional (current MCP server doesn't expose a `ready` field anyway, so the original await was a no-op).
3. Pass the real `Error` to `dbtTerminal.error` in both catch blocks; for the synthetic "extension not installed" branch, collapse the duplicate text into the second arg and pass `undefined` for the third.

Plus:

- New `src/test/suite/mcpServer.test.ts` — 5 tests covering: missing extension (with proper message + undefined error), disabled MCP (exports undefined), exports-with-ready, exports-without-ready, regression guard for the `[object Object]` corruption.
- `package-lock.json` version bump 0.60.6 → 0.60.7 (missed by the release commit).

## Pre / post-fix evidence (Docker code-server, `altimate.disableMcpServer = true`)

**Pre-fix** — `dbt` output channel (`screenshots/mcp-disabled-undefined-exports/before-dbt-output.log`):

```
[error] DbtPowerUserMcpServer:updateMcpExtensionApiError:Error updating MCP extension API:[object Object] []
```

Browser dev console: 18 errors total, including the line above. Note the `[object Object]` masking the real `Cannot read properties of undefined (reading 'ready')` message — that's the second bug in action.

**Post-fix** — `dbt` output channel (`screenshots/mcp-disabled-undefined-exports/after-cleanup-dbt-output.log`):

```
[info]  DbtPowerUserMcpServer: updateMcpExtensionApi:MCP extension is installed but not exporting an API (likely disabled via altimate.disableMcpServer); skipping integration []
[info]  DbtPowerUserMcpServer: registerToolsInMcpExtension:MCP extension API not found []
```

Browser dev console: 13 errors total — `updateMcpExtensionApiError` line gone. Remaining errors are unrelated (CORS to open-vsx, missing `macros/` in the test project).

**Happy path (MCP enabled, default settings)** — silent, no error, no info, no regression. Verified in `screenshots/mcp-disabled-undefined-exports/after-mcp-enabled-dbt-output.log`.

## Tests

```
$ npx jest
Test Suites: 28 passed, 28 total
Tests:       1 skipped, 461 passed, 462 total
```

Including 5 new tests for the MCP guard and the `[object Object]` regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP extension integration: now logs informative messages when the extension or its API is unavailable, preserves original errors when reporting failures, and conditionally waits for the extension to signal readiness before registering integrations.

* **Tests**
  * Added tests covering missing extension, disabled/absent API, readiness vs. immediate registration, and error propagation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->