### PR TITLE
ci: add silent-close shim to altimate-qa watchdog (migration item 12)

### DIFF
--- a/.github/workflows/silent-close-shim.yml
+++ b/.github/workflows/silent-close-shim.yml
@@ -1,0 +1,67 @@
+name: Silent-Close Shim → altimate-qa watchdog
+
+# Cross-repo notification shim for the silent-close watchdog living in
+# AltimateAI/altimate-qa. Fires a `repository_dispatch` to altimate-qa
+# the moment a PR closes here, so the watchdog can react in seconds
+# instead of waiting for its 5-minute cron tick.
+#
+# This file is THE canonical version. To onboard a new repo, copy this
+# file verbatim to `.github/workflows/silent-close-shim.yml` in the new
+# repo and add the `AUTOPILOT_DISPATCH_TOKEN` secret to that repo's
+# Actions settings (must be a PAT or App token with `repo` scope on
+# AltimateAI/altimate-qa so the dispatch endpoint accepts the call).
+#
+# Reference: docs/specs/2026-05-01-closed-by-attribution-standard.md
+# Reference incident: 2026-04-29 12:24 UTC silent bulk-close (47 PRs).
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: silent-close-shim-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Notify altimate-qa watchdog
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Send repository_dispatch
+        env:
+          GH_TOKEN: ${{ secrets.AUTOPILOT_DISPATCH_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          CLOSED_BY: ${{ github.event.sender.login }}
+          WAS_MERGED: ${{ github.event.pull_request.merged }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::AUTOPILOT_DISPATCH_TOKEN not set — shim disabled for ${REPO}#${PR_NUM}"
+            exit 0
+          fi
+
+          payload=$(jq -n \
+            --arg repo "$REPO" \
+            --argjson pr_number "$PR_NUM" \
+            --arg closed_by "$CLOSED_BY" \
+            --argjson was_merged "${WAS_MERGED:-false}" \
+            --arg title "$PR_TITLE" \
+            '{event_type: "pr-closed",
+              client_payload: {
+                repo: $repo,
+                pr_number: $pr_number,
+                closed_by: $closed_by,
+                was_merged: $was_merged,
+                title: $title
+              }}')
+
+          echo "$payload" | gh api repos/AltimateAI/altimate-qa/dispatches \
+            --input - \
+            && echo "Dispatched: ${REPO}#${PR_NUM} closed_by=${CLOSED_BY} merged=${WAS_MERGED:-false}" \
+            || echo "::warning::Dispatch failed for ${REPO}#${PR_NUM}"


### PR DESCRIPTION
## Summary

Cross-repo notification shim that fires `repository_dispatch` to AltimateAI/altimate-qa whenever a PR closes here, so the silent-close watchdog can react in seconds instead of waiting up to 5 minutes for its cron tick.

## What this does

- Triggers on `pull_request: closed` events.
- Sends `event_type=pr-closed` with `{repo, pr_number, closed_by, was_merged, title}` payload to AltimateAI/altimate-qa.
- Self-disables (warning, exit 0) if `AUTOPILOT_DISPATCH_TOKEN` secret is not set on this repo. Never fails the PR.

## Why

Reference incident: 2026-04-29 12:24 UTC silent bulk-close (47 PRs in 90s, 6 fix PRs lost). The watchdog already exists in altimate-qa but ran on a 5-min cron — up to 5 minutes of fix-PR loss before the reopener fired. This shim closes that gap to ~20s end-to-end.

The receiving end is **altimate-qa PR #366** which adds the `repository_dispatch` trigger to `silent-close-watchdog.yml` and a `--single-pr` fast path to the reopener script. That PR should land before this one is wired up (until it does, the dispatch is a no-op on the receiving end).

## Setup needed (after merge)

Add `AUTOPILOT_DISPATCH_TOKEN` secret to this repo's Actions settings:

`github.com/AltimateAI/<this-repo>/settings/secrets/actions`

Token must have `repo` scope on `AltimateAI/altimate-qa` so the dispatch endpoint accepts it. PAT or App token both work.

## Test plan

- [ ] Merge altimate-qa #366 first (receiving end)
- [ ] Add `AUTOPILOT_DISPATCH_TOKEN` secret here
- [ ] Force-close a test PR in this repo, observe a dispatch run on altimate-qa within ~20s
- [ ] Confirm the cron sweep on altimate-qa still runs (5-min schedule unchanged) so any partial rollout doesn't break detection

## Reference

- Spec: `templates/cross-repo-shims/README.md` in altimate-qa
- altimate-qa receiving PR: AltimateAI/altimate-qa#366
- Migration item: 12 of the autopilot self-health epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure improvements to enhance internal QA workflow automation and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->