### PR TITLE
feat: default column-level lineage to local sqlEngine

### DIFF
--- a/src/services/dbtLineageService.ts
+++ b/src/services/dbtLineageService.ts
@@ -369,7 +369,7 @@ export class DbtLineageService {
     // --- altimate-core: try local column lineage first ---
     const cllEngine = workspace
       .getConfiguration("dbt")
-      .get<string>("lineage.cllEngine", "legacy");
+      .get<string>("lineage.cllEngine", "sqlEngine");
 
     this.dbtTerminal.debug(
       "dbtLineageService:getConnectedColumns",


### PR DESCRIPTION
## Summary
- Flip the default for the (currently undeclared) `dbt.lineage.cllEngine` setting from `legacy` to `sqlEngine` in `src/services/dbtLineageService.ts:372`, so out-of-the-box CLL runs through the local altimate-core engine first.
- Behavior preserved for users who set `dbt.lineage.cllEngine` explicitly — only the unset/default case changes.
- Existing fallback logic still kicks in when the native module is unavailable or `computeColumnLineage` throws, so `legacy` remains a transparent safety net (and emits the existing warn-level telemetry on fallback).

## Test plan
- [ ] Open a dbt project without setting `dbt.lineage.cllEngine`; confirm CLL requests now hit `computeColumnLineage` (debug log: `Column lineage engine: sqlEngine`).
- [ ] Set `dbt.lineage.cllEngine` to `legacy` in settings; confirm requests still go through the legacy SaaS API path.
- [ ] Force the native module to fail (e.g. on an unsupported platform) and confirm the fallback warn telemetry fires and CLL still resolves via the legacy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default configuration for column lineage computation to prioritize local processing over legacy API calls, with automatic fallback if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->