### PR TITLE
fix: "Get distinct column values" fails with 'result.flat is not a function'

### DIFF
--- a/src/dbt_client/dbtProject.ts
+++ b/src/dbt_client/dbtProject.ts
@@ -1114,13 +1114,16 @@ export class DBTProject implements Disposable {
         true,
         { model, column },
       );
-      const result = this.dbtProjectIntegration.getColumnValues(model, column);
+      const result = await this.dbtProjectIntegration.getColumnValues(
+        model,
+        column,
+      );
       this.telemetry.endTelemetryEvent(
         TelemetryEvents["DocumentationEditor/GetDistinctColumnValues"],
         undefined,
         { column, model },
       );
-      return (result as any).flat();
+      return result;
     } catch (error) {
       this.telemetry.endTelemetryEvent(
         TelemetryEvents["DocumentationEditor/GetDistinctColumnValues"],


### PR DESCRIPTION
## Summary
- Documentation Editor → Add `accepted_values` test on a column → **Get distinct column values** crashes with toast `result.flat is not a function`. Dropdown never populates; user has no way to seed test values from the existing data.
- Root cause: missing `await` on `DBTProject.getColumnValues` calling `dbtProjectIntegration.getColumnValues(...)` (declared `Promise<unknown[]>`). Code then calls `.flat()` on the unresolved Promise.
- The `as any` cast was masking the type error.
- The `.flat()` was already obsolete since #1697 moved flattening into the integration library — the adapter (`dbtIntegrationAdapter.ts:1029`) already returns a flat `unknown[]`. Pre-#1697 it was correct; post-refactor it's both wrong and unnecessary.
- 5-line fix: `await` it, drop `as any` + `.flat()`, return the result directly.

## Provenance
Regression introduced by [#1697](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1697) ("refactor: use dbt integration library", merged 2025-10-22). Has been broken in `master` for ~7 months. Anyone exercising `accepted_values` test creation in the Doc Editor has hit this.

## Verification
Pre/post-fix end-to-end run on a docker code-server with this branch checked out, against the bundled `jaffle-shop-duckdb` fixture. Comment below has screenshots + repro sequence.

- **Pre-fix on master**: clicking "Get distinct column values" surfaces the exact reported toast (`result.flat is not a function`). Dropdown stays empty.
- **Post-fix**: same click populates the dropdown with 79 distinct `first_name` values from the materialized table ("Kathleen", "Amy", "Thomas", ... — real jaffle data).

## Test plan
- [x] Bug reproduced on `master` build (full docker + Playwright)
- [x] Post-fix: 79 distinct values populate, no toast
- [x] Telemetry events (`DocumentationEditor/GetDistinctColumnValues` start/end) preserved
- [x] `finally { cleanupConnections() }` still runs (only the return shape changed)
- [ ] CI: tsc + lint clean
- [ ] Reviewer: try with at least one non-duckdb adapter if accessible (the fix is in the framework-agnostic layer above the integration strategies, so all should benefit equally)

## Risk
Tiny. The function is now correctly `await`ed and returns what the type signature already said it should. No call-site changes needed (the function was already `async`). The removed `.flat()` was already a no-op for the post-#1697 data shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved column value retrieval to properly handle asynchronous operations, ensuring accurate and reliable data delivery without unnecessary transformations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->