### PR TITLE
chore: bump @altimateai/dbt-integration to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.3.1",
+        "@altimateai/dbt-integration": "^0.3.2",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.1.tgz",
-      "integrity": "sha512-GqxKZd9PIBiFod7ZNu6G1AXDOl1U2vSxuZJ6JtLcZIhtN5F6QUzGz36g5KL06Naaxy1SHuhO0hZD/bmBnqzMng==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.2.tgz",
+      "integrity": "sha512-XINV2Q3Xg7BYFekbI5lkMN5TqOkrDDHV1JnOstaDbWCFQHZYr6gqx6CiU7F4r4mUU84DkMYRMST3e1/Un6JDQw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1264,7 +1264,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.3.1",
+    "@altimateai/dbt-integration": "^0.3.2",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",


### PR DESCRIPTION
## Summary

Bump `@altimateai/dbt-integration` from `^0.3.1` to `^0.3.2`.

0.3.2 is the npm release that ships the [Validate SQL `database`-through-the-altimate-core-schema fix](https://github.com/AltimateAI/altimate-dbt-integration/pull/108) — without that release, "Validate SQL" reports `Table '<X>' not found` for every parent on Snowflake projects (and any other warehouse where dbt compiles refs into fully-qualified 3-part identifiers).

Released to npm today after the [bump PR on dbt-integration](https://github.com/AltimateAI/altimate-dbt-integration/pull/109) merged.

## Diff

Just `package.json` (`^0.3.1` → `^0.3.2`) and the lockfile resolution.

## Test plan

- [x] `npm install` resolves `@altimateai/dbt-integration@0.3.2` cleanly
- [x] Verified the AI-6726 fix is in the new tarball (`grep` confirms `database:c.database||null` in `node_modules/@altimateai/dbt-integration/dist/index.js`)
- [ ] Reviewer-side: confirm `npm install` reproduces the same lockfile entries when run locally
- [ ] Optional: re-run E2E from `vscode-dbt-power-user#1968`'s comment against this branch to confirm the "Table not found" diagnostic stays gone end-to-end through the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer patch version to improve stability and compatibility.
  * Minor version bump only; no API or public behavior changes were introduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->