### PR TITLE
fix: wire coreEngineDependencies into Factory<DBTCloudProjectIntegration>

### DIFF
--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -676,6 +676,9 @@ container
       onDiagnosticsChanged: () => void,
     ) => {
       const { container } = context;
+      const pythonStrategyFactory = container.get<
+        (projectRoot: string) => PythonDBTCommandExecutionStrategy
+      >("Factory<PythonDBTCommandExecutionStrategy>");
       return new DBTCloudProjectIntegration(
         container.get(DBTCommandExecutionInfrastructure),
         container.get(DBTCommandFactory),
@@ -688,6 +691,11 @@ container
         deferConfig,
         onDiagnosticsChanged,
         container.get(DbtCloudVariantDetector),
+        {
+          pythonDBTCommandExecutionStrategy: pythonStrategyFactory(projectRoot),
+          dbtConfiguration: container.get<DBTConfiguration>("DBTConfiguration"),
+          dbtIntegrationClient: container.get(DbtIntegrationClient),
+        },
       );
     };
   });

--- a/src/test/suite/dbtCloudCoreEngineDeps.test.ts
+++ b/src/test/suite/dbtCloudCoreEngineDeps.test.ts
@@ -1,0 +1,96 @@
+import {
+  DBTCloudProjectIntegration,
+  DBTCommandExecutionInfrastructure,
+  DBTCommandFactory,
+  DBTConfiguration,
+  DBTDiagnosticData,
+  DBTTerminal,
+  DbtCloudVariantDetector,
+  DbtIntegrationClient,
+  DeferConfig,
+  PythonDBTCommandExecutionStrategy,
+  PythonEnvironmentProvider,
+  RuntimePythonEnvironment,
+} from "@altimateai/dbt-integration";
+import { describe, expect, it, jest } from "@jest/globals";
+
+// Documents the runtime contract that Factory<DBTCloudProjectIntegration> must
+// satisfy. The Cloud integration only constructs its engine inside
+// refreshProjectConfig(), and for any non-Fusion variant (including the
+// "no ~/.dbt/dbt_cloud.yml" / "API call failed" case where detect() returns
+// null) it routes through CloudCoreCommandIntegration — which requires
+// coreEngineDependencies to be passed in. Without those, the engine is never
+// constructed and every subsequent dialect call throws "engine not initialized".
+
+const noopTerminal = (): DBTTerminal =>
+  ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+    show: jest.fn(),
+  }) as unknown as DBTTerminal;
+
+const stubVariantDetectorReturningNull = (): DbtCloudVariantDetector =>
+  ({
+    detect: jest.fn(async () => null),
+  }) as unknown as DbtCloudVariantDetector;
+
+const buildIntegration = (opts: {
+  withCoreEngineDeps: boolean;
+}): DBTCloudProjectIntegration => {
+  const terminal = noopTerminal();
+  const detector = stubVariantDetectorReturningNull();
+  const onDiagnosticsChanged = () => {};
+  const coreEngineDeps = opts.withCoreEngineDeps
+    ? {
+        pythonDBTCommandExecutionStrategy:
+          {} as unknown as PythonDBTCommandExecutionStrategy,
+        dbtConfiguration: {} as unknown as DBTConfiguration,
+        dbtIntegrationClient: {} as unknown as DbtIntegrationClient,
+      }
+    : undefined;
+  return new DBTCloudProjectIntegration(
+    {} as unknown as DBTCommandExecutionInfrastructure,
+    {} as unknown as DBTCommandFactory,
+    () => ({}) as never,
+    {} as unknown as RuntimePythonEnvironment,
+    {} as unknown as PythonEnvironmentProvider,
+    terminal,
+    "/tmp/project",
+    [] as DBTDiagnosticData[],
+    {} as DeferConfig,
+    onDiagnosticsChanged,
+    detector,
+    coreEngineDeps,
+  );
+};
+
+describe("DBTCloudProjectIntegration coreEngineDependencies contract", () => {
+  it("createEngine throws on a non-Fusion variant when coreEngineDependencies is omitted (the v0.61.0 regression — Factory<DBTCloudProjectIntegration> must wire these up)", () => {
+    const integration = buildIntegration({ withCoreEngineDeps: false });
+    expect(() =>
+      (
+        integration as unknown as {
+          createEngine: () => unknown;
+        }
+      ).createEngine(),
+    ).toThrow(/cannot construct CloudCoreCommandIntegration/);
+  });
+
+  it("createEngine clears the coreEngineDependencies guard once they are provided", () => {
+    // Pinpoints the guard at the top of createEngine. Construction past the
+    // guard reaches into CloudCoreCommandIntegration's super-chain which needs
+    // real DBTCommandExecutionInfrastructure / RuntimePythonEnvironment
+    // wiring; here we only prove the missing-deps gate is no longer hit.
+    const integration = buildIntegration({ withCoreEngineDeps: true });
+    expect(() =>
+      (
+        integration as unknown as {
+          createEngine: () => unknown;
+        }
+      ).createEngine(),
+    ).not.toThrow(/cannot construct CloudCoreCommandIntegration/);
+  });
+});

--- a/src/test/suite/dbtCloudFactoryWiring.test.ts
+++ b/src/test/suite/dbtCloudFactoryWiring.test.ts
@@ -1,0 +1,101 @@
+import {
+  DBTCloudProjectIntegration,
+  DBTDiagnosticData,
+  DeferConfig,
+} from "@altimateai/dbt-integration";
+import { describe, expect, it, jest } from "@jest/globals";
+
+// The shared vscode mock at src/test/mock/vscode.ts has no `env` or
+// `extensions` namespaces. Stub them in before importing inversify.config —
+// the Cloud factory transitively constructs TelemetryService (reads env.appName
+// + creates a TelemetryReporter, which calls env.createTelemetryLogger) and
+// VSCodeRuntimePythonEnvironmentProvider (reads extensions.getExtension).
+import * as vscodeMock from "../mock/vscode";
+const vscodeMockAny = vscodeMock as Record<string, unknown>;
+vscodeMockAny.env = {
+  appName: "vscode-test",
+  machineId: "test-machine",
+  sessionId: "test-session",
+  isTelemetryEnabled: false,
+  onDidChangeTelemetryEnabled: () => ({ dispose: () => {} }),
+  createTelemetryLogger: () => ({
+    logUsage: () => {},
+    logError: () => {},
+    dispose: () => {},
+    onDidChangeEnableStates: () => ({ dispose: () => {} }),
+  }),
+};
+// VSCodeDBTTerminal calls outputChannel.debug/info/warn/error — the shared
+// mock channel only has append/appendLine/clear/show/hide/dispose.
+const sharedWindow = vscodeMockAny.window as Record<string, unknown>;
+sharedWindow.createOutputChannel = jest.fn(() => ({
+  append: jest.fn(),
+  appendLine: jest.fn(),
+  clear: jest.fn(),
+  show: jest.fn(),
+  hide: jest.fn(),
+  dispose: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  trace: jest.fn(),
+  replace: jest.fn(),
+  name: "Log - dbt",
+  logLevel: 1,
+  onDidChangeLogLevel: () => ({ dispose: () => {} }),
+}));
+vscodeMockAny.extensions = {
+  getExtension: jest.fn(() => ({
+    isActive: true,
+    activate: () => Promise.resolve(),
+    exports: {
+      settings: {
+        getExecutionDetails: () => ({ execCommand: ["python"] }),
+        onDidChangeExecutionDetails: () => ({ dispose: () => {} }),
+      },
+      environment: {
+        getEnvironmentPaths: async () => [],
+        getEnvironmentDetails: async () => ({ executable: { uri: undefined } }),
+      },
+    },
+  })),
+};
+
+import { container } from "../../inversify.config";
+
+describe("Factory<DBTCloudProjectIntegration>", () => {
+  it("constructs the Cloud integration with coreEngineDependencies wired up so non-Fusion variants can build a CloudCoreCommandIntegration engine", () => {
+    type CloudFactory = (
+      projectRoot: string,
+      projectConfigDiagnostics: DBTDiagnosticData[],
+      deferConfig: DeferConfig,
+      onDiagnosticsChanged: () => void,
+    ) => DBTCloudProjectIntegration;
+
+    const factory = container.get<CloudFactory>(
+      "Factory<DBTCloudProjectIntegration>",
+    );
+    const integration = factory(
+      "/tmp/project",
+      [],
+      {} as DeferConfig,
+      () => {},
+    );
+
+    const deps = (
+      integration as unknown as {
+        coreEngineDependencies?: {
+          pythonDBTCommandExecutionStrategy: unknown;
+          dbtConfiguration: unknown;
+          dbtIntegrationClient: unknown;
+        };
+      }
+    ).coreEngineDependencies;
+
+    expect(deps).toBeDefined();
+    expect(deps?.pythonDBTCommandExecutionStrategy).toBeDefined();
+    expect(deps?.dbtConfiguration).toBeDefined();
+    expect(deps?.dbtIntegrationClient).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a regression introduced in v0.61.0 (dbt-integration 0.3.0 / #1936) where every dbt Cloud user on a non-Fusion variant — `latest`, `compatible`, `extended`, or anyone whose `~/.dbt/dbt_cloud.yml` is missing/unreadable so variant detection returns `null` — sees `An unexpected error occured while initializing the dbt project at <path>: Error: DBTCloudProjectIntegration: engine not initialized. Call refreshProjectConfig() first.` on extension activation. Customer report attached internally.

## Root cause

`DBTCloudProjectIntegration` constructs its engine inside `refreshProjectConfig()`. The `latest-fusion` variant builds a `CloudFusionIntegration` (no extra deps); every other variant routes through `CloudCoreCommandIntegration`, which the library guards behind a required `coreEngineDependencies` argument (`pythonDBTCommandExecutionStrategy`, `dbtConfiguration`, `dbtIntegrationClient`).

`Factory<DBTCloudProjectIntegration>` in `src/inversify.config.ts` was passing only 11 of the 12 constructor arguments, leaving `coreEngineDependencies` `undefined`. `createEngine()` then threw `cannot construct CloudCoreCommandIntegration without coreEngineDependencies`. `DBTIntegrationAdapter.refreshProjectConfig()` (`altimate-dbt-integration/src/dbtIntegrationAdapter.ts`) caught that and downgraded it to a project-config diagnostic, then ran `rebuildManifest()` unconditionally — `requireEngine()` on the still-undefined engine threw the user-visible message, which `dbtProject.initialize()` wrapped with `extendErrorWithSupportLinks`.

Affected: every Cloud user not on `latest-fusion`. Latest-fusion users are unaffected because `CloudFusionIntegration` doesn't need `coreEngineDependencies`.

## Fix

Thread `coreEngineDependencies` into `Factory<DBTCloudProjectIntegration>` the same way `Factory<DBTCoreCommandProjectIntegration>` already does — pull `Factory<PythonDBTCommandExecutionStrategy>` and project-scope it, plus the singleton `DBTConfiguration` and `DbtIntegrationClient` bindings.

## Pre-fix / post-fix verification

`src/test/suite/dbtCloudFactoryWiring.test.ts` exercises `Factory<DBTCloudProjectIntegration>` and asserts `coreEngineDependencies` is populated.

```
# pre-fix (master HEAD)
$ npx jest src/test/suite/dbtCloudFactoryWiring.test.ts --no-coverage
FAIL src/test/suite/dbtCloudFactoryWiring.test.ts
  ✕ constructs the Cloud integration with coreEngineDependencies wired up …
    expect(received).toBeDefined()
    Received: undefined

# post-fix
PASS src/test/suite/dbtCloudFactoryWiring.test.ts
  ✓ constructs the Cloud integration with coreEngineDependencies wired up …
```

`src/test/suite/dbtCloudCoreEngineDeps.test.ts` pins the library contract independently — `createEngine` throws `cannot construct CloudCoreCommandIntegration` when deps are omitted, and clears that guard once they are provided. Both tests pass post-fix.

Full suite: 32/32 suites pass, 480 tests pass (1 skipped). `tsc -p ./` clean. `rsbuild build --mode development` produces `dist/extension.js` cleanly.

## Test plan

- [ ] Manual: in a project with `dbt.dbtIntegration: cloud` and a `~/.dbt/dbt_cloud.yml` resolving to a `latest`/`compatible`/`extended` track, reload the window — extension should activate without the engine-not-initialized error and the manifest should rebuild.
- [ ] Manual: in a project with `dbt.dbtIntegration: cloud` and **no** `~/.dbt/dbt_cloud.yml` present, reload the window — extension should activate (variant detection silently returns null, factory falls into `CloudCoreCommandIntegration`).
- [ ] Manual: in a project with `dbt.dbtIntegration: cloud` and a `latest-fusion` track, reload the window — `CloudFusionIntegration` path unchanged, no regression.
- [ ] Automated: `npx jest` (480 passing locally on this branch).

## Follow-up

Library hardening to prevent recurrence: make `coreEngineDependencies` a required constructor parameter in `DBTCloudProjectIntegration` (currently optional). Consumers that only ever route to Fusion can pass a stub or the param can become a factory function — either way, TypeScript would catch this class of regression at the consumer's compile time. To be filed as a separate PR against `altimate-dbt-integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for dependency injection configuration and core engine dependencies validation.

* **Chores**
  * Updated internal dependency injection configuration to improve modularity in integration initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->