### PR TITLE
chore: fix prettier formatting drift after prettier-eslint 16 bump

### DIFF
--- a/src/dbt_client/runtimePythonEnvironmentProvider.ts
+++ b/src/dbt_client/runtimePythonEnvironmentProvider.ts
@@ -8,9 +8,7 @@ import { Uri, workspace } from "vscode";
 import { PythonEnvironment } from "./pythonEnvironment";
 
 @injectable()
-export class VSCodeRuntimePythonEnvironmentProvider
-  implements PythonEnvironmentProvider
-{
+export class VSCodeRuntimePythonEnvironmentProvider implements PythonEnvironmentProvider {
   private callbacks: ((environment: RuntimePythonEnvironment) => void)[] = [];
 
   constructor(
@@ -59,9 +57,7 @@ export class VSCodeRuntimePythonEnvironmentProvider
 }
 
 @injectable()
-export class StaticRuntimePythonEnvironment
-  implements RuntimePythonEnvironment
-{
+export class StaticRuntimePythonEnvironment implements RuntimePythonEnvironment {
   constructor(
     @inject(PythonEnvironment)
     private vscodeEnvironment: PythonEnvironment,

--- a/src/test/suite/bigQueryCostEstimate.test.ts
+++ b/src/test/suite/bigQueryCostEstimate.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, jest } from "@jest/globals";
 import { DBTTerminal } from "@altimateai/dbt-integration";
+import { describe, expect, it, jest } from "@jest/globals";
 import { BigQueryCostEstimate } from "../../commands/bigQueryCostEstimate";
 import { DBTProjectContainer } from "../../dbt_client/dbtProjectContainer";
 import { TelemetryService } from "../../telemetry";
@@ -119,9 +119,9 @@ describe("BigQueryCostEstimate.estimateCost arg destructure", () => {
       return returnResult;
     }
 
-    function postFixWrapper(
-      { returnResult }: { returnResult?: boolean } = {},
-    ): boolean | undefined {
+    function postFixWrapper({ returnResult }: { returnResult?: boolean } = {}):
+      | boolean
+      | undefined {
       return returnResult;
     }
 

--- a/src/test/suite/telemetryService.test.ts
+++ b/src/test/suite/telemetryService.test.ts
@@ -39,7 +39,9 @@ describe("TelemetryService.sendTelemetryError surfaces diagnostic fields", () =>
     (vscode as { env?: unknown }).env = {
       appName: "Visual Studio Code",
       createTelemetryLogger: jest.fn().mockReturnValue({
-        onDidChangeEnableStates: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+        onDidChangeEnableStates: jest
+          .fn()
+          .mockReturnValue({ dispose: jest.fn() }),
         isErrorsEnabled: false,
         isUsageEnabled: false,
         logUsage: jest.fn(),
@@ -88,10 +90,11 @@ describe("TelemetryService.sendTelemetryError surfaces diagnostic fields", () =>
   });
 
   it("forwards error.code for system errors (ENOENT, EACCES, etc.)", () => {
-    const err = Object.assign(
-      new Error("spawn /usr/local/bin/python ENOENT"),
-      { code: "ENOENT", syscall: "spawn", errno: -2 },
-    );
+    const err = Object.assign(new Error("spawn /usr/local/bin/python ENOENT"), {
+      code: "ENOENT",
+      syscall: "spawn",
+      errno: -2,
+    });
     telemetry.sendTelemetryError(
       "innoverio.vscode-dbt-power-user/CommandProcessExecutionError",
       err,


### PR DESCRIPTION
## Summary

Cleans up 9 \`prettier/prettier\` lint errors via \`npm run lint:fix\`:

- **2 in \`src/dbt_client/runtimePythonEnvironmentProvider.ts\`** — caused by prettier-eslint v16 changing the line-break behavior for \`implements\` clauses. Surfaced when #1900 landed.
- **3 in \`src/test/suite/bigQueryCostEstimate.test.ts\`** — pre-existing on master; lint isn't CI-gated so they accumulated.
- **4 in \`src/test/suite/telemetryService.test.ts\`** — pre-existing, same reason.

After this PR, \`npm run lint\` reports zero errors.

## Test plan

- [x] \`npm run lint\` runs clean locally (was 9 errors before, 0 after)
- [x] Diff is purely whitespace/line-break formatting; no semantic changes
- [ ] CI green (build + test still pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting consistency in internal code declarations and test file organization across multiple modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->