### PR TITLE
chore: make cte codelens provider to log debug instead of warn statement

### DIFF
--- a/src/code_lens_provider/cteCodeLensProvider.ts
+++ b/src/code_lens_provider/cteCodeLensProvider.ts
@@ -662,7 +662,7 @@ export class CteCodeLensProvider implements CodeLensProvider, Disposable {
       pos++;
     }
 
-    this.dbtTerminal.warn(
+    this.dbtTerminal.debug(
       "CteCodeLensProvider",
       `No main SELECT found after WITH clause starting at ${withStartPos}, checked ${selectsChecked} SELECT statements`,
     );


### PR DESCRIPTION
## Overview

### Problem

Telemetry events spike up for some warnings related to ctecodelens

### Solution

Change it to debug

### Screenshot/Demo

A picture is worth a thousand words. Please highlight the changes if applicable.

### How to test

- Steps to be followed to verify the solution or code changes
- Mention if there is any settings configuration added/changed/deleted

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging severity for a diagnostic condition.

**Note:** No user-facing changes in this release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1945)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->