### PR TITLE
feat: [AI-6522] add telemetry for walkthrough dbt install commands

### DIFF
--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -160,6 +160,8 @@ export class WalkthroughCommands {
   }
 
   private async installDbtFusion(): Promise<void> {
+    const platform = process.platform;
+    this.telemetry.sendTelemetryEvent("installDbtFusion", { platform });
     let error = undefined;
     await window.withProgress(
       {
@@ -169,7 +171,6 @@ export class WalkthroughCommands {
       },
       async () => {
         try {
-          const platform = process.platform;
           let command: string;
           let args: string[];
 
@@ -205,6 +206,9 @@ export class WalkthroughCommands {
           this.dbtProjectContainer.initialize();
         } catch (err) {
           error = err;
+          this.telemetry.sendTelemetryError("installDbtFusionError", err, {
+            platform,
+          });
         }
       },
     );
@@ -220,6 +224,8 @@ export class WalkthroughCommands {
   }
 
   private async installDbtCloud(): Promise<void> {
+    const platform = process.platform;
+    this.telemetry.sendTelemetryEvent("installDbtCloud", { platform });
     let error = undefined;
     await window.withProgress(
       {
@@ -255,6 +261,9 @@ export class WalkthroughCommands {
           this.dbtProjectContainer.initialize();
         } catch (err) {
           error = err;
+          this.telemetry.sendTelemetryError("installDbtCloudError", err, {
+            platform,
+          });
         }
       },
     );
@@ -309,6 +318,14 @@ export class WalkthroughCommands {
     }
     const packageVersion = dbtVersion.label;
     const packageName = this.mapToAdapterPackage(adapter.label);
+    const platform = process.platform;
+    const telemetryProps = {
+      adapter: adapter.label,
+      packageName,
+      dbtVersion: packageVersion,
+      platform,
+    };
+    this.telemetry.sendTelemetryEvent("installDbtCore", telemetryProps);
     let error = undefined;
     await window.withProgress(
       {
@@ -354,6 +371,11 @@ export class WalkthroughCommands {
           this.dbtProjectContainer.initialize();
         } catch (err) {
           error = err;
+          this.telemetry.sendTelemetryError(
+            "installDbtCoreError",
+            err,
+            telemetryProps,
+          );
         }
       },
     );

--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -225,7 +225,12 @@ export class WalkthroughCommands {
 
   private async installDbtCloud(): Promise<void> {
     const platform = process.platform;
-    this.telemetry.sendTelemetryEvent("installDbtCloud", { platform });
+    const telemetryProps = {
+      platform,
+      pythonPath: this.pythonEnvironment.pythonPath ?? "unknown",
+      pythonVersion: this.pythonEnvironment.pythonVersion ?? "unknown",
+    };
+    this.telemetry.sendTelemetryEvent("installDbtCloud", telemetryProps);
     let error = undefined;
     await window.withProgress(
       {
@@ -261,9 +266,11 @@ export class WalkthroughCommands {
           this.dbtProjectContainer.initialize();
         } catch (err) {
           error = err;
-          this.telemetry.sendTelemetryError("installDbtCloudError", err, {
-            platform,
-          });
+          this.telemetry.sendTelemetryError(
+            "installDbtCloudError",
+            err,
+            telemetryProps,
+          );
         }
       },
     );
@@ -324,6 +331,8 @@ export class WalkthroughCommands {
       packageName,
       dbtVersion: packageVersion,
       platform,
+      pythonPath: this.pythonEnvironment.pythonPath ?? "unknown",
+      pythonVersion: this.pythonEnvironment.pythonVersion ?? "unknown",
     };
     this.telemetry.sendTelemetryEvent("installDbtCore", telemetryProps);
     let error = undefined;


### PR DESCRIPTION
## Summary

Adds dedicated telemetry to the three setup-wizard install paths (`installDbtCore`, `installDbtCloud`, `installDbtFusion`) so we can measure install failure rates per platform and per adapter. Today these failures only surface as a UI error and produce no telemetry — a gap surfaced during the [AI-6522](https://altimateai.atlassian.net/browse/AI-6522) detection-coverage audit.

- Emits `installDbt{Core,Cloud,Fusion}` on entry with `platform` (and `adapter` / `dbtVersion` / `packageName` for core).
- Emits `installDbt{Core,Cloud,Fusion}Error` on the catch path via `sendTelemetryError` with the same dimensions, so failures can be grouped by cause in App Insights.
- No behavior change — UI error dialog and retry prompt are unchanged.

## Context

Audit of 30d App Insights data showed 6,409 users hitting `extensionActivationError`, but install-command failures from the walkthrough were a complete blind spot — caught into a local `error` variable, shown in UI, and dropped on the floor. We have `installDeps` / `installDepsError` events for `dbt deps` but nothing for the actual `pip install` / `curl install.sh` step that comes earlier in the wizard.

This PR is the first slice of telemetry additions called out in the [Jira gap analysis](https://altimateai.atlassian.net/browse/AI-6522?focusedCommentId=41697). Python-environment-specific events (`pythonInterpreterNotSelected` / `pythonExtensionUnavailableError`) live in `@altimateai/dbt-integration` and will be scoped separately.

## Test plan

- [ ] Open the dbt walkthrough on a fresh machine and run "Install dbt core" — verify `installDbtCore` event appears with the picked adapter/version/platform.
- [ ] Force a failure (e.g., pick `risingwave` on a Python that can't install it) — verify `installDbtCoreError` fires with the same dimensions plus stack trace.
- [ ] Run "Install dbt cloud" — verify `installDbtCloud` event.
- [ ] Run "Install dbt fusion" — verify `installDbtFusion` event.
- [ ] Confirm no regression in the existing UI flow (error dialog + retry prompt still shown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-6522]: https://altimateai.atlassian.net/browse/AI-6522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved telemetry for dbt installation flows: now captures platform and includes richer properties (platform, Python path/version, and installer-specific details) when emitting install and error events for dbt Fusion, dbt Cloud, and dbt Core.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1946)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->