### PR TITLE
fix: skip Lineage:getStartingNode telemetry for non-dbt files

### DIFF
--- a/src/test/suite/newLineagePanel.test.ts
+++ b/src/test/suite/newLineagePanel.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { workspace } from "vscode";
+import { window, workspace } from "vscode";
 import { NewLineagePanel } from "../../webview_provider/newLineagePanel";
 
 describe("NewLineagePanel", () => {
@@ -140,6 +140,59 @@ describe("NewLineagePanel", () => {
             }),
           }),
         }),
+      );
+    });
+  });
+
+  describe("getStartingNode — telemetry noise on non-dbt files", () => {
+    // Manifest is loaded (skips the "No event found" branch) but neither the
+    // node map nor the function map contains the active file's name, so control
+    // reaches the "No node found for <name>" dbtTerminal.info call.
+    const eventWithNoMatch = {
+      event: {
+        nodeMetaMap: { lookupByBaseName: jest.fn().mockReturnValue(undefined) },
+        functionMetaMap: { get: jest.fn().mockReturnValue(undefined) },
+      },
+    };
+
+    const setActiveFile = (fileName: string) => {
+      (window as any).activeTextEditor = {
+        document: { fileName, uri: { path: fileName } },
+      };
+    };
+
+    beforeEach(() => {
+      (panel as any).queryManifestService.getEventByCurrentProject = jest
+        .fn()
+        .mockReturnValue(eventWithNoMatch);
+      (panel as any).dbtLineageService = { createTable: jest.fn() };
+    });
+
+    it("does NOT send telemetry when the active file is a non-dbt file", () => {
+      // A shell script can never be a dbt node — this event is pure noise and
+      // accounts for the bulk of the in-the-wild Lineage:getStartingNode volume.
+      setActiveFile("/ws/scripts/etc-backfill_6.sh");
+
+      (panel as any).getStartingNode();
+
+      // dbtTerminal.info(name, message, sendTelemetry): the 3rd arg must be false.
+      expect((panel as any).dbtTerminal.info).toHaveBeenCalledWith(
+        "Lineage:getStartingNode",
+        expect.stringContaining("No node found"),
+        false,
+      );
+    });
+
+    it("still sends telemetry for a dbt file with no matching node", () => {
+      // A .sql file with no node IS a legitimate diagnostic — keep telemetry.
+      setActiveFile("/ws/models/orphan.sql");
+
+      (panel as any).getStartingNode();
+
+      expect((panel as any).dbtTerminal.info).toHaveBeenCalledWith(
+        "Lineage:getStartingNode",
+        expect.stringContaining("No node found"),
+        true,
       );
     });
   });

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -718,9 +718,15 @@ export class NewLineagePanel
       return { node, aiEnabled };
     }
 
+    // Only report this as telemetry for actual dbt files. A non-dbt file (e.g. a
+    // .sh/.md script) can never be a dbt node, so the panel re-rendering on every
+    // editor switch would otherwise emit this event constantly — pure noise. Keep
+    // the output-channel log for debugging but skip telemetry for non-dbt files.
+    const isDbtFile = NewLineagePanel.DBT_FILE_EXTENSIONS.includes(ext);
     this.dbtTerminal.info(
       "Lineage:getStartingNode",
       `No node found for ${tableName}`,
+      isDbtFile,
     );
     return {
       aiEnabled,


### PR DESCRIPTION
## Problem
With the model lineage panel open, switching the active editor to a **non-dbt file** (`.sh`, `.md`, `.txt`, …) emits an info-level `Lineage:getStartingNode` telemetry event (`No node found for <file>`) on **every editor change**. A non-dbt file can never be a dbt node, so this is expected behavior being over-reported — and in the field it's the single highest-volume named telemetry event (~1,900 events across ~108 machines in 24h on the current release, all integration modes, all platforms).

## Root cause
`getStartingNode` (`src/webview_provider/newLineagePanel.ts`) looks the active file up in the node/function maps; for a non-dbt file the lookup never matches and control reaches `dbtTerminal.info("Lineage:getStartingNode", …)`, which defaults `sendTelemetry=true`.

This is a **distinct branch** from the one fixed by #1931 (the `No event found` manifest-load race — same event name, different message). That fix didn't touch this `No node found for <file>` path.

## Fix
Gate the telemetry on the file extension: keep the output-channel log for debugging, but pass `sendTelemetry=false` when the active file isn't a dbt file (`.sql`/`.py`/`.csv`). A dbt file with no matching node still reports telemetry — that remains a legitimate diagnostic.

## Pre/post-fix repro (unit test, mocked telemetry)
Telemetry can't be reliably asserted through Playwright, so coverage is a mocked-`DBTTerminal` test driving `getStartingNode`:

**Before** (against unpatched code):
```
✕ does NOT send telemetry when the active file is a non-dbt file
    Expected: "Lineage:getStartingNode", StringContaining "No node found", false
    Received: "Lineage:getStartingNode", "No node found for etc-backfill_6.sh"   ← no sendTelemetry arg → defaults true
```

**After**:
```
✓ does NOT send telemetry when the active file is a non-dbt file
✓ still sends telemetry for a dbt file with no matching node
Tests: 7 passed, 7 total
```

## Risk
Minimal, localized — one call-site argument + a regression test; output-channel logging is unchanged. Heads-up: open PR #1905 (ERD overlay) also edits `getStartingNode` (a different line), so a trivial rebase may be needed depending on merge order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry logging now only occurs for recognized dbt files, preventing extraneous log entries for non-dbt scripts.

* **Tests**
  * Added test coverage for getStartingNode telemetry behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AltimateAI/vscode-dbt-power-user/pull/1984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->