### PR TITLE
fix: wire lineage Export button to SaaS via extension host

### DIFF
--- a/src/altimate.ts
+++ b/src/altimate.ts
@@ -458,6 +458,13 @@ export class AltimateRequest {
     });
   }
 
+  async exportLineage(req: { name: string; lineage_data: unknown }) {
+    return this.fetch<{ url: string }>("dbt/v4/export-lineage", {
+      method: "POST",
+      body: JSON.stringify(req),
+    });
+  }
+
   async runModeller(req: SQLToModelRequest) {
     return this.fetch<SQLToModelResponse>("dbt/v1/sqltomodel", {
       method: "POST",

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -246,6 +246,39 @@ export class NewLineagePanel
       return;
     }
 
+    if (command === "exportLineage") {
+      try {
+        const body = await this.altimate.exportLineage({
+          name: params.name,
+          lineage_data: params.lineage_data,
+        });
+        this._panel?.webview.postMessage({
+          command: "response",
+          args: { id, syncRequestId, body, status: true },
+        });
+      } catch (error) {
+        this._panel?.webview.postMessage({
+          command: "response",
+          args: {
+            id,
+            syncRequestId,
+            error: (error as Error).message,
+            status: false,
+          },
+        });
+        window.showErrorMessage(
+          extendErrorWithSupportLinks(
+            "Could not export lineage: " + (error as Error).message,
+          ),
+        );
+        this.telemetry.sendTelemetryError(
+          "altimateLineageExportLineageError",
+          error,
+        );
+      }
+      return;
+    }
+
     if (command === "columnLineage") {
       this.handleColumnLineage(args, () => {
         this._panel?.webview.postMessage({

--- a/webview_panels/src/modules/lineage/LineageView.tsx
+++ b/webview_panels/src/modules/lineage/LineageView.tsx
@@ -67,6 +67,17 @@ const LineageView = (): JSX.Element | null => {
           break;
       }
     };
+    // @ts-expect-error TODO: add type generic for executeRequestInSync
+    ApiHelper.post = async (url: string, data?: Record<string, unknown>) => {
+      switch (url) {
+        case "dbt/v4/export-lineage":
+          return executeRequestInSync("exportLineage", {
+            args: { params: data ?? {} },
+          });
+        default:
+          break;
+      }
+    };
     setIsApiHelperInitialized(true);
   }, [isComponentsApiInitialized]);
 


### PR DESCRIPTION
## Summary

The Export button on the lineage toolbar (top-right, next to Settings/Help) opened a popover but the inner submit silently failed — clicking Export did nothing visible, the popover closed, no notification, no network request.

**Root cause:** the inner submit calls `ApiHelper.post("dbt/v4/export-lineage", ...)` (in `@altimateai/ui-components`), but `LineageView.tsx` only patched `ApiHelper.get`. `ApiHelper.post` fell through to the default no-op stub (`async () => ({}) as T`), so the call resolved to `{}` immediately, `response?.url` was `undefined`, the success notification was skipped, and the popover closed.

**Fix:** three small wires.

| File | Change |
|---|---|
| `webview_panels/src/modules/lineage/LineageView.tsx` | Patch `ApiHelper.post` to route `dbt/v4/export-lineage` → `executeRequestInSync("exportLineage", ...)`. |
| `src/webview_provider/newLineagePanel.ts` | Add `exportLineage` command handler mirroring `sendFeedback`; returns `{ url }` to the webview. |
| `src/altimate.ts` | Add `altimate.exportLineage(req)` POSTing to `dbt/v4/export-lineage` with the user's API key. |

## Test plan
- [x] Typecheck `tsc --noEmit` (extension + webview): no new errors
- [x] `rsbuild build --mode development`: extension bundle contains `exportLineage` symbol
- [x] `vite build` (main + renderer, `--minify false`): webview bundle contains `dbt/v4/export-lineage` route
- [x] Jest: `altimate.test.ts` + `newLineagePanel.test.ts` pass (9/9)
- [ ] Pre-fix/post-fix E2E on docker code-server (results posted as comment)
- [ ] Manual smoke: lineage render, expand/reset, settings, sendFeedback all unaffected

[AI-6465]: https://altimateai.atlassian.net/browse/AI-6465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now export lineage data with custom naming, receiving a URL to access their exported information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->