### PR TITLE
chore: drop unused chai and @types/chai from devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@rsbuild/core": "^1.5.17",
-        "@types/chai": "^4.3.9",
         "@types/glob": "^8.1.0",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "@types/jest": "^29.5.0",
@@ -58,7 +57,6 @@
         "@vscode/debugprotocol": "^1.68.0",
         "@vscode/test-electron": "^2.4.1",
         "@vscode/zeromq": "^0.2.1",
-        "chai": "^4.3.10",
         "concurrently": "^9.2.1",
         "cross-env": "^7.0.3",
         "eslint": "^8.57.0",
@@ -3035,11 +3033,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/chai": {
-      "version": "4.3.20",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "license": "MIT",
@@ -4127,14 +4120,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -4671,23 +4656,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4710,17 +4678,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cheerio": {
@@ -5342,17 +5299,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -6669,14 +6615,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -9308,14 +9246,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
@@ -10784,14 +10714,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/pend": {
@@ -13281,14 +13203,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -1214,7 +1214,6 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@rsbuild/core": "^1.5.17",
-    "@types/chai": "^4.3.9",
     "@types/glob": "^8.1.0",
     "@types/istanbul-lib-coverage": "^2.0.6",
     "@types/jest": "^29.5.0",
@@ -1230,7 +1229,6 @@
     "@vscode/debugprotocol": "^1.68.0",
     "@vscode/test-electron": "^2.4.1",
     "@vscode/zeromq": "^0.2.1",
-    "chai": "^4.3.10",
     "concurrently": "^9.2.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary

- Removes `chai` (`^4.3.10`) and `@types/chai` (`^4.3.9`) from `devDependencies`.
- Both are unused — no `import .. chai` or `require("chai")` anywhere in `src/`, `webview_panels/src/`, or jest setup.
- Tests use jest `expect()` for unit suites (`src/test/suite/*.test.ts`) and Node's `assert` for the integration suites (`src/test/integration/*.test.ts`).

## Why now

Dependabot opened a PR to bump chai 4 → 6 (chai 5+ is ESM-only). That PR was effectively a no-op since nothing imports chai. Cleaner fix: drop both packages instead. Same security-alert outcome, less lockfile churn over time.

## Verification

| Step | Result |
|---|---|
| `tsc --noEmit -p tsconfig.json` | ✅ exit 0 |
| `npm test` | ✅ 35/35 suites pass, 493 tests pass, 1 skipped |
| `npm install` | ✅ lockfile regenerated (-86 lines, 0 transitive deps newly needed) |

## Test plan

- [x] tsc clean
- [x] full jest suite green
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused testing dependencies from the project build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->