### PR TITLE
chore: bump version to 0.61.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.61.4",
+  "version": "0.61.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.61.4",
+      "version": "0.61.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/AltimateAI/vscode-dbt-power-user/issues"
   },
-  "version": "0.61.4",
+  "version": "0.61.5",
   "engines": {
     "vscode": "^1.95.0"
   },


### PR DESCRIPTION
## Summary

Bump `0.61.4` → `0.61.5` to prepare a release. Hold this PR until both feature/fix PRs in this round have merged, then merge this last so the release commit tags the bump.

## What lands in 0.61.5

Full commit range since [c861fbac](https://github.com/AltimateAI/vscode-dbt-power-user/commit/c861fbac9e6eeabff91ea807b41c01a6b28116e2) (the 0.61.4 bump):

### Bug fixes — user-facing

| PR | Status | Issue / Ticket | Summary |
|---|---|---|---|
| [#1968](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1968) | ✅ merged | AI-6727 | CTE profiler reports 0 rows on Snowflake/Oracle (case-folding lookup) |
| [#1965](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1965) | ✅ merged | AI-6710 | "Get distinct column values" fails with `result.flat is not a function` |
| [#1962](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1962) | ✅ merged | — | Doc-editor settings / help drawer won't reopen after close |
| [#1953](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1953) | ✅ merged | — | Drop unused `nonExistingAllowListFolders` telemetry + fix warn condition |
| [#1973](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1973) | open, ready | AI-6726 (via lib) | Bumps `@altimateai/dbt-integration` to `0.3.2` — pulls in Validate SQL `database`-through-the-altimate-core-schema fix |
| [#1974](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1974) | open, ready | AI-6693 | Map `unique_id` → `uniqueId` for `/sqltomodel` POST — fixes "Convert to dbt model" silently failing |

### Features

| PR | Status | Summary |
|---|---|---|
| [#1966](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1966) | ✅ merged | Add Altimate Code action links to model / macro / YAML column hover tooltips |

### Maintenance / docs / dev-tooling

| PR | Status | Summary |
|---|---|---|
| [#1969](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1969) | ✅ merged | Dep: drop unused `chai` and `@types/chai` from devDependencies |
| [#1951](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1951) | ✅ merged | Drop CTE-parser mid-edit warnings to debug log level |
| [#1955](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1955) | ✅ merged | Fix prettier formatting drift after prettier-eslint 16 bump |
| [#1948](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1948) | ✅ merged | Migrate DataPilot docs to Altimate Code + refresh troubleshooting |
| [#1902](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1902) | ✅ merged | Dep: bump `@vscode/vsce` from 2.32.0 to 3.9.1 |
| [#1963](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1963) | ✅ merged | Dep: bump `sqlfluff` in test-fixtures/jaffle-shop-duckdb |
| [#1964](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1964) | ✅ merged | Dep: bump `idna` in test-fixtures/jaffle-shop-duckdb |

### AI-6671 sub-ticket coverage

Of the AI-6671 SA-report children, this release ships fixes for **AI-6726, AI-6727, AI-6693, AI-6710**. The remaining children are out of scope:

- AI-6694 — closed not-a-bug
- AI-6695 — already shipped in 0.61.x earlier
- AI-6728 — upstream-blocked on `sqlguard-core`, no extension-side fix

## Versioning note

This release contains one `feat:` commit ([#1966](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1966) — hover-tooltip Altimate Code action links). Per strict semver that argues for a minor bump (`0.62.0`) rather than a patch (`0.61.5`). The repo's recent history has been lax — patch bumps have shipped with mixed content too. Recommending `0.61.5` because the headliners are bug fixes from the SA report and the feature is small / additive, but happy to flip to `0.62.0` if you want the version number to reflect the feature inclusion more prominently.

## Release plan

1. Merge [#1973](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1973).
2. Merge [#1974](https://github.com/AltimateAI/vscode-dbt-power-user/pull/1974).
3. Merge this PR last.
4. Tag `v0.61.5` on the resulting `master` commit; release pipeline picks it up.

If anything in 1–3 changes scope, this bump is a 1-character edit.

## Diff

Just `package.json` (`version`) and `package-lock.json` (root `version` entries × 2). Mirrors the previous bump shape from [c861fbac](https://github.com/AltimateAI/vscode-dbt-power-user/commit/c861fbac9e6eeabff91ea807b41c01a6b28116e2).

## Test plan

- [x] Diff scoped to the three `"version"` strings; no other changes
- [ ] Reviewer: confirm version-bump-size choice (`0.61.5` patch vs `0.62.0` minor given #1966 is `feat:`)
- [ ] After merge: tag `v0.61.5` and cut release