### PR TITLE
fix: reset lineage graph state when focal node changes

### DIFF
--- a/webview_panels/src/modules/lineage/LineageView.tsx
+++ b/webview_panels/src/modules/lineage/LineageView.tsx
@@ -132,6 +132,14 @@ const LineageView = (): JSX.Element | null => {
   }
 
   const lineageType = renderNode.details ? "sql" : "dynamic";
+  // Force the inner Lineage component to fully unmount/remount when the focal
+  // node changes (or disappears). Without this, the component carries
+  // stale graph state across renders — sibling nodes from the previous
+  // focal model linger, and the missing-lineage warning ends up overlaid
+  // on top of the prior graph instead of replacing it.
+  const lineageKey = !renderNode.node
+    ? "no-node"
+    : `${renderNode.node.id ?? renderNode.node.table}::${renderNode.node.nodeType}`;
 
   return (
     <TooltipProvider>
@@ -148,6 +156,7 @@ const LineageView = (): JSX.Element | null => {
         )}
         <div className={`${styles.lineageWrap} al-tw-scope`}>
           <Lineage
+            key={lineageKey}
             theme={theme}
             dynamicLineage={renderNode}
             lineageType={lineageType}


### PR DESCRIPTION
## Summary

Two reproducible rendering bugs in the Lineage panel that survive PR #1857 and aren't covered by PR #1931:

1. **Stale graph on model switch.** Going from `orders.sql` (which shows `stg_orders + stg_payments → orders`) to `stg_orders.sql` leaves `stg_payments` orphaned in the graph and the actual upstream `raw_orders` seed is never added. The new focal node is highlighted, but the surrounding topology is the previous model's graph.

2. **Warning overlaid on stale graph.** Switching from any rendered model to a non-dbt file (e.g. `dbt_project.yml`) draws the "missing lineage" warning text **on top of** the previous graph instead of clearing it.

Both reproduce on `origin/master @ e384e88c` against the bundled `jaffle-shop-duckdb`.

## Root cause

The inner `<Lineage>` component (from `@altimateai/ui-components/lineage`) holds graph state (nodes, edges, viewport) internally and does not fully reset it when its `dynamicLineage` prop changes. The extension correctly posts new render payloads with the right node, but the component carries over the previous graph's nodes and edges.

## Fix

Pass a `key` prop derived from the focal node's identity:

```tsx
const lineageKey = !renderNode.node
  ? "no-node"
  : `${renderNode.node.id ?? renderNode.node.table}::${renderNode.node.nodeType}`;
```

When the focal node changes (or disappears for non-dbt files), React unmounts and remounts the `Lineage` component, dropping any stale internal state. For non-dbt files (no `node`), all warning-text states share a single `"no-node"` mount so the graph area stays empty.

9 lines, contained to `LineageView.tsx`. No changes to the ui-components package itself.

## Verification

Pre-fix and post-fix screenshots in `screenshots/lineage-stale-graph/`:

| State | File |
|---|---|
| Bug A — pre-fix (stg_payments orphan, raw_orders missing) | `before-02-bug-a-stale-graph.png` |
| Bug A — **post-fix (raw_orders → stg_orders → customers + orders, no orphans)** | `after-03-bug-a-fixed.png` |
| Bug B — pre-fix (warning overlaid on stale graph) | `before-03-bug-b-warning-overlay.png` |
| Bug B — **post-fix (clean warning, no graph)** | `after-01-yaml-no-stale-graph.png` |
| Happy path — switch back to customers.sql rebuilds correctly | `after-04-customers-rebuilds.png` |

## Tradeoff

`key` change forces a full unmount/remount of the lineage graph each time the focal node changes. For switching between models this is the desired behavior (we *want* a fresh graph). The unmount cost is negligible compared to the render cost of the actual graph.

This does **not** affect re-renders within the same focal node (e.g. expanding/collapsing nodes, applying CLL) — those keep the same key and the component preserves state as before.

## Relationship to other PRs

- Independent of #1931 (the postMessage race fix). Both target master directly. They can be reviewed and merged in either order.
- Out of scope: the underlying state-management bug in `@altimateai/ui-components` that necessitates the workaround. A proper fix in that package would let us drop the `key` prop, but the package isn't owned in this repo.

## Test plan

- [ ] `customers.sql` → lineage renders correctly
- [ ] Switch to `orders.sql` → graph rebuilds for orders, no leftover customers nodes
- [ ] Switch to `stg_orders.sql` → shows `raw_orders → stg_orders → customers + orders`, no `stg_payments` orphan
- [ ] Switch to `dbt_project.yml` → clean warning text, empty graph area below
- [ ] Switch back to `customers.sql` → graph rebuilds for customers, no leftover stg_orders highlights
- [ ] Expand a node within the same model → graph updates without remount (smooth, no flicker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)