### PR TITLE
fix: guard `bigqueryCostEstimate` against undefined args (command-palette crash)

### DIFF
--- a/src/commands/bigQueryCostEstimate.ts
+++ b/src/commands/bigQueryCostEstimate.ts
@@ -15,7 +15,7 @@ export class BigQueryCostEstimate {
     private telemetry: TelemetryService,
   ) {}
 
-  async estimateCost({ returnResult }: { returnResult?: boolean }) {
+  async estimateCost({ returnResult }: { returnResult?: boolean } = {}) {
     const modelName = path.basename(
       window.activeTextEditor!.document.fileName,
       ".sql",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -291,7 +291,7 @@ export class VSCodeCommands implements Disposable {
       ),
       commands.registerCommand(
         "dbtPowerUser.bigqueryCostEstimate",
-        ({ returnResult }: { returnResult?: boolean }) =>
+        ({ returnResult }: { returnResult?: boolean } = {}) =>
           this.bigQueryCostEstimate.estimateCost({ returnResult }),
       ),
       commands.registerTextEditorCommand(

--- a/src/test/suite/bigQueryCostEstimate.test.ts
+++ b/src/test/suite/bigQueryCostEstimate.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { DBTTerminal } from "@altimateai/dbt-integration";
+import { BigQueryCostEstimate } from "../../commands/bigQueryCostEstimate";
+import { DBTProjectContainer } from "../../dbt_client/dbtProjectContainer";
+import { TelemetryService } from "../../telemetry";
+
+/**
+ * Telemetry on 0.60.7 surfaced an `unhandlederror`:
+ *
+ *   Cannot destructure property 'returnResult' of 'undefined' as it is undefined.
+ *
+ * Root cause: `BigQueryCostEstimate.estimateCost` destructures its argument
+ * without a default. When the command is invoked from the command palette
+ * (`dbtPowerUser.bigQueryCostEstimate`), VS Code passes `undefined` instead
+ * of `{ returnResult: true }` (which only the insights panel call site provides),
+ * crashing on the destructure before any method body runs.
+ */
+describe("BigQueryCostEstimate.estimateCost arg destructure", () => {
+  // Mirrors the pre-fix signature exactly:
+  //   async estimateCost({ returnResult }: { returnResult?: boolean })
+  function preFixDestructure(arg: { returnResult?: boolean }) {
+    const { returnResult } = arg;
+    return returnResult;
+  }
+
+  // Mirrors the post-fix signature:
+  //   async estimateCost({ returnResult }: { returnResult?: boolean } = {})
+  function postFixDestructure(arg: { returnResult?: boolean } = {}) {
+    const { returnResult } = arg;
+    return returnResult;
+  }
+
+  describe("pre-fix characterization (regression guard)", () => {
+    it("crashes when invoked with undefined (command palette path)", () => {
+      expect(() => preFixDestructure(undefined as never)).toThrow(
+        /Cannot destructure/,
+      );
+    });
+
+    it("works when invoked with explicit args (insights panel path)", () => {
+      expect(preFixDestructure({ returnResult: true })).toBe(true);
+    });
+  });
+
+  describe("post-fix behaviour", () => {
+    it("does not crash when invoked with undefined", () => {
+      expect(() => postFixDestructure(undefined)).not.toThrow();
+      expect(postFixDestructure(undefined)).toBeUndefined();
+    });
+
+    it("does not crash when invoked with no argument at all", () => {
+      expect(() => (postFixDestructure as () => unknown)()).not.toThrow();
+    });
+
+    it("preserves the explicit-arg path", () => {
+      expect(postFixDestructure({ returnResult: true })).toBe(true);
+      expect(postFixDestructure({ returnResult: false })).toBe(false);
+    });
+  });
+
+  /**
+   * Hits the actual production class so the test result depends on whether
+   * the source-level fix has been applied. The destructure runs before any
+   * other code in the method, so this test cleanly isolates the bug from
+   * downstream behaviour: pre-fix master throws `TypeError: Cannot
+   * destructure property 'returnResult' of 'undefined'` synchronously;
+   * post-fix the call passes the destructure and only fails further
+   * downstream on the `window.activeTextEditor` access — proving the
+   * specific telemetry-reported crash is gone.
+   */
+  describe("production class (master vs fix branch)", () => {
+    const buildEstimator = () => {
+      const terminal = {
+        show: jest.fn(),
+        log: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      } as unknown as DBTTerminal;
+      const container = {
+        findDBTProject: jest.fn(),
+      } as unknown as DBTProjectContainer;
+      const telemetry = {
+        sendTelemetryError: jest.fn(),
+        sendTelemetryEvent: jest.fn(),
+      } as unknown as TelemetryService;
+      return new BigQueryCostEstimate(container, terminal, telemetry);
+    };
+
+    it("no longer throws the destructure TypeError when invoked with no args", async () => {
+      const estimator = buildEstimator();
+      let caught: unknown;
+      try {
+        await (estimator.estimateCost as () => Promise<unknown>)();
+      } catch (e) {
+        caught = e;
+      }
+      // Whatever happens further down the method body, the specific
+      // unhandlederror reported in 0.60.7 telemetry must not reappear.
+      expect(String(caught ?? "")).not.toMatch(
+        /Cannot destructure property 'returnResult'/,
+      );
+    });
+  });
+
+  /**
+   * The command-palette path goes through the registerCommand wrapper in
+   * `commands/index.ts:294`, which ALSO destructures `{ returnResult }`
+   * from its argument. VS Code invokes the handler with `undefined` when
+   * the command is run without args, so the wrapper crashes before
+   * `estimateCost` is ever called. Both call-sites must default to `{}`
+   * for the fix to actually reach the user.
+   */
+  describe("registerCommand wrapper destructure (commands/index.ts:294)", () => {
+    function preFixWrapper({
+      returnResult,
+    }: {
+      returnResult?: boolean;
+    }): boolean | undefined {
+      return returnResult;
+    }
+
+    function postFixWrapper(
+      { returnResult }: { returnResult?: boolean } = {},
+    ): boolean | undefined {
+      return returnResult;
+    }
+
+    it("pre-fix wrapper crashes when VS Code passes undefined", () => {
+      expect(() => preFixWrapper(undefined as never)).toThrow(
+        /Cannot destructure/,
+      );
+    });
+
+    it("post-fix wrapper survives VS Code passing undefined", () => {
+      expect(() => postFixWrapper(undefined)).not.toThrow();
+      expect(postFixWrapper(undefined)).toBeUndefined();
+    });
+
+    it("post-fix wrapper preserves explicit-arg behaviour", () => {
+      expect(postFixWrapper({ returnResult: true })).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Telemetry on 0.60.7 surfaced an `unhandlederror`:

```
Cannot destructure property 'returnResult' of 'undefined' as it is undefined.
```

2 events / 1 machine in 24h. Small numerically, but a real null-guard miss with an unambiguous repro: invoke the `dbtPowerUser.bigqueryCostEstimate` command from the command palette (no args).

## Root cause

Two consecutive destructures with no default:

```ts
// src/commands/index.ts:294
commands.registerCommand(
  "dbtPowerUser.bigqueryCostEstimate",
  ({ returnResult }: { returnResult?: boolean }) =>     // ← throws first
    this.bigQueryCostEstimate.estimateCost({ returnResult }),
),

// src/commands/bigQueryCostEstimate.ts:18
async estimateCost({ returnResult }: { returnResult?: boolean }) { ... }   // ← would also throw
```

The insights-panel call site (`webview_provider/insightsPanel.ts:659`) always passes `{ returnResult: true }`, so the path was exercised cleanly in dev. The command-palette path passes `undefined` to the registered handler — the wrapper at line 294 destructures synchronously and throws before `estimateCost` is ever reached. Even if the wrapper were guarded, the method itself would throw the same way for any future caller passing `undefined`.

## Fix

Default both call sites to `{}`:

```diff
- ({ returnResult }: { returnResult?: boolean }) =>
+ ({ returnResult }: { returnResult?: boolean } = {}) =>
```

```diff
- async estimateCost({ returnResult }: { returnResult?: boolean }) {
+ async estimateCost({ returnResult }: { returnResult?: boolean } = {}) {
```

## Pre/post evidence

New `src/test/suite/bigQueryCostEstimate.test.ts` covers the destructure pattern (characterization + post-fix), the registerCommand wrapper, and a runtime test against the production class that asserts the exact telemetry-reported message no longer reaches the user.

**Pre-fix on `origin/master` HEAD (4d067e04, fix not applied):**

```
FAIL src/test/suite/bigQueryCostEstimate.test.ts
  BigQueryCostEstimate.estimateCost arg destructure
    pre-fix characterization (regression guard)
      ✓ crashes when invoked with undefined (command palette path) (3 ms)
      ✓ works when invoked with explicit args (insights panel path)
    post-fix behaviour
      ✓ does not crash when invoked with undefined (1 ms)
      ✓ does not crash when invoked with no argument at all
      ✓ preserves the explicit-arg path
    production class (master vs fix branch)
      ✕ no longer throws the destructure TypeError when invoked with no args (2 ms)
    registerCommand wrapper destructure (commands/index.ts:294)
      ✓ pre-fix wrapper crashes when VS Code passes undefined
      ✓ post-fix wrapper survives VS Code passing undefined (1 ms)
      ✓ post-fix wrapper preserves explicit-arg behaviour

  ● BigQueryCostEstimate.estimateCost arg destructure › production class (master vs fix branch) › no longer throws the destructure TypeError when invoked with no args

    expect(received).not.toMatch(expected)

    Expected pattern: not /Cannot destructure property 'returnResult'/
    Received string:      "TypeError: Cannot destructure property 'returnResult' of 'undefined' as it is undefined."

       97 |       // Whatever happens further down the method body, the specific
       98 |       // unhandlederror reported in 0.60.7 telemetry must not reappear.
    >  99 |       expect(String(caught ?? "")).not.toMatch(
          |                                        ^
      100 |         /Cannot destructure property 'returnResult'/,
      101 |       );
      102 |     });

      at Object.<anonymous> (src/test/suite/bigQueryCostEstimate.test.ts:99:40)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 8 passed, 9 total
Snapshots:   0 total
Time:        4.2 s
Ran all test suites matching /src\/test\/suite\/bigQueryCostEstimate.test.ts/i.
```

**Post-fix on this branch:**

```
PASS src/test/suite/bigQueryCostEstimate.test.ts
  BigQueryCostEstimate.estimateCost arg destructure
    pre-fix characterization (regression guard)
      ✓ crashes when invoked with undefined (command palette path) (3 ms)
      ✓ works when invoked with explicit args (insights panel path) (1 ms)
    post-fix behaviour
      ✓ does not crash when invoked with undefined
      ✓ does not crash when invoked with no argument at all
      ✓ preserves the explicit-arg path
    production class (master vs fix branch)
      ✓ no longer throws the destructure TypeError when invoked with no args
    registerCommand wrapper destructure (commands/index.ts:294)
      ✓ pre-fix wrapper crashes when VS Code passes undefined
      ✓ post-fix wrapper survives VS Code passing undefined (1 ms)
      ✓ post-fix wrapper preserves explicit-arg behaviour

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        2.766 s, estimated 5 s
Ran all test suites matching /src\/test\/suite\/bigQueryCostEstimate.test.ts/i.
```

Full jest suite: 465 pass, 1 pre-existing skipped (28 suites total).

## Secondary code paths considered

- `webview_provider/insightsPanel.ts:659` — the only other caller. Always passes `{ returnResult: true }`. No behaviour change.
- `commands/index.ts` registers ~80 commands; this PR only modifies the one wrapper that's known to crash. Other handlers either take no args, accept their args directly without destructuring (e.g., `(item: RunTreeItem) => ...`), or already use `undefined` checks before destructure (e.g., `profileCtes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the BigQuery cost estimate feature that prevented it from functioning correctly when invoked without explicitly providing all required parameters. The feature now gracefully handles optional parameters.

* **Tests**
  * Added extensive test coverage for the cost estimate functionality to verify that parameter handling behavior works correctly in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->