### PR TITLE
chore: drop CTE-parser mid-edit warnings to debug

### DIFF
--- a/src/code_lens_provider/cteCodeLensProvider.ts
+++ b/src/code_lens_provider/cteCodeLensProvider.ts
@@ -161,7 +161,7 @@ export class CteCodeLensProvider implements CodeLensProvider, Disposable {
       // Find the end of this WITH clause (before the main SELECT)
       const withClauseEnd = this.findWithClauseEnd(text, withStartPos);
       if (withClauseEnd === -1) {
-        this.dbtTerminal.warn(
+        this.dbtTerminal.debug(
           "CteCodeLensProvider",
           `Could not find end of WITH clause #${withClauseCount} starting at ${withStartPos}`,
         );
@@ -351,7 +351,7 @@ export class CteCodeLensProvider implements CodeLensProvider, Disposable {
         }
         endPos++;
       }
-      this.dbtTerminal.warn(
+      this.dbtTerminal.debug(
         "CteCodeLensProvider",
         `Unterminated block comment starting at position ${pos}`,
       );
@@ -376,7 +376,7 @@ export class CteCodeLensProvider implements CodeLensProvider, Disposable {
         }
         endPos++;
       }
-      this.dbtTerminal.warn(
+      this.dbtTerminal.debug(
         "CteCodeLensProvider",
         `Unterminated Jinja comment starting at position ${pos}`,
       );
@@ -639,7 +639,7 @@ export class CteCodeLensProvider implements CodeLensProvider, Disposable {
           const remainingText = text.substring(pos);
           const nestedWithMatch = remainingText.match(/^\s*with\b/i);
           if (nestedWithMatch) {
-            this.dbtTerminal.warn(
+            this.dbtTerminal.debug(
               "CteCodeLensProvider",
               `Found nested WITH clause at position ${pos}, bailing out - nested WITH clauses are not supported`,
             );
@@ -707,7 +707,7 @@ export class CteCodeLensProvider implements CodeLensProvider, Disposable {
         cteMatch.index + cteMatch.fullMatch.length - 1,
       );
       if (cteQueryEnd === -1) {
-        this.dbtTerminal.warn(
+        this.dbtTerminal.debug(
           "CteCodeLensProvider",
           `Could not find matching closing parenthesis for CTE: ${cteName}`,
         );
@@ -809,7 +809,7 @@ export class CteCodeLensProvider implements CodeLensProvider, Disposable {
       );
       return pos - 1;
     } else {
-      this.dbtTerminal.warn(
+      this.dbtTerminal.debug(
         "CteCodeLensProvider",
         `Could not find matching closing paren, remaining open parens: ${parenCount}, max depth reached: ${maxDepth}`,
       );


### PR DESCRIPTION
## Summary

Six remaining `dbtTerminal.warn` calls in `cteCodeLensProvider.ts` fire on normal mid-edit states (unterminated parens, unterminated `/* */` or `{# #}` comments, mid-edit WITH clauses, intentionally-unsupported nested WITH). Each call writes a `level=warn` telemetry event for what is, from the user's perspective, just an incomplete keystroke.

Combined volume in production (24h, 0.61.2 + 0.61.3): **~4,900 events across ~120 machines**. All `warn`-level. None actionable.

Commit `93b2da18` (#1945) already started this conversion. This finishes the sweep. `debug` writes to the output channel only and does not send telemetry.

## Lines flipped

| Line | Message |
|---|---|
| 164 | "Could not find end of WITH clause" |
| 354 | "Unterminated block comment" |
| 379 | "Unterminated Jinja comment" |
| 642 | "Found nested WITH clause, bailing out" |
| 710 | "Could not find matching closing parenthesis for CTE" |
| 812 | "Could not find matching closing paren, remaining open parens" |

## Test plan

- [x] All 76 existing `cteCodeLensProvider.test.ts` tests pass unchanged
- [x] ESLint clean on modified file
- [x] Bundle builds via `rsbuild build --mode development`

Post-merge: the top-of-cluster "Could not find matching closing paren" (2,784 events from 88 machines/24h) and "No main SELECT found after WITH clause" (539 events from 27 machines) disappear from `*Warn` telemetry dashboards within the ~2h staging retention window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal diagnostic logging to reduce noise from non-critical CTE parsing edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->