### PR TITLE
fix: [AI-6702] doc-editor settings/help drawer won't reopen after close

### DIFF
--- a/webview_panels/src/modules/commonActionButtons/CommonActionButtons.tsx
+++ b/webview_panels/src/modules/commonActionButtons/CommonActionButtons.tsx
@@ -59,8 +59,12 @@ const CommonActionButtons = (): JSX.Element => {
         )}
       </PopoverWithButton>
 
-      {action === SelectedAction.SETTINGS ? <DocGeneratorSettings /> : null}
-      {action === SelectedAction.HELP ? <HelpButton /> : null}
+      {action === SelectedAction.SETTINGS ? (
+        <DocGeneratorSettings onClose={() => setAction(undefined)} />
+      ) : null}
+      {action === SelectedAction.HELP ? (
+        <HelpButton onClose={() => setAction(undefined)} />
+      ) : null}
     </Stack>
   );
 };

--- a/webview_panels/src/modules/commonActionButtons/HelpButton.tsx
+++ b/webview_panels/src/modules/commonActionButtons/HelpButton.tsx
@@ -10,7 +10,11 @@ enum Pages {
   TESTS,
 }
 
-const HelpButton = (): JSX.Element => {
+interface Props {
+  onClose?: () => void;
+}
+
+const HelpButton = ({ onClose }: Props): JSX.Element => {
   const [selectedPage, setSelectedPage] = useState(Pages.DOCUMENTATION);
   const drawerRef = useRef<DrawerRef | null>(null);
 
@@ -30,7 +34,7 @@ const HelpButton = (): JSX.Element => {
     sendTelemetryEvent(TelemetryEvents["DocumentationEditor/HelpTestsOpen"]);
   };
   return (
-    <Drawer title="Help" onOpen={onOpen} ref={drawerRef}>
+    <Drawer title="Help" onOpen={onOpen} onClose={onClose} ref={drawerRef}>
       <ButtonGroup className="mb-2">
         <Button
           color={selectedPage === Pages.DOCUMENTATION ? "primary" : "secondary"}

--- a/webview_panels/src/modules/documentationEditor/components/settings/DocGeneratorSettings.tsx
+++ b/webview_panels/src/modules/documentationEditor/components/settings/DocGeneratorSettings.tsx
@@ -13,7 +13,11 @@ import { sendTelemetryEvent } from "../telemetry";
 import { TelemetryEvents } from "@telemetryEvents";
 import { useEffect, useRef } from "react";
 
-const DocGeneratorSettings = (): JSX.Element => {
+interface Props {
+  onClose?: () => void;
+}
+
+const DocGeneratorSettings = ({ onClose }: Props): JSX.Element => {
   const {
     dispatch,
     state: { userInstructions },
@@ -50,7 +54,7 @@ const DocGeneratorSettings = (): JSX.Element => {
   };
 
   return (
-    <Drawer title="Help" onOpen={onOpen} ref={drawerRef}>
+    <Drawer title="Help" onOpen={onOpen} onClose={onClose} ref={drawerRef}>
       <Stack direction="column">
         <h5>Configure settings for document generation</h5>
         <Stack direction="column">


### PR DESCRIPTION
## Summary
- Doc Editor → More actions → Settings/Help drawer doesn't reopen after first close — needs window reload to recover ([AI-6702](https://altimateai.atlassian.net/browse/AI-6702))
- Root cause: `CommonActionButtons` conditionally renders `<DocGeneratorSettings />` / `<HelpButton />` by `action` state, and the children open the drawer with mount-only `useEffect(() => drawerRef.current?.open(), [])`. Closing the drawer via X doesn't reset `action`, so the child stays mounted, the next click is `setAction(SETTINGS)` with no value change → React bails → effect never re-fires.
- Fix: thread the existing `Drawer.onClose` from children to `CommonActionButtons` so it can `setAction(undefined)` on close → unmount → next click re-mounts → effect re-fires. 3-line patch across 3 files.

## Pre/post-fix verification
Reproduced and verified end-to-end via Playwright against a docker code-server build hitting prod altimate. Comment below has the full pre/post comparison (screenshots, 5+3 stress cycles, interleaved Settings ↔ Help).

## Test plan
- [x] Bug reproduced on `master`: Settings click #2 after a close → drawer stays unmounted (`drawerInDom: false`)
- [x] Reload-window workaround confirmed
- [x] Post-fix: Settings open/close × 5 cycles, no reload
- [x] Post-fix: Help open/close × 3 cycles
- [x] Post-fix: Interleaved Settings ↔ Help × 5
- [ ] Local: doc-gen still works end-to-end on Technical/General/Business User (already verified pre-fix; behaviour unchanged by this PR)
- [ ] CI: tsc + lint clean

## Risk
Tiny patch — adds an optional prop. No other call sites import these components. Drawer.onClose was already the canonical close hook; we're just consuming it. No behaviour change when `onClose` is undefined.

[AI-6702]: https://altimateai.atlassian.net/browse/AI-6702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management for help and documentation settings panels to enable more reliable closing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->