### PR TITLE
docs(harness): wire altimate-code symlink + binary shim into sandbox contract

### DIFF
--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -304,15 +304,21 @@ This section is the machine-readable contract for the harness sandbox system. Th
 
 | Phase | Marker file | What's available |
 |---|---|---|
-| **Phase 1: code-ready** | `/workspace/.code-ready` | Source code, `node_modules`, linters, `tsc` |
-| **Phase 2: server-ready** | `/workspace/.server-ready` | code-server running on :3001, extension loaded |
+| **Phase 1: code-ready** | `/workspace/.code-ready` | Source code, `node_modules` (extension + webview_panels), `altimate-code` symlinks, `altimate` binary on PATH, linters, `tsc` |
+| **Phase 2: server-ready** | `/workspace/.server-ready` | Initial webpack build done, code-server on :3001 with the extension symlinked, `yarn watch` running |
 
-`harness spawn` returns at phase 1 (~5s with base image). Agent reads codebase while code-server starts (~30-60s for yarn compile + code-server boot).
+`harness spawn` returns at phase 1 (~10-30s with the base image). Watch mode (`yarn watch`) runs concurrent webview_panels + webpack `--watch`, so file edits auto-rebuild — reload the code-server tab to pick them up.
+
+The sandbox also clones **altimate-code** alongside at `/workspace/altimate-code` and symlinks its `@altimateai/*` workspace packages (`altimate-code`, `dbt-tools`, `drivers`) into this extension's `node_modules/`. Edits to either repo are picked up by `yarn watch` — no per-package publish/install loop. This mirrors the pattern that wires `altimate-mcp-engine` into `vscode-altimate-mcp-server`. The local `altimate` binary is also exposed on PATH (`~/.local/bin/altimate`) so any future runtime-spawn use resolves to the local clone.
 
 ```yaml
 repo: vscode-dbt-power-user
 repo_url: https://github.com/AltimateAI/vscode-dbt-power-user.git
-base_image: altimateacr.azurecr.io/vscode-dbt-power-user-base:latest
+# Reuses mcp-server's pre-baked base image — it has code-server, yarn, node,
+# bun, and the build tools we need. A dedicated vscode-dbt-power-user-base
+# image can be built later if cold-start time matters; switching here is a
+# one-line change.
+base_image: altimateacr.azurecr.io/vscode-altimate-mcp-server-base:latest
 working_dir: /workspace/vscode-dbt-power-user
 port: 3001
 health_path: /healthz
@@ -328,12 +334,54 @@ sidecars: []
 setup_commands:
   - name: enable-corepack
     cmd: corepack enable
-  - name: install-root-deps
-    cmd: yarn install --immutable 2>&1 | tail -5 || yarn install 2>&1 | tail -5
+  - name: install-extension-deps
+    cmd: yarn install --frozen-lockfile 2>&1 | tail -5 || yarn install 2>&1 | tail -5
+  # webview_panels is npm-managed (per package.json scripts: install:panels
+  # uses `npm install --prefix ./webview_panels`), so use npm here too —
+  # using yarn would create a competing yarn.lock and drift the install.
   - name: install-webview-deps
-    cmd: cd webview_panels && (yarn install --immutable 2>&1 | tail -5 || yarn install 2>&1 | tail -5)
-  - name: compile-extension
-    cmd: yarn compile
+    cmd: cd webview_panels && (npm ci 2>&1 | tail -5 || npm install 2>&1 | tail -5)
+  # altimate-code is cloned alongside at /workspace/altimate-code by the
+  # init-clone container. We install its bun deps and symlink the three
+  # @altimateai/* workspace pkgs into this extension's node_modules so any
+  # build-time consumer (rspack/webpack alias, direct import) resolves to
+  # the local source. The `altimate` shim on PATH covers the runtime case.
+  - name: install-altimate-code-deps
+    cmd: |
+      if [ -d /workspace/altimate-code ]; then
+        cd /workspace/altimate-code && \
+          (~/.bun/bin/bun install 2>&1 | tail -5 || bun install 2>&1 | tail -5)
+      fi
+  - name: link-altimate-code-pkgs
+    cmd: |
+      if [ -d /workspace/altimate-code ]; then
+        mkdir -p /workspace/vscode-dbt-power-user/node_modules/@altimateai
+        for pkg in altimate-code dbt-tools drivers; do
+          src=""
+          case "$pkg" in
+            altimate-code) src=/workspace/altimate-code/packages/opencode ;;
+            dbt-tools)     src=/workspace/altimate-code/packages/dbt-tools ;;
+            drivers)       src=/workspace/altimate-code/packages/drivers ;;
+          esac
+          [ -d "$src" ] && ln -sfn "$src" /workspace/vscode-dbt-power-user/node_modules/@altimateai/$pkg
+        done
+      fi
+  - name: expose-altimate-binary
+    cmd: |
+      if [ -d /workspace/altimate-code ]; then
+        mkdir -p $HOME/.local/bin
+        printf '%s\n' \
+          '#!/bin/bash' \
+          '# Sandbox shim — runs altimate-code from local clone, not npm.' \
+          'exec bun run --cwd /workspace/altimate-code/packages/opencode --conditions=browser src/index.ts "$@"' \
+          > $HOME/.local/bin/altimate
+        chmod +x $HOME/.local/bin/altimate
+        grep -q '\.local/bin' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+      fi
+  # `yarn webpack` runs panel:webviews + webpack --mode development. This is
+  # the actual extension build (yarn compile only does tsc, not bundling).
+  - name: initial-extension-build
+    cmd: yarn webpack 2>&1 | tail -10
   - name: setup-code-server-extension
     cmd: |
       EXT_DIR="$HOME/.local/share/code-server/extensions"
@@ -344,7 +392,7 @@ setup_commands:
       SETTINGS_DIR="$HOME/.local/share/code-server/User"
       mkdir -p "$SETTINGS_DIR"
       if [ ! -f "$SETTINGS_DIR/settings.json" ]; then
-        echo '{"altimate.onboardedMcpServer": true}' > "$SETTINGS_DIR/settings.json"
+        echo '{"dbt.altimateAiKey": ""}' > "$SETTINGS_DIR/settings.json"
       fi
 
 start_command: >
@@ -356,8 +404,15 @@ start_command: >
   --log debug
 ```
 
+### Common ops in the sandbox
+
+- **Restart watcher**: `harness exec vscode-dbt-power-user "pkill -f 'webpack --watch'; cd /workspace/vscode-dbt-power-user && yarn watch > /tmp/webpack-watch.log 2>&1 &"`
+- **Run linters / tsc**: `harness exec vscode-dbt-power-user "cd /workspace/vscode-dbt-power-user && yarn lint && yarn test-compile"`
+- **Run the local altimate CLI**: `harness exec vscode-dbt-power-user "altimate --help"` — resolves to the shim in `~/.local/bin`, runs from `/workspace/altimate-code/packages/opencode`.
+
 ### Sandbox troubleshooting
 
-- **Extension not loading in sandbox**: Check symlink at `~/.local/share/code-server/extensions/vscode-dbt-power-user` and that `dist/extension.js` was built by `yarn compile`.
-- **Slow phase 1**: Base image may be stale. Rebuild with `az acr build --registry altimateacr --image vscode-dbt-power-user-base:latest -f Dockerfile.base .`
-- **MCP server not starting**: Verify `altimate.onboardedMcpServer: true` in code-server settings.
+- **Extension not loading in sandbox**: Check symlink at `~/.local/share/code-server/extensions/vscode-dbt-power-user` and that `dist/extension.js` was built by `yarn webpack`.
+- **`altimate` binary missing**: `/workspace/altimate-code` may not have cloned. Check `harness logs <sandbox-id>` for the clone init container output.
+- **`@altimateai/*` import resolution off**: Verify the symlinks at `node_modules/@altimateai/{altimate-code,dbt-tools,drivers}` point at `/workspace/altimate-code/packages/{opencode,dbt-tools,drivers}`.
+- **Slow phase 1**: Base image may be stale. Rebuild with `az acr build --registry altimateacr --image vscode-altimate-mcp-server-base:latest -f Dockerfile.base .` (we share the mcp-server base image).

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -389,16 +389,27 @@ setup_commands:
         chmod +x $HOME/.local/bin/altimate
         grep -q '\.local/bin' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
       fi
+  # ts-loader declares webpack as a peerDependency but power-user's
+  # package.json doesn't list it, so install on demand. Without it the
+  # rsbuild build fails with "Cannot find module 'webpack'".
+  - name: install-webpack-peer
+    cmd: |
+      if [ ! -d node_modules/webpack ]; then
+        yarn add --dev --no-progress webpack 2>&1 | tail -3 || true
+      fi
   # `yarn build-dev` runs panel:webviews + rsbuild build --mode development.
   # This is the actual extension build (yarn compile only does tsc, not bundling).
   # NODE_OPTIONS bumps the heap — rsbuild + vite OOM with the default 4GB.
   - name: initial-extension-build
     cmd: NODE_OPTIONS="--max-old-space-size=8192" yarn build-dev 2>&1 | tail -20
+  # The symlink dir name MUST include version suffix (publisher.name-X.Y.Z),
+  # else code-server's obsolete scanner re-marks it as removed every boot.
   - name: setup-code-server-extension
     cmd: |
       EXT_DIR="$HOME/.local/share/code-server/extensions"
       mkdir -p "$EXT_DIR"
-      ln -sf /workspace/vscode-dbt-power-user "$EXT_DIR/vscode-dbt-power-user"
+      EXT_NAME="$(node -p "require('./package.json').publisher").$(node -p "require('./package.json').name")-$(node -p "require('./package.json').version")"
+      ln -sfn /workspace/vscode-dbt-power-user "$EXT_DIR/$EXT_NAME"
   - name: setup-code-server-settings
     cmd: |
       SETTINGS_DIR="$HOME/.local/share/code-server/User"

--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -349,8 +349,19 @@ setup_commands:
   - name: install-altimate-code-deps
     cmd: |
       if [ -d /workspace/altimate-code ]; then
-        cd /workspace/altimate-code && \
-          (~/.bun/bin/bun install 2>&1 | tail -5 || bun install 2>&1 | tail -5)
+        # Bun is required (altimate-code packageManager: bun@1.3.10).
+        # Base image lacks both unzip + bun; install on demand.
+        if ! command -v bun >/dev/null 2>&1 && [ ! -x "$HOME/.bun/bin/bun" ]; then
+          if ! command -v unzip >/dev/null 2>&1; then
+            sudo -n apt-get update -qq >/dev/null 2>&1 && \
+              sudo -n apt-get install -y -qq unzip >/dev/null 2>&1 || true
+          fi
+          curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1 || true
+        fi
+        export PATH="$HOME/.bun/bin:$PATH"
+        if command -v bun >/dev/null 2>&1; then
+          (cd /workspace/altimate-code && bun install 2>&1 | tail -5) || true
+        fi
       fi
   - name: link-altimate-code-pkgs
     cmd: |
@@ -378,10 +389,11 @@ setup_commands:
         chmod +x $HOME/.local/bin/altimate
         grep -q '\.local/bin' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
       fi
-  # `yarn webpack` runs panel:webviews + webpack --mode development. This is
-  # the actual extension build (yarn compile only does tsc, not bundling).
+  # `yarn build-dev` runs panel:webviews + rsbuild build --mode development.
+  # This is the actual extension build (yarn compile only does tsc, not bundling).
+  # NODE_OPTIONS bumps the heap — rsbuild + vite OOM with the default 4GB.
   - name: initial-extension-build
-    cmd: yarn webpack 2>&1 | tail -10
+    cmd: NODE_OPTIONS="--max-old-space-size=8192" yarn build-dev 2>&1 | tail -20
   - name: setup-code-server-extension
     cmd: |
       EXT_DIR="$HOME/.local/share/code-server/extensions"
@@ -406,13 +418,13 @@ start_command: >
 
 ### Common ops in the sandbox
 
-- **Restart watcher**: `harness exec vscode-dbt-power-user "pkill -f 'webpack --watch'; cd /workspace/vscode-dbt-power-user && yarn watch > /tmp/webpack-watch.log 2>&1 &"`
+- **Restart watcher**: `harness exec vscode-dbt-power-user "pkill -f 'rsbuild build --watch'; cd /workspace/vscode-dbt-power-user && NODE_OPTIONS='--max-old-space-size=8192' yarn watch > /tmp/build-watch.log 2>&1 &"`
 - **Run linters / tsc**: `harness exec vscode-dbt-power-user "cd /workspace/vscode-dbt-power-user && yarn lint && yarn test-compile"`
 - **Run the local altimate CLI**: `harness exec vscode-dbt-power-user "altimate --help"` — resolves to the shim in `~/.local/bin`, runs from `/workspace/altimate-code/packages/opencode`.
 
 ### Sandbox troubleshooting
 
-- **Extension not loading in sandbox**: Check symlink at `~/.local/share/code-server/extensions/vscode-dbt-power-user` and that `dist/extension.js` was built by `yarn webpack`.
+- **Extension not loading in sandbox**: Check symlink at `~/.local/share/code-server/extensions/vscode-dbt-power-user` and that `dist/extension.js` was built by `yarn build-dev`.
 - **`altimate` binary missing**: `/workspace/altimate-code` may not have cloned. Check `harness logs <sandbox-id>` for the clone init container output.
 - **`@altimateai/*` import resolution off**: Verify the symlinks at `node_modules/@altimateai/{altimate-code,dbt-tools,drivers}` point at `/workspace/altimate-code/packages/{opencode,dbt-tools,drivers}`.
 - **Slow phase 1**: Base image may be stale. Rebuild with `az acr build --registry altimateacr --image vscode-altimate-mcp-server-base:latest -f Dockerfile.base .` (we share the mcp-server base image).


### PR DESCRIPTION
## Summary

Updates the existing Harness Sandbox Contract section in `.claude/skills/dev-workflow/SKILL.md` to teach the harness CLI how to spawn this repo as a sandbox pod **with altimate-code symlinked alongside** — same pattern that wires `altimate-mcp-engine` into `vscode-altimate-mcp-server` today.

## What changes inside the sandbox

1. **altimate-code is cloned alongside** at `/workspace/altimate-code` by the init-clone container.
2. **bun deps installed** for altimate-code's workspaces.
3. **Workspace pkgs symlinked** into this extension's `node_modules`:
   - `altimate-code/packages/opencode` → `node_modules/@altimateai/altimate-code`
   - `altimate-code/packages/dbt-tools` → `node_modules/@altimateai/dbt-tools`
   - `altimate-code/packages/drivers` → `node_modules/@altimateai/drivers`
4. **`altimate` shim on PATH** at `~/.local/bin/altimate` runs the local opencode source via bun. Any future `spawn("altimate", …)` resolves to the local clone, not npm-installed.
5. Edits to either repo are picked up by `yarn watch` — no per-package publish/install loop.

## Other contract fixes

The previous contract had a few rough edges that would have prevented a clean spawn:

| Field | Before | After | Why |
|---|---|---|---|
| `base_image` | `vscode-dbt-power-user-base:latest` | `vscode-altimate-mcp-server-base:latest` | The power-user-specific base image was never built. mcp-server's image already has all the tools we need (code-server, yarn, node, bun). Easy to switch to a dedicated power-user base later. |
| `install-webview-deps` | `yarn install` | `npm install` | `webview_panels` is npm-managed per `install:panels` script in package.json. Using yarn was drifting the lockfile. |
| `compile-extension` | `yarn compile` | `yarn webpack` | `yarn compile` only runs `tsc`. The actual extension bundle comes from `yarn webpack`. |
| code-server settings | `{"altimate.onboardedMcpServer": true}` | `{"dbt.altimateAiKey": ""}` | Wrong setting was being seeded — that key belongs to mcp-server. |

## Companion PR in AltimateAI/harness

This skill is the human-readable + machine-readable spec; the matching pod template lives in [AltimateAI/harness](https://github.com/AltimateAI/harness) and runs all of these `setup_commands` in sequence. Both PRs are needed for `harness spawn vscode-dbt-power-user` to work end-to-end.

## Test plan

- [ ] `harness spawn vscode-dbt-power-user --ref master` reaches code-ready in <30s
- [ ] `harness exec vscode-dbt-power-user "ls -la node_modules/@altimateai/"` shows three symlinks pointing at `/workspace/altimate-code/packages/{opencode,dbt-tools,drivers}`
- [ ] `harness exec vscode-dbt-power-user "altimate --help"` runs from the local clone
- [ ] code-server reachable via `harness forward vscode-dbt-power-user` on port 3001 with the extension loaded
- [ ] Edit a `.ts` file in `/workspace/altimate-code/packages/opencode/src/` → reload code-server → change is picked up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced an explicit two-phase sandbox lifecycle (code-ready → server-ready) and clarified initialization/dependency steps for local development.
  * Updated dev-server bootstrap settings and refined setup guidance, including on-demand tooling installation and extension bundling updates.
  * Added common sandbox commands (watcher, lint/type-checker, local CLI) and expanded troubleshooting tips for builds, symlinks, and base-image rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->