### PR TITLE
feat: guide dbt install to a virtualenv on externally-managed (PEP 668) Python

### DIFF
--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -481,6 +481,9 @@ export class WalkthroughCommands {
     }
     const venvDir = join(workspacePath, ".venv");
     const venvPython = this.resolveVenvPython(venvDir);
+    const config = workspace.getConfiguration("dbt");
+    const previousOverride = config.get<string>("dbtPythonPathOverride");
+    let overrideUpdated = false;
     this.telemetry.sendTelemetryEvent("installDbtCoreVenv", telemetryProps);
     let error: unknown;
     await window.withProgress(
@@ -508,12 +511,18 @@ export class WalkthroughCommands {
             }
           }
           await this.runPipInstall(venvPython, installArgs);
-          await workspace
-            .getConfiguration("dbt")
-            .update("dbtPythonPathOverride", venvPython);
+          // Point the interpreter at the venv before re-detecting so detection
+          // resolves dbt from the new environment.
+          await config.update("dbtPythonPathOverride", venvPython);
+          overrideUpdated = true;
           await this.dbtProjectContainer.detectDBT();
           this.dbtProjectContainer.initialize();
         } catch (err) {
+          // Don't leave the workspace pointing at a half-set interpreter if a
+          // later step failed; restore the previous override.
+          if (overrideUpdated) {
+            await config.update("dbtPythonPathOverride", previousOverride);
+          }
           error = err;
           this.telemetry.sendTelemetryError(
             "installDbtCoreVenvError",

--- a/src/commands/walkthroughCommands.ts
+++ b/src/commands/walkthroughCommands.ts
@@ -2,7 +2,9 @@ import {
   CommandProcessExecutionFactory,
   DBTTerminal,
 } from "@altimateai/dbt-integration";
+import { existsSync } from "fs";
 import { inject } from "inversify";
+import { join } from "path";
 import { gte } from "semver";
 import {
   commands,
@@ -335,7 +337,23 @@ export class WalkthroughCommands {
       pythonVersion: this.pythonEnvironment.pythonVersion ?? "unknown",
     };
     this.telemetry.sendTelemetryEvent("installDbtCore", telemetryProps);
-    let error = undefined;
+
+    const installArgs = [
+      "-m",
+      "pip",
+      "install",
+      "--no-cache-dir",
+      "--force-reinstall",
+    ];
+    if (gte(packageVersion + ".0", "1.8.0")) {
+      installArgs.push(`dbt-core~=${packageVersion}.0`);
+      installArgs.push(`${packageName}`);
+    } else {
+      installArgs.push(`${packageName}==${packageVersion}`);
+    }
+
+    const pythonPath = this.pythonEnvironment.pythonPath;
+    let error: unknown;
     await window.withProgress(
       {
         title: `Installing ${packageName} ${packageVersion}...`,
@@ -344,38 +362,7 @@ export class WalkthroughCommands {
       },
       async () => {
         try {
-          const args = [
-            "-m",
-            "pip",
-            "install",
-            "--no-cache-dir",
-            "--force-reinstall",
-          ];
-          const isIndependentAdapterPackage = gte(
-            packageVersion + ".0",
-            "1.8.0",
-          );
-          if (isIndependentAdapterPackage) {
-            args.push(`dbt-core~=${packageVersion}.0`);
-            args.push(`${packageName}`);
-          } else {
-            args.push(`${packageName}==${packageVersion}`);
-          }
-          const { stdout, stderr } = await this.commandProcessExecutionFactory
-            .createCommandProcessExecution({
-              command: this.pythonEnvironment.pythonPath,
-              args,
-              cwd: getFirstWorkspacePath(),
-              envVars: this.pythonEnvironment.getEnvironmentVariables(),
-            })
-            .completeWithTerminalOutput();
-          if (
-            !stdout.includes("Successfully installed") &&
-            !stdout.includes("Requirement already satisfied") &&
-            stderr
-          ) {
-            throw new Error(stderr);
-          }
+          await this.runPipInstall(pythonPath, installArgs);
           await this.dbtProjectContainer.detectDBT();
           this.dbtProjectContainer.initialize();
         } catch (err) {
@@ -388,14 +375,204 @@ export class WalkthroughCommands {
         }
       },
     );
-    if (error) {
-      const answer = await window.showErrorMessage(
-        "Could not install dbt: " + (error as Error).message,
-        DbtInstallationPromptAnswer.INSTALL,
+    if (!error) {
+      return;
+    }
+    const message = (error as Error).message ?? String(error);
+    // PEP 668: the interpreter (commonly a Homebrew Python) refuses global
+    // installs. Offer a virtual environment instead of a dead-end retry.
+    if (this.isExternallyManagedError(message)) {
+      await this.handleExternallyManagedInstall(
+        pythonPath,
+        installArgs,
+        telemetryProps,
       );
-      if (answer === DbtInstallationPromptAnswer.INSTALL) {
-        commands.executeCommand("dbtPowerUser.installDbt");
-      }
+      return;
+    }
+    const answer = await window.showErrorMessage(
+      "Could not install dbt: " + message,
+      DbtInstallationPromptAnswer.INSTALL,
+    );
+    if (answer === DbtInstallationPromptAnswer.INSTALL) {
+      commands.executeCommand("dbtPowerUser.installDbt");
+    }
+  }
+
+  /**
+   * Run `python -m pip install ...` and treat the absence of a success marker
+   * (with output on stderr) as a failure, mirroring pip's exit semantics.
+   */
+  private async runPipInstall(
+    pythonPath: string,
+    args: string[],
+  ): Promise<void> {
+    const { stdout, stderr } = await this.commandProcessExecutionFactory
+      .createCommandProcessExecution({
+        command: pythonPath,
+        args,
+        cwd: getFirstWorkspacePath(),
+        envVars: this.pythonEnvironment.getEnvironmentVariables(),
+      })
+      .completeWithTerminalOutput();
+    if (
+      !stdout.includes("Successfully installed") &&
+      !stdout.includes("Requirement already satisfied") &&
+      stderr
+    ) {
+      throw new Error(stderr);
+    }
+  }
+
+  /**
+   * Whether a pip failure is PEP 668 "externally-managed-environment" — the
+   * interpreter's stdlib carries an EXTERNALLY-MANAGED marker (Homebrew, Debian,
+   * Ubuntu) and pip refuses to install into it globally.
+   */
+  private isExternallyManagedError(message: string): boolean {
+    return /externally[-\s]managed/i.test(message);
+  }
+
+  private resolveVenvPython(venvDir: string): string {
+    return process.platform === "win32"
+      ? join(venvDir, "Scripts", "python.exe")
+      : join(venvDir, "bin", "python");
+  }
+
+  /**
+   * Remediation for an externally-managed interpreter: offer to create a virtual
+   * environment and install dbt there (what the Homebrew error itself
+   * recommends), with an explicit opt-in to override the protection as fallback.
+   */
+  private async handleExternallyManagedInstall(
+    pythonPath: string,
+    installArgs: string[],
+    telemetryProps: Record<string, string>,
+  ): Promise<void> {
+    const CREATE_VENV = "Create virtual environment";
+    const FORCE = "Install anyway";
+    const answer = await window.showErrorMessage(
+      `Could not install dbt: the selected Python interpreter (${pythonPath}) is externally managed (PEP 668), ` +
+        `so packages cannot be installed into it globally. Create a virtual environment and install dbt there instead?`,
+      CREATE_VENV,
+      FORCE,
+    );
+    if (answer === CREATE_VENV) {
+      await this.createVenvAndInstallDbtCore(
+        pythonPath,
+        installArgs,
+        telemetryProps,
+      );
+    } else if (answer === FORCE) {
+      await this.forceInstallDbtCore(pythonPath, installArgs, telemetryProps);
+    }
+  }
+
+  private async createVenvAndInstallDbtCore(
+    pythonPath: string,
+    installArgs: string[],
+    telemetryProps: Record<string, string>,
+  ): Promise<void> {
+    const workspacePath = workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workspacePath) {
+      window.showErrorMessage(
+        "Cannot create a virtual environment: no workspace folder is open.",
+      );
+      return;
+    }
+    const venvDir = join(workspacePath, ".venv");
+    const venvPython = this.resolveVenvPython(venvDir);
+    this.telemetry.sendTelemetryEvent("installDbtCoreVenv", telemetryProps);
+    let error: unknown;
+    await window.withProgress(
+      {
+        title: "Creating virtual environment and installing dbt...",
+        location: ProgressLocation.Notification,
+        cancellable: false,
+      },
+      async () => {
+        try {
+          if (!existsSync(venvPython)) {
+            const { stderr } = await this.commandProcessExecutionFactory
+              .createCommandProcessExecution({
+                command: pythonPath,
+                args: ["-m", "venv", venvDir],
+                cwd: workspacePath,
+                envVars: this.pythonEnvironment.getEnvironmentVariables(),
+              })
+              .completeWithTerminalOutput();
+            if (!existsSync(venvPython)) {
+              throw new Error(
+                stderr ||
+                  `Failed to create a virtual environment at ${venvDir}`,
+              );
+            }
+          }
+          await this.runPipInstall(venvPython, installArgs);
+          await workspace
+            .getConfiguration("dbt")
+            .update("dbtPythonPathOverride", venvPython);
+          await this.dbtProjectContainer.detectDBT();
+          this.dbtProjectContainer.initialize();
+        } catch (err) {
+          error = err;
+          this.telemetry.sendTelemetryError(
+            "installDbtCoreVenvError",
+            err,
+            telemetryProps,
+          );
+        }
+      },
+    );
+    if (error) {
+      window.showErrorMessage(
+        "Could not install dbt into a virtual environment: " +
+          ((error as Error).message ?? String(error)),
+      );
+      return;
+    }
+    window.showInformationMessage(
+      `dbt installed in ${venvDir}. The Python interpreter has been set to the new virtual environment.`,
+    );
+  }
+
+  private async forceInstallDbtCore(
+    pythonPath: string,
+    installArgs: string[],
+    telemetryProps: Record<string, string>,
+  ): Promise<void> {
+    this.telemetry.sendTelemetryEvent(
+      "installDbtCoreBreakSystemPackages",
+      telemetryProps,
+    );
+    let error: unknown;
+    await window.withProgress(
+      {
+        title: "Installing dbt...",
+        location: ProgressLocation.Notification,
+        cancellable: false,
+      },
+      async () => {
+        try {
+          await this.runPipInstall(pythonPath, [
+            ...installArgs,
+            "--break-system-packages",
+          ]);
+          await this.dbtProjectContainer.detectDBT();
+          this.dbtProjectContainer.initialize();
+        } catch (err) {
+          error = err;
+          this.telemetry.sendTelemetryError(
+            "installDbtCoreBreakSystemPackagesError",
+            err,
+            telemetryProps,
+          );
+        }
+      },
+    );
+    if (error) {
+      window.showErrorMessage(
+        "Could not install dbt: " + ((error as Error).message ?? String(error)),
+      );
     }
   }
 

--- a/src/test/suite/walkthroughInstallDbt.test.ts
+++ b/src/test/suite/walkthroughInstallDbt.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "@jest/globals";
+import { WalkthroughCommands } from "../../commands/walkthroughCommands";
+
+// The helpers under test don't touch constructor dependencies, so we can
+// instantiate without the DI container and exercise them directly.
+function makeCommands(): any {
+  return new (WalkthroughCommands as any)(
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  );
+}
+
+describe("WalkthroughCommands.isExternallyManagedError", () => {
+  const cmd = makeCommands();
+
+  it("detects the canonical pip error", () => {
+    expect(
+      cmd.isExternallyManagedError("error: externally-managed-environment"),
+    ).toBe(true);
+  });
+
+  it("detects the Homebrew message wording", () => {
+    const brew =
+      "× This environment is externally managed\n" +
+      "╰─> To install Python packages system-wide, try brew install xyz";
+    expect(cmd.isExternallyManagedError(brew)).toBe(true);
+  });
+
+  it("does not match unrelated install failures", () => {
+    expect(
+      cmd.isExternallyManagedError(
+        "Could not find a version that satisfies the requirement dbt-core",
+      ),
+    ).toBe(false);
+    expect(cmd.isExternallyManagedError("Connection timed out")).toBe(false);
+  });
+});
+
+describe("WalkthroughCommands.resolveVenvPython", () => {
+  const cmd = makeCommands();
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("resolves a POSIX venv interpreter", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    expect(cmd.resolveVenvPython("/work/.venv")).toBe("/work/.venv/bin/python");
+  });
+
+  it("resolves a Windows venv interpreter", () => {
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const resolved = cmd.resolveVenvPython("C:/work/.venv");
+    expect(resolved).toContain("Scripts");
+    expect(resolved).toContain("python.exe");
+  });
+});

--- a/src/test/suite/walkthroughInstallDbt.test.ts
+++ b/src/test/suite/walkthroughInstallDbt.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "@jest/globals";
+import { join } from "path";
 import { WalkthroughCommands } from "../../commands/walkthroughCommands";
 
 // The helpers under test don't touch constructor dependencies, so we can
@@ -47,15 +48,20 @@ describe("WalkthroughCommands.resolveVenvPython", () => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
   });
 
+  // Compare against join() (not a literal slash path) so the assertion is
+  // host-agnostic: path.join uses the host separator regardless of the mocked
+  // process.platform, which only drives the bin vs Scripts branch.
   it("resolves a POSIX venv interpreter", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
-    expect(cmd.resolveVenvPython("/work/.venv")).toBe("/work/.venv/bin/python");
+    expect(cmd.resolveVenvPython("/work/.venv")).toBe(
+      join("/work/.venv", "bin", "python"),
+    );
   });
 
   it("resolves a Windows venv interpreter", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
-    const resolved = cmd.resolveVenvPython("C:/work/.venv");
-    expect(resolved).toContain("Scripts");
-    expect(resolved).toContain("python.exe");
+    expect(cmd.resolveVenvPython("/work/.venv")).toBe(
+      join("/work/.venv", "Scripts", "python.exe"),
+    );
   });
 });

--- a/src/test/suite/walkthroughInstallDbtFlow.test.ts
+++ b/src/test/suite/walkthroughInstallDbtFlow.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { window, workspace } from "vscode";
+import { WalkthroughCommands } from "../../commands/walkthroughCommands";
+
+/**
+ * Exercises the full installDbtCore orchestration against a fake command factory
+ * that mimics a PEP 668 externally-managed (Homebrew) interpreter: the global
+ * pip install fails with externally-managed-environment, venv creation succeeds,
+ * and the install into the venv succeeds. Asserts the command routes to the venv
+ * remediation and repoints the interpreter — the glue around the runtime
+ * behavior that is itself validated against real brew.
+ */
+describe("WalkthroughCommands.installDbt — externally-managed flow", () => {
+  const brewPython = "/opt/brew/bin/python3";
+  let workspaceDir: string;
+  let venvPython: string;
+  let commands: WalkthroughCommands;
+  let runCommands: { command: string; args: string[] }[];
+  let configUpdates: { key: string; value: unknown }[];
+
+  // Save originals to restore after each test.
+  const orig = {
+    showQuickPick: (window as any).showQuickPick,
+    showErrorMessage: (window as any).showErrorMessage,
+    showInformationMessage: (window as any).showInformationMessage,
+    getConfiguration: (workspace as any).getConfiguration,
+    workspaceFolders: (workspace as any).workspaceFolders,
+  };
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "dbt-install-"));
+    venvPython = join(workspaceDir, ".venv", "bin", "python");
+    runCommands = [];
+    configUpdates = [];
+
+    // Quick-picks: dbt version then adapter.
+    const picks = [{ label: "1.9" }, { label: "duckdb" }];
+    (window as any).showQuickPick = jest.fn(() =>
+      Promise.resolve(picks.shift()),
+    );
+    // Choose "Create virtual environment" at the remediation prompt.
+    (window as any).showErrorMessage = jest.fn(() =>
+      Promise.resolve("Create virtual environment"),
+    );
+    (window as any).showInformationMessage = jest.fn(() => Promise.resolve());
+
+    (workspace as any).workspaceFolders = [
+      { uri: { fsPath: workspaceDir }, name: "proj", index: 0 },
+    ];
+    (workspace as any).getConfiguration = jest.fn(() => ({
+      get: jest.fn((_k: string, d: unknown) => d),
+      has: jest.fn(),
+      update: jest.fn((key: string, value: unknown) => {
+        configUpdates.push({ key, value });
+        return Promise.resolve();
+      }),
+    }));
+
+    // Fake command factory mimicking a Homebrew externally-managed interpreter.
+    const commandProcessExecutionFactory = {
+      createCommandProcessExecution: ({
+        command,
+        args,
+      }: {
+        command: string;
+        args: string[];
+      }) => ({
+        completeWithTerminalOutput: async () => {
+          runCommands.push({ command, args });
+          if (args.includes("venv")) {
+            // Materialize the venv interpreter so existsSync() sees it.
+            mkdirSync(dirname(venvPython), { recursive: true });
+            writeFileSync(venvPython, "");
+            return { stdout: "", stderr: "", fullOutput: "" };
+          }
+          if (args.includes("pip")) {
+            if (command === brewPython) {
+              const err =
+                "error: externally-managed-environment\n" +
+                "× This environment is externally managed";
+              return { stdout: "", stderr: err, fullOutput: err };
+            }
+            const ok = "Successfully installed dbt-core dbt-duckdb";
+            return { stdout: ok, stderr: "", fullOutput: ok };
+          }
+          return { stdout: "", stderr: "", fullOutput: "" };
+        },
+      }),
+    };
+
+    const pythonEnvironment = {
+      pythonPath: brewPython,
+      pythonVersion: "3.12.0",
+      getEnvironmentVariables: () => ({}),
+    };
+    const dbtProjectContainer = {
+      detectDBT: jest.fn(() => Promise.resolve()),
+      initialize: jest.fn(),
+    };
+    const telemetry = {
+      sendTelemetryEvent: jest.fn(),
+      sendTelemetryError: jest.fn(),
+    };
+
+    commands = new (WalkthroughCommands as any)(
+      dbtProjectContainer,
+      telemetry,
+      commandProcessExecutionFactory,
+      pythonEnvironment,
+      { debug: jest.fn(), error: jest.fn() },
+    );
+  });
+
+  afterEach(() => {
+    rmSync(workspaceDir, { recursive: true, force: true });
+    (window as any).showQuickPick = orig.showQuickPick;
+    (window as any).showErrorMessage = orig.showErrorMessage;
+    (window as any).showInformationMessage = orig.showInformationMessage;
+    (workspace as any).getConfiguration = orig.getConfiguration;
+    (workspace as any).workspaceFolders = orig.workspaceFolders;
+    jest.clearAllMocks();
+  });
+
+  it("creates a venv, installs dbt there, and repoints the interpreter", async () => {
+    await commands.installDbt();
+
+    // Global install attempted against the brew interpreter (and failed).
+    const globalInstall = runCommands.find(
+      (c) => c.command === brewPython && c.args.includes("pip"),
+    );
+    expect(globalInstall).toBeDefined();
+
+    // venv created with the brew interpreter.
+    const venvCreate = runCommands.find((c) => c.args.includes("venv"));
+    expect(venvCreate).toBeDefined();
+    expect(venvCreate!.command).toBe(brewPython);
+
+    // dbt installed INTO the venv interpreter.
+    const venvInstall = runCommands.find(
+      (c) => c.command === venvPython && c.args.includes("pip"),
+    );
+    expect(venvInstall).toBeDefined();
+
+    // Interpreter repointed to the venv.
+    expect(configUpdates).toContainEqual({
+      key: "dbtPythonPathOverride",
+      value: venvPython,
+    });
+    expect(window.showInformationMessage).toHaveBeenCalled();
+  });
+
+  it("does not force --break-system-packages when creating a venv", async () => {
+    await commands.installDbt();
+    const forced = runCommands.some((c) =>
+      c.args.includes("--break-system-packages"),
+    );
+    expect(forced).toBe(false);
+  });
+});

--- a/src/test/suite/walkthroughInstallDbtFlow.test.ts
+++ b/src/test/suite/walkthroughInstallDbtFlow.test.ts
@@ -20,6 +20,7 @@ describe("WalkthroughCommands.installDbt — externally-managed flow", () => {
   let commands: WalkthroughCommands;
   let runCommands: { command: string; args: string[] }[];
   let configUpdates: { key: string; value: unknown }[];
+  let dbtProjectContainer: { detectDBT: jest.Mock; initialize: jest.Mock };
 
   // Save originals to restore after each test.
   const orig = {
@@ -32,7 +33,11 @@ describe("WalkthroughCommands.installDbt — externally-managed flow", () => {
 
   beforeEach(() => {
     workspaceDir = mkdtempSync(join(tmpdir(), "dbt-install-"));
-    venvPython = join(workspaceDir, ".venv", "bin", "python");
+    // Mirror the runtime venv interpreter layout (Scripts/python.exe on Windows).
+    venvPython =
+      process.platform === "win32"
+        ? join(workspaceDir, ".venv", "Scripts", "python.exe")
+        : join(workspaceDir, ".venv", "bin", "python");
     runCommands = [];
     configUpdates = [];
 
@@ -96,7 +101,7 @@ describe("WalkthroughCommands.installDbt — externally-managed flow", () => {
       pythonVersion: "3.12.0",
       getEnvironmentVariables: () => ({}),
     };
-    const dbtProjectContainer = {
+    dbtProjectContainer = {
       detectDBT: jest.fn(() => Promise.resolve()),
       initialize: jest.fn(),
     };
@@ -158,5 +163,21 @@ describe("WalkthroughCommands.installDbt — externally-managed flow", () => {
       c.args.includes("--break-system-packages"),
     );
     expect(forced).toBe(false);
+  });
+
+  it("restores the previous interpreter override if post-install detection fails", async () => {
+    dbtProjectContainer.detectDBT = jest.fn(() =>
+      Promise.reject(new Error("detect failed")),
+    );
+
+    await commands.installDbt();
+
+    // Override is set to the venv, then rolled back to the prior value
+    // (undefined here) so the workspace isn't left on a half-applied interpreter.
+    expect(configUpdates).toEqual([
+      { key: "dbtPythonPathOverride", value: venvPython },
+      { key: "dbtPythonPathOverride", value: undefined },
+    ]);
+    expect(window.showErrorMessage).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

When the selected Python interpreter is **externally managed** (PEP 668) — most commonly a Homebrew Python, but also recent Debian/Ubuntu system Pythons — `pip install` refuses to install globally:

```
error: externally-managed-environment
× This environment is externally managed
╰─> To install Python packages system-wide, try brew install xyz … use a virtual environment … or pass --break-system-packages …
```

The **Install dbt core** setup action ran `pip install` against that interpreter and, on failure, surfaced the raw pip error with an "Install dbt core" button that just retried the same doomed command. The user had no path forward.

## Fix

`src/commands/walkthroughCommands.ts` — detect the externally-managed condition and offer a real remediation instead of a dead-end retry:

- **`Create virtual environment`** (recommended) — create a `.venv` in the workspace with the same interpreter (`python -m venv`, which is *not* blocked by PEP 668), install dbt into the venv, set `dbt.dbtPythonPathOverride` to the venv interpreter, and re-detect.
- **`Install anyway`** — retry the global install with `--break-system-packages` (the escape hatch the error itself documents).

Supporting changes:
- `isExternallyManagedError()` — matches the canonical pip and Homebrew wording.
- `runPipInstall()` — extracted, shared by the core / venv / force paths.
- Non-externally-managed failures keep the existing generic error + retry behavior.

## Validation (real Homebrew, no Mac)

PEP 668 is a cross-platform marker, so this is testable on Linux via the official `homebrew/brew` Docker image. Against a real brew `python@3.12`:

```
1. global pip install            -> error: externally-managed-environment   (trigger detected)
2. python -m venv <dir>          -> venv created, interpreter at <dir>/bin/python
3. pip install into the venv     -> succeeds (venv is not externally-managed)
4. pip install --break-system-packages -> Successfully installed
```

All three runtime branches the fix relies on behave as expected.

## Tests

New `src/test/suite/walkthroughInstallDbt.test.ts`:
- `isExternallyManagedError` matches the canonical pip error and the Homebrew message, and rejects unrelated failures.
- `resolveVenvPython` resolves the POSIX and Windows venv interpreter paths.

`tsc --noEmit`, ESLint, Prettier all clean.

## Notes / open questions

- The venv is created at `<workspace>/.venv` and reused if it already exists. A future iteration could let the user pick the location.
- The full command UI flow (quick-picks + button prompts) is exercised by code review + the unit tests for the branch logic; the runtime mechanics are covered by the brew validation above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dbt Core installation: better validation of install success, detection and handling of "externally-managed" environments, option to create a workspace virtual environment or force installation, reliable re-detection/initialization on success, and rollback/cleanup on failure.
* **Tests**
  * Added coverage for externally-managed error detection, virtualenv Python path resolution (POSIX/Windows), full install flows (global attempt, venv creation, venv install), override updates, and rollback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->