### PR TITLE
fix: map unique_id → uniqueId for /sqltomodel POST

### DIFF
--- a/src/altimate.ts
+++ b/src/altimate.ts
@@ -84,11 +84,27 @@ type SqlLineageResponse = {
   nodePositions?: Record<string, [number, number]>;
 };
 
+// `@altimateai/dbt-integration` preserves dbt's manifest convention and exposes
+// `unique_id` (snake_case) on NodeMetaData / SourceMetaData. The /sqltomodel
+// backend Pydantic schema expects `uniqueId` (camelCase) — only that one field.
+// Map at the HTTP boundary instead of asking the backend to alias both shapes,
+// so the wire contract stays anchored at a single TS-owned mapper.
+type BackendModelNode = NodeMetaData & { uniqueId: string };
+type BackendSourceMetaData = SourceMetaData & { uniqueId: string };
+
+export const toBackendModelNode = (n: NodeMetaData): BackendModelNode => ({
+  ...n,
+  uniqueId: n.unique_id,
+});
+export const toBackendSourceMetaData = (
+  s: SourceMetaData,
+): BackendSourceMetaData => ({ ...s, uniqueId: s.unique_id });
+
 interface SQLToModelRequest {
   sql: string;
   adapter: string;
-  models: NodeMetaData[];
-  sources: SourceMetaData[];
+  models: BackendModelNode[];
+  sources: BackendSourceMetaData[];
 }
 
 interface DBTProjectHealthConfig {

--- a/src/commands/sqlToModel.ts
+++ b/src/commands/sqlToModel.ts
@@ -2,7 +2,11 @@ import { DBTTerminal } from "@altimateai/dbt-integration";
 import { inject } from "inversify";
 import * as path from "path";
 import { Position, ProgressLocation, Range, window } from "vscode";
-import { AltimateRequest } from "../altimate";
+import {
+  AltimateRequest,
+  toBackendModelNode,
+  toBackendSourceMetaData,
+} from "../altimate";
 import { DBTProjectContainer } from "../dbt_client/dbtProjectContainer";
 import {
   ManifestCacheChangedEvent,
@@ -102,8 +106,8 @@ export class SqlToModel {
             // conversions that were half done. if it fails, just send the text as is.
             sql: compiledSql || fileText,
             adapter: project.getAdapterType(),
-            models: allmodels,
-            sources: allsources,
+            models: allmodels.map(toBackendModelNode),
+            sources: allsources.map(toBackendSourceMetaData),
           });
         },
       );


### PR DESCRIPTION
## Summary

`@altimateai/dbt-integration` exposes `NodeMetaData` and `SourceMetaData` with `unique_id` (snake_case) — that's dbt's manifest convention, which the library preserves. The backend Pydantic schema for `POST /dbt/v1/sqltomodel` expects `uniqueId` (camelCase). The "Convert to dbt model" command has been silently failing in production with `Field required: uniqueId` since the [dbt-integration library refactor in #1697](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1697) (~7 months ago); surfaced via an SA report.

Owning the case translation extension-side keeps the wire contract anchored at a single TS mapper, consistent with the direction we want for the rest of the `/dbt/v1/*` endpoints. (An alternative backend-side fix was opened and closed — see comments on that for the architecture conversation.)

## Diff

- `src/altimate.ts` — add `BackendModelNode` / `BackendSourceMetaData` (intersection types over dbt-integration's manifest types), plus `toBackendModelNode` / `toBackendSourceMetaData` helpers. `SQLToModelRequest` updated to use the new types.
- `src/commands/sqlToModel.ts` — apply the mappers to `allmodels` and `allsources` before posting.

The mappers spread the source object — every other field (`schema`, `package_name`, `resource_type`, `depends_on`, etc.) already matches the backend Pydantic shape and flows through unchanged. The backend's Pydantic models default to ignoring extra fields, so leaving the original `unique_id` alongside the new `uniqueId` is harmless.

## Test plan

- [x] `npx tsc --noEmit` clean on changed files
- [x] `npx eslint src/altimate.ts src/commands/sqlToModel.ts` clean
- [ ] Reviewer-side: load the build against a Snowflake project, open a SQL file, run "dbt Power User: Convert SQL to model" — should no longer error with `Field required: uniqueId` on each model and source in the panel response.

A wire-format standardisation ticket will follow to audit the rest of the `/dbt/v1/*` surface for similar asymmetries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data formatting in the SQL-to-model conversion process to ensure proper backend API compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->