### PR TITLE
fix: CTE profiler returns 0 rows on Snowflake-like adapters

### DIFF
--- a/src/cte_profiler/cteProfilerService.ts
+++ b/src/cte_profiler/cteProfilerService.ts
@@ -271,7 +271,12 @@ export class CteProfilerService implements Disposable {
     if (data.length === 0) {
       return 0;
     }
-    const count = data[0]["_profile_count"];
+    // Read the single COUNT(*) value by position rather than by name. The
+    // profiler builds the query itself and aliases the result, but adapters
+    // fold the alias according to their dialect's identifier rules — Snowflake
+    // and Oracle uppercase unquoted aliases, so a lowercase key lookup
+    // misses the row and the profiler reports 0 for every CTE.
+    const count = Object.values(data[0])[0];
     return typeof count === "number" ? count : Number(count) || 0;
   }
 

--- a/src/test/suite/cteProfilerService.test.ts
+++ b/src/test/suite/cteProfilerService.test.ts
@@ -1,0 +1,54 @@
+import { DBTTerminal } from "@altimateai/dbt-integration";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { CteProfilerService } from "../../cte_profiler/cteProfilerService";
+import { DBTProjectContainer } from "../../dbt_client/dbtProjectContainer";
+
+describe("CteProfilerService.extractRowCount", () => {
+  let svc: CteProfilerService;
+
+  beforeEach(() => {
+    const dbtTerminal = {
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      log: jest.fn(),
+      trace: jest.fn(),
+    } as unknown as DBTTerminal;
+    const dbtProjectContainer = {} as DBTProjectContainer;
+    svc = new CteProfilerService(dbtProjectContainer, dbtTerminal);
+  });
+
+  // Use a private-field accessor — extractRowCount is intentionally private,
+  // but the entire purpose of this test is to lock in its dialect-agnostic
+  // behavior so that the Snowflake / Oracle case-folding regression doesn't
+  // come back.
+  const extract = (data: Record<string, unknown>[]): number =>
+    (
+      svc as unknown as { extractRowCount: (d: typeof data) => number }
+    ).extractRowCount(data);
+
+  it("returns the count when adapter returns uppercase keys (Snowflake/Oracle)", () => {
+    // Snowflake and Oracle fold unquoted identifiers to UPPERCASE, so the
+    // adapter zips column_names verbatim and the row arrives as _PROFILE_COUNT.
+    // The buggy pre-fix lookup `data[0]["_profile_count"]` returned undefined
+    // here and fell through to 0; the fix reads by position so it works.
+    expect(extract([{ _PROFILE_COUNT: 99 }])).toBe(99);
+  });
+
+  it("returns the count when adapter returns lowercase keys (Postgres/DuckDB)", () => {
+    expect(extract([{ _profile_count: 42 }])).toBe(42);
+  });
+
+  it("coerces string counts (some adapters return BigInteger as string)", () => {
+    expect(extract([{ _PROFILE_COUNT: "1234" }])).toBe(1234);
+  });
+
+  it("returns 0 when the query produced no rows", () => {
+    expect(extract([])).toBe(0);
+  });
+
+  it("returns 0 when the column value is non-numeric", () => {
+    expect(extract([{ _PROFILE_COUNT: "not-a-number" }])).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- "Profile CTEs" reports 0 rows for every CTE on Snowflake (and Oracle) even when the same CTE clearly returns data via the "Execute query" codelens. Root cause: the profiler emits `SELECT COUNT(*) AS _profile_count FROM <cte>` with an **unquoted** alias, which Snowflake folds to UPPERCASE. The adapter zips `column_names` verbatim into the row dict, so the row arrives as `{ _PROFILE_COUNT: n }` and the previous `data[0]["_profile_count"]` lookup misses → falls through to 0.
- Fix is one line: read the COUNT result by position via `Object.values(data[0])[0]`. The profiler builds the query itself, knows it's a single-column COUNT, and the positional read sidesteps every dialect's identifier folding rule. Empty-result and non-numeric safety preserved.
- Postgres, Redshift, DuckDB, and BigQuery fold to lowercase / preserve case, so the lookup happened to work there — which is why this slipped through dev and CI.

## Test plan

- [x] New unit test `src/test/suite/cteProfilerService.test.ts` exercises:
  - uppercase Snowflake/Oracle row shape (`{ _PROFILE_COUNT: 99 }`) — the case that was returning 0 before
  - lowercase Postgres/DuckDB row shape (regression guard)
  - BigInteger-as-string coercion (some adapters stringify long counts)
  - empty rows (returns 0)
  - non-numeric values (returns 0)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on the changed files
- [ ] Manual: load a Snowflake-backed dbt project (jaffle_shop_core or equivalent), open a model with multiple CTEs, run "Profile CTEs" codelens, confirm the decorations now show real row counts instead of 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where CTE row counts were incorrectly displayed as zero, which could impact query profiling accuracy.

* **Tests**
  * Added test coverage for row count extraction to improve reliability across different database systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->