### PR TITLE
fix: guard against undefined extension.exports in MCP server init

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -52,6 +52,14 @@ export class DbtPowerUserMcpServer implements Disposable {
       if (!extension.isActive) {
         await extension.activate();
       }
+      if (!extension.exports) {
+        this.dbtTerminal.error(
+          "DbtPowerUserMcpServer:updateMcpExtensionApiError",
+          "MCP extension exports not available",
+          { message: "Extension activated but exports are undefined" },
+        );
+        return;
+      }
       await extension.exports.ready;
       this.mcpExtensionApi = extension.exports as ToolRegistry;
 

--- a/src/test/suite/mcpServer.test.ts
+++ b/src/test/suite/mcpServer.test.ts
@@ -1,0 +1,160 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { extensions } from "../mock/vscode";
+
+const mockDbtTerminal = {
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+
+const mockMcpServerTools = {
+  getMcpTools: jest.fn().mockReturnValue([]),
+  dispose: jest.fn(),
+};
+
+const mockAltimate = {};
+
+const mockEventEmitter = {
+  eventEmitter: {
+    event: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+  },
+};
+
+const mockAltimateAuthService = {
+  handlePreviewFeatures: jest.fn().mockReturnValue(true),
+};
+
+describe("DbtPowerUserMcpServer", () => {
+  let DbtPowerUserMcpServer: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const mod = await import("../../mcp/index");
+    DbtPowerUserMcpServer = mod.DbtPowerUserMcpServer;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const createServer = () => {
+    return new DbtPowerUserMcpServer(
+      mockMcpServerTools as any,
+      mockDbtTerminal as any,
+      mockAltimate as any,
+      mockEventEmitter as any,
+      mockAltimateAuthService as any,
+    );
+  };
+
+  describe("updateMcpExtensionApi", () => {
+    it("should handle missing MCP extension gracefully", async () => {
+      (extensions.getExtension as jest.Mock).mockReturnValue(undefined);
+
+      const server = createServer();
+      await server.updateMcpExtensionApi();
+
+      expect(mockDbtTerminal.error).toHaveBeenCalledWith(
+        "DbtPowerUserMcpServer: enableMcpExtensionIntegration",
+        "Failed to install MCP extension",
+        expect.objectContaining({
+          message: "Failed to install Altimate MCP Server extension",
+        }),
+      );
+    });
+
+    it("should handle extension with undefined exports without crashing", async () => {
+      const mockExtension = {
+        isActive: true,
+        activate: jest.fn(),
+        exports: undefined,
+      };
+      (extensions.getExtension as jest.Mock).mockReturnValue(mockExtension);
+
+      const server = createServer();
+      await server.updateMcpExtensionApi();
+
+      expect(mockDbtTerminal.error).toHaveBeenCalledWith(
+        "DbtPowerUserMcpServer:updateMcpExtensionApiError",
+        "MCP extension exports not available",
+        expect.objectContaining({
+          message: "Extension activated but exports are undefined",
+        }),
+      );
+    });
+
+    it("should activate inactive extension before accessing exports", async () => {
+      const activateFn = jest.fn().mockResolvedValue(undefined as never);
+      const mockExtension = {
+        isActive: false,
+        activate: activateFn,
+        exports: undefined,
+      };
+      (extensions.getExtension as jest.Mock).mockReturnValue(mockExtension);
+
+      const server = createServer();
+      await server.updateMcpExtensionApi();
+
+      expect(activateFn).toHaveBeenCalled();
+      expect(mockDbtTerminal.error).toHaveBeenCalledWith(
+        "DbtPowerUserMcpServer:updateMcpExtensionApiError",
+        "MCP extension exports not available",
+        expect.any(Object),
+      );
+    });
+
+    it("should await exports.ready and register API when exports are valid", async () => {
+      const mockAddMcpIntegrationConfig = jest
+        .fn()
+        .mockResolvedValue(undefined as never);
+      const mockExtension = {
+        isActive: true,
+        activate: jest.fn(),
+        exports: {
+          ready: Promise.resolve(),
+          registerTools: jest.fn(),
+          addMcpIntegrationConfig: mockAddMcpIntegrationConfig,
+        },
+      };
+      (extensions.getExtension as jest.Mock).mockReturnValue(mockExtension);
+
+      const server = createServer();
+      await server.updateMcpExtensionApi();
+
+      expect(mockAddMcpIntegrationConfig).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            title: "Advanced Data Tools",
+          }),
+        ]),
+      );
+    });
+
+    it("should handle exports.ready rejection gracefully", async () => {
+      const mockExtension = {
+        isActive: true,
+        activate: jest.fn(),
+        exports: {
+          ready: Promise.reject(new Error("Extension init failed")),
+        },
+      };
+      (extensions.getExtension as jest.Mock).mockReturnValue(mockExtension);
+
+      const server = createServer();
+      await server.updateMcpExtensionApi();
+
+      expect(mockDbtTerminal.error).toHaveBeenCalledWith(
+        "DbtPowerUserMcpServer:updateMcpExtensionApiError",
+        "Error updating MCP extension API",
+        expect.objectContaining({ message: "Extension init failed" }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Evidence Matrix

| Source | Checked | Data Extracted |
|--------|---------|----------------|
| App Insights Telemetry | ✅ | 2270 events in 24h, event: `DbtPowerUserMcpServer:updateMcpExtensionApiError`, message: "Cannot read properties of undefined (reading 'ready')" |
| Sentry | ❌ | N/A — extension telemetry via Azure App Insights |
| Code Search | ✅ | `src/mcp/index.ts:55` — `extension.exports.ready` accessed without null check |
| Existing Tests | ✅ | No existing tests for `DbtPowerUserMcpServer.updateMcpExtensionApi()` — created new test suite |

## Discovery

Azure Application Insights telemetry shows **2270 occurrences** of `Cannot read properties of undefined (reading 'ready')` in the last 24 hours across versions 0.51.2–0.60.7 and all modes (core, cloud, fusion). Top event: `DbtPowerUserMcpServer:updateMcpExtensionApiError`.

## Root Cause Analysis

In `src/mcp/index.ts`, the `updateMcpExtensionApi()` method:
1. Gets the `altimateai.vscode-altimate-mcp-server` extension via `extensions.getExtension()`
2. Checks if the extension exists ✅
3. Activates it if not active ✅
4. **Accesses `extension.exports.ready` without checking if `exports` is defined** ❌

VS Code's `Extension.exports` is typed as `T | undefined`. When the MCP extension is present but hasn't fully initialized its exports (e.g., during a race condition at activation), `exports` is `undefined`, and accessing `.ready` throws the TypeError.

The error is caught by the surrounding try/catch, so it doesn't crash the extension — but it generates 2270 telemetry noise events per day and prevents MCP tool registration.

## Why This Fix Resolves It

Added an explicit `!extension.exports` guard (line 55–62) that:
- Returns early if exports are undefined, matching the existing pattern for `!extension` at line 43
- Logs the condition via `dbtTerminal.error` for debuggability
- Is non-breaking: `mcpExtensionApi` stays `undefined`, which is already handled by the null check in `registerToolsInMcpExtension()` at line 87

## Self-Critique

1. **Root cause confidence:** HIGH — the stack trace message exactly matches accessing `.ready` on undefined, and `extension.exports` is the only object before `.ready` that can be undefined
2. **What could be wrong:** The underlying cause of `exports` being undefined (MCP extension activation timing) is not fixed — this is a defensive guard. If the MCP extension consistently fails to export, tools won't register.
3. **Edge cases considered:** Extension missing, exports undefined, exports.ready rejecting, normal happy path
4. **Test coverage:** 5 new regression tests covering all branches of `updateMcpExtensionApi()`

## Impact

- **Affects:** 2270 events/day across all modes and multiple versions
- **User impact:** MCP tools fail to register silently; extension still activates normally
- **Risk:** Low — defensive null guard, no behavior change when exports are defined
- **Files changed:** 1 source file (8 lines added), 1 test file (160 lines)

---
Generated by QA Autopilot | Extension Telemetry