### PR TITLE
fix: guard Validate SQL and Visualize SQL against the compiled-preview pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -991,7 +991,7 @@
         {
           "command": "dbtPowerUser.sqlLineage",
           "group": "dbt@8",
-          "when": "resourceLangId =~ /^sql$|^jinja-sql$/"
+          "when": "resourceLangId =~ /^sql$|^jinja-sql$/ && resourceScheme != 'query-preview'"
         },
         {
           "command": "dbtPowerUser.testCurrentModel",
@@ -1016,7 +1016,7 @@
         {
           "command": "dbtPowerUser.validateSql",
           "group": "dbt@4",
-          "when": "resourceLangId =~ /^sql$|^jinja-sql$/"
+          "when": "resourceLangId =~ /^sql$|^jinja-sql$/ && resourceScheme != 'query-preview'"
         },
         {
           "command": "dbtPowerUser.bigqueryCostEstimate",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1016,6 +1016,17 @@ export class VSCodeCommands implements Disposable {
         },
       ),
       commands.registerCommand("dbtPowerUser.sqlLineage", async () => {
+        const activeUri = window.activeTextEditor?.document.uri;
+        if (activeUri?.scheme === SqlPreviewContentProvider.SCHEME) {
+          // The compiled-SQL preview is a read-only derived artifact served by
+          // a TextDocumentContentProvider; workspace.fs has no provider for its
+          // scheme, so reading it throws ENOPRO. Visualize SQL operates on the
+          // source model, so there is nothing to visualize from the preview.
+          window.showInformationMessage(
+            "Visualize SQL runs on a dbt model file, not the compiled SQL preview.",
+          );
+          return;
+        }
         window.withProgress(
           {
             title: "Retrieving SQL visualization",

--- a/src/commands/validateSql.ts
+++ b/src/commands/validateSql.ts
@@ -91,6 +91,16 @@ export class ValidateSql {
     }
     const activedoc = window.activeTextEditor;
     const currentFilePath = activedoc.document.uri;
+    if (currentFilePath.scheme === SqlPreviewContentProvider.SCHEME) {
+      // The compiled-SQL preview is a read-only derived artifact served by a
+      // TextDocumentContentProvider; workspace.fs has no provider for its
+      // scheme, so reading it throws ENOPRO. Validate SQL operates on the
+      // source model, so there is nothing to validate from the preview.
+      window.showInformationMessage(
+        "Validate SQL runs on a dbt model file, not the compiled SQL preview.",
+      );
+      return;
+    }
     const project = this.dbtProjectContainer.findDBTProject(currentFilePath);
     if (!project) {
       await window.showErrorMessage("Unable to build project");
@@ -191,12 +201,7 @@ export class ValidateSql {
       models: parentModels,
     };
     const response = await this.getProject()?.validateSql(request);
-    const activeUri = window.activeTextEditor?.document.uri;
-    if (activeUri.scheme === SqlPreviewContentProvider.SCHEME) {
-      // current focus on compiled sql document
-      return;
-    }
-    const compileSQLUri = activeUri.with({
+    const compileSQLUri = currentFilePath.with({
       scheme: SqlPreviewContentProvider.SCHEME,
     });
     const isOpen = !!window.visibleTextEditors.find(

--- a/src/test/suite/sqlPreviewCommandGuard.test.ts
+++ b/src/test/suite/sqlPreviewCommandGuard.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "@jest/globals";
+
+/**
+ * Customer UAT surfaced an error when "Validate SQL" or "Visualize SQL (Beta)"
+ * was run with the compiled-SQL preview pane focused:
+ *
+ *   ENOPRO: No file system provider found for resource
+ *   'query-preview:/…/customers.sql'
+ *
+ * Root cause: both commands read the active editor's content with
+ * `workspace.fs.readFile(uri)`. The compiled preview is served by a
+ * `TextDocumentContentProvider` registered for the `query-preview` scheme
+ * (`SqlPreviewContentProvider.SCHEME`). `workspace.fs.*` does not route through
+ * content providers — it looks up a `FileSystemProvider`, finds none for
+ * `query-preview`, and throws `ENOPRO`.
+ *
+ *   - validateSql.ts          — read at L131; an existing scheme guard sat
+ *                               AFTER the read, so it never prevented the crash.
+ *   - sqlLineagePanel.ts       — read at L159; no guard at all. The command
+ *                               handler lives in commands/index.ts.
+ *
+ * The fix has two layers, both characterized below:
+ *   1. Menu: `editor/context` when-clause gains `resourceScheme != 'query-preview'`
+ *      so the items don't appear on the preview pane.
+ *   2. Handler: each command early-returns with an info toast when the active
+ *      editor is the preview, before any `workspace.fs` call (covers the
+ *      Command Palette path, which has no when-gating).
+ *
+ * These tests mirror the guard logic (same characterization style as
+ * bigQueryCostEstimate.test.ts) rather than instantiating the heavy command
+ * classes / VS Code host.
+ */
+describe("compiled-preview guard for Validate SQL / Visualize SQL", () => {
+  // SqlPreviewContentProvider.SCHEME
+  const PREVIEW_SCHEME = "query-preview";
+
+  type Uri = { scheme: string };
+
+  describe("Layer 2 — handler control flow around workspace.fs.readFile", () => {
+    /**
+     * Pre-fix validateSql: the file is read first and the scheme is only
+     * checked afterwards, so a preview URI reaches `readFile` and throws.
+     */
+    function preFixHandlerFlow(uri: Uri): string[] {
+      const steps: string[] = [];
+      steps.push("readFile"); // workspace.fs.readFile(currentFilePath)
+      if (uri.scheme === PREVIEW_SCHEME) {
+        steps.push("return"); // guard, but too late to help
+      }
+      return steps;
+    }
+
+    /**
+     * Post-fix (both handlers): the scheme is checked at the top, before any
+     * `workspace.fs` call. Preview → info toast + early return; anything else
+     * proceeds to read.
+     */
+    function postFixHandlerFlow(uri: Uri): string[] {
+      const steps: string[] = [];
+      if (uri.scheme === PREVIEW_SCHEME) {
+        steps.push("showInformationMessage");
+        steps.push("return");
+        return steps;
+      }
+      steps.push("readFile");
+      return steps;
+    }
+
+    it("pre-fix: a preview URI reaches readFile (the ENOPRO crash)", () => {
+      const steps = preFixHandlerFlow({ scheme: PREVIEW_SCHEME });
+      expect(steps).toContain("readFile");
+      // the guard runs, but only after the crashing read
+      expect(steps.indexOf("readFile")).toBeLessThan(steps.indexOf("return"));
+    });
+
+    it("post-fix: a preview URI short-circuits before any fs read", () => {
+      const steps = postFixHandlerFlow({ scheme: PREVIEW_SCHEME });
+      expect(steps).not.toContain("readFile");
+      expect(steps).toEqual(["showInformationMessage", "return"]);
+    });
+
+    it("post-fix: a real file URI still proceeds to read", () => {
+      expect(postFixHandlerFlow({ scheme: "file" })).toEqual(["readFile"]);
+    });
+
+    it("post-fix: a remote source URI still proceeds (denylist, not file-only)", () => {
+      // vscode-remote: (SSH / Codespaces / WSL) must keep working
+      expect(postFixHandlerFlow({ scheme: "vscode-remote" })).toEqual([
+        "readFile",
+      ]);
+    });
+  });
+
+  describe("Layer 1 — editor/context when-clause visibility", () => {
+    /**
+     * Mirrors the when-clause applied to dbtPowerUser.validateSql and
+     * dbtPowerUser.sqlLineage:
+     *   resourceLangId =~ /^sql$|^jinja-sql$/ && resourceScheme != 'query-preview'
+     */
+    function menuItemVisible(langId: string, scheme: string): boolean {
+      return /^sql$|^jinja-sql$/.test(langId) && scheme !== PREVIEW_SCHEME;
+    }
+
+    it("visible on a source .sql / jinja-sql file", () => {
+      expect(menuItemVisible("sql", "file")).toBe(true);
+      expect(menuItemVisible("jinja-sql", "file")).toBe(true);
+    });
+
+    it("hidden on the compiled preview pane", () => {
+      expect(menuItemVisible("sql", PREVIEW_SCHEME)).toBe(false);
+    });
+
+    it("still visible on remote source files (denylist preserves vscode-remote)", () => {
+      expect(menuItemVisible("sql", "vscode-remote")).toBe(true);
+    });
+
+    it("still gated by language id (not shown on non-sql files)", () => {
+      expect(menuItemVisible("python", "file")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Running **Validate SQL** or **Visualize SQL (Beta)** with the compiled-SQL preview pane focused crashes with:

```
ENOPRO: No file system provider found for resource 'query-preview:/…/customers.sql'
```

The compiled preview is served by a `TextDocumentContentProvider` registered for the `query-preview` scheme. Both commands read the active editor's content with `workspace.fs.readFile()`, which routes through `FileSystemProvider`s (not content providers) — there is none for `query-preview`, so the read throws `ENOPRO`.

- `src/commands/validateSql.ts` — `workspace.fs.readFile(currentFilePath)` on the active editor URI. An existing scheme guard sat *after* the read, so it never prevented the crash.
- `src/webview_provider/sqlLineagePanel.ts` — `workspace.fs.readFile(currentFile)` on the tracked active editor URI, with no guard at all.

The other dbt commands offered on the preview's right-click menu (Run / Test / Compile / Convert to dbt Model / Estimate cost / Open target SQL) do **not** crash — they read via `document.getText()` or resolve the model by name — so only these two needed fixing.

## Fix

**Hide on the preview (menu layer).** Added `&& resourceScheme != 'query-preview'` to the `editor/context` `when` clause for `dbtPowerUser.validateSql` and `dbtPowerUser.sqlLineage`. The denylist form (`!= 'query-preview'`, not `== 'file'`) keeps the items available for remote-SSH / Codespaces / WSL source files.

**Guard the handlers (defensive layer).** The Command Palette has no `when`-gating, so both commands are still invocable from it regardless of focus. Each handler now early-returns with a one-line info toast when the active editor is the preview, before any `workspace.fs` call:

> Validate SQL runs on a dbt model file, not the compiled SQL preview.

For `validateSql` the existing too-late guard was relocated to the top of the handler, and `compileSQLUri` is now derived from the source file path (also removes a latent `undefined.scheme` access).

## Verification

Built and sideloaded into code-server (DuckDB jaffle-shop, dialect-independent — the failure fires before any warehouse/backend call):

| Scenario | Before | After |
|---|---|---|
| Preview pane right-click menu | both commands listed | both commands hidden |
| Validate SQL via Palette, preview focused | `ENOPRO` error toast | info toast, no crash |
| Visualize SQL via Palette, preview focused | `ENOPRO` error toast | info toast, no crash |
| Source `.sql` file (menu + run) | works | unchanged — both commands present and functional |

Screenshots in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQL visualization and SQL validation commands now properly detect compiled SQL preview files and display informational messages instead of attempting processing on preview artifacts.
  * Context menu items for these commands are hidden when viewing preview files to prevent user confusion.

* **Tests**
  * Added comprehensive tests for preview file handling behavior and command visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->