### PR TITLE
fix: re-trigger lineage render on webview:ready to close postMessage race

### DIFF
--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -92,6 +92,11 @@ export class NewLineagePanel
     this.renderStartingNode();
   }
 
+  protected onWebviewReady() {
+    super.onWebviewReady();
+    this.renderStartingNode();
+  }
+
   changedActiveColorTheme() {
     if (!this._panel) {
       return;


### PR DESCRIPTION
## Summary

Customer report: *"Lately, the lineage tab just brings up a blank panel (i.e. no lineage). If I restart the IDE, it will show up. But, once I select another model, I run into the same issue."*

Telemetry confirms the bug. In the last 7 days on `0.60.7`:

- `Lineage:getStartingNode` *"No event found"* — **811 events across 84 distinct machines**
- Top affected machine: 93 occurrences in a 35-minute single session, all of them this one event, *zero* other extension telemetry on that machine in 30 days.
- 81 of the 84 affected machines have **no other errors** — extension activates fine, the lineage panel is silently broken for them.

## Root cause

When the lineage webview is first created, `newLineagePanel.init()` posts a `render` to the webview before React's `window.addEventListener("message", …)` (registered inside `LineageView.tsx`'s `useEffect`) has run. VS Code's webview API queues postMessages until the iframe's HTML is ready, **not** until React's effects have run, so this initial render can be silently dropped.

When the render is dropped, `renderNode` stays at the initial `{ aiEnabled: true }` (no `node`), so `<Lineage dynamicLineage={renderNode}>` mounts with no starting node and the graph area appears blank — matching the customer's literal symptom.

The webview already attempts recovery via `executeRequestInAsync("init", {})` once its listener registers, and PR #1857 added an `eventMapChanged → renderStartingNode` path. Both close *some* races, but neither covers the case where:
- the webview's `init` recovery is delayed enough that the user perceives the panel as broken before the ack arrives, or
- the manifest is already cached on panel creation, so `eventMapChanged` doesn't re-fire.

## Fix

Override `onWebviewReady` on `NewLineagePanel` to re-run `renderStartingNode()` when the framework-level `webview:ready` ack arrives. By that point both `useListeners` (AppProvider) and `LineageView`'s own message listener have registered, so the second render lands.

The existing webview-driven `init` recovery and the manifest-change re-render remain in place as additional belts.

5 lines, no behavior change for users on the happy path.

## Verification

Reproduced the literal blank panel deterministically by widening the `LineageView` listener registration race window with a `setTimeout(1500)` and disabling the existing `executeRequestInAsync("init", {})` recovery — pure isolation test for this fix's path.

Before fix, recovery disabled, race wide
<img width="1598" height="305" alt="image" src="https://github.com/user-attachments/assets/acacacf1-50e5-4380-ad1a-c5f1b2bb8a46" />

After fix:
<img width="1601" height="328" alt="image" src="https://github.com/user-attachments/assets/97363e48-b2f4-45f0-abd4-8fd7f229cfeb" />

Customer's "blank on second model" pattern (open, switch model, blank again) also rebuilds correctly post-fix on `customers.sql ↔ orders.sql ↔ stg_customers.sql`.

## Test plan

- [ ] Open lineage panel on a fresh model file → graph renders
- [ ] Reload IDE → open lineage panel → graph renders (no blank state)
- [ ] Switch to a different model → graph rebuilds for new focal node
- [ ] Switch to a non-dbt file → "missing lineage" warning shown
- [ ] Multi-root workspace → lineage renders for files in dbt project root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the lineage panel initialization to ensure content displays correctly when the panel loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->