### PR TITLE
chore: bump @altimateai/dbt-integration to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.2.14",
+        "@altimateai/dbt-integration": "^0.3.0",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.2.14.tgz",
-      "integrity": "sha512-44hFBx3gXss2RUlRZE9cIpAocffB3miAzpjvmma1EED0jiOhyrgmzGsw3RXEZqs73OuLYpDehixvRUt1vTfcfQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.0.tgz",
+      "integrity": "sha512-h3NigXk+e7gmFnQPFy7+nSMKJfAn2mp1UrIzvTIPwfoU992PleQUDuo2Fz2aNlMWLxDjOXLqzjCj6UKMck1LzA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1342,7 +1342,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.2.14",
+    "@altimateai/dbt-integration": "^0.3.0",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -657,7 +657,6 @@ container
         projectConfigDiagnostics,
         deferConfig,
         onDiagnosticsChanged,
-        container.get(DbtCloudVariantDetector),
       );
     };
   });


### PR DESCRIPTION
## Summary
- Bump `@altimateai/dbt-integration` from `^0.2.14` to `^0.3.0` (`package.json` + `package-lock.json`).
- Drop the trailing `DbtCloudVariantDetector` argument from the `DBTFusionCommandProjectIntegration` factory in `src/inversify.config.ts` — 0.3.0 removed it from that constructor (the `DBTCloudProjectIntegration` factory still passes it, matching the unchanged cloud signature).

## Test plan
- [x] `npx tsc --noEmit` (clean)
- [x] `npm run test-compile` (clean)
- [x] `npm test` — 30 suites / 477 tests pass
- [ ] Smoke-test extension against a dbt Fusion project locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration framework dependency to the latest version
  * Streamlined internal configuration for core components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->