### PR TITLE
feat: root model lineage from a source when its YAML is open

### DIFF
--- a/src/test/suite/newLineagePanel.test.ts
+++ b/src/test/suite/newLineagePanel.test.ts
@@ -246,6 +246,9 @@ describe("NewLineagePanel — source YAML rooting", () => {
     panel = Object.create(NewLineagePanel.prototype);
     (panel as any)._panel = { webview: { postMessage: jest.fn() } };
     (panel as any).altimate = { enabled: jest.fn().mockReturnValue(false) };
+    (panel as any).validationProvider = {
+      isAuthenticated: jest.fn().mockReturnValue(false),
+    };
     (panel as any).dbtTerminal = {
       info: jest.fn(),
       debug: jest.fn(),
@@ -585,9 +588,7 @@ describe("NewLineagePanel — source YAML rooting", () => {
     // threading this is 2 (guard + getStartingNode), iterating
     // sourceMetaMap twice per cursor move.
     expect(resolveSpy).toHaveBeenCalledTimes(1);
-    expect(
-      (panel as any)._panel.webview.postMessage,
-    ).toHaveBeenCalledWith(
+    expect((panel as any)._panel.webview.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         command: "render",
         args: expect.objectContaining({

--- a/src/test/suite/newLineagePanel.test.ts
+++ b/src/test/suite/newLineagePanel.test.ts
@@ -316,6 +316,41 @@ describe("NewLineagePanel — source YAML rooting", () => {
     );
   });
 
+  it("roots the same way for a .yaml file (not just .yml)", () => {
+    const filePath = "/proj/models/sources/identifies.yaml";
+    const sourceMetaMap = new Map([
+      [
+        "segment_website_production",
+        {
+          package_name: "proj",
+          name: "segment_website_production",
+          tables: [sourceTable("identifies", filePath)],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    (window as any).activeTextEditor = makeEditor(
+      filePath,
+      "sources:\n  - name: segment_website_production\n    tables:\n      - name: identifies\n",
+    );
+
+    const result = (panel as any).getStartingNode();
+
+    expect(result.node).toEqual({
+      table: "source.proj.segment_website_production.identifies",
+    });
+    expect((panel as any).dbtLineageService.createTable).toHaveBeenCalledWith(
+      expect.anything(),
+      filePath,
+      "source.proj.segment_website_production.identifies",
+    );
+  });
+
   it("picks the source table the cursor sits within when the file has many", () => {
     const filePath = "/proj/models/sources/multi.yml";
     const body = [

--- a/src/test/suite/newLineagePanel.test.ts
+++ b/src/test/suite/newLineagePanel.test.ts
@@ -217,6 +217,7 @@ describe("NewLineagePanel — source YAML rooting", () => {
         uri: { fsPath: filePath, path: filePath },
         lineCount: lines.length,
         lineAt: (line: number) => ({ text: lines[line] ?? "" }),
+        getText: () => body,
       },
       selection: { active: { line: cursorLine } },
     };
@@ -423,6 +424,174 @@ describe("NewLineagePanel — source YAML rooting", () => {
     const result = (panel as any).getStartingNode();
 
     expect(result.node).toEqual({ table: "source.proj.seg.identifies" });
+  });
+
+  it("does not mistake a source-level name for a table declaration", () => {
+    const filePath = "/proj/models/sources/pages.yml";
+    // The SOURCE is named "pages" and one of its TABLES is also named
+    // "pages". With a plain line regex the source-level `- name: pages`
+    // (line 1) would anchor the table, so a cursor on the `tables:` line
+    // (line 2) would wrongly pick "pages"; the AST walk only sees table
+    // declarations, so nothing is at-or-above the cursor and the panel
+    // falls back to the file's first table.
+    const body = [
+      "sources:",
+      "  - name: pages",
+      "    tables:",
+      "      - name: identifies",
+      "      - name: pages",
+    ].join("\n");
+    const sourceMetaMap = new Map([
+      [
+        "pages",
+        {
+          package_name: "proj",
+          name: "pages",
+          tables: [
+            sourceTable("identifies", filePath),
+            sourceTable("pages", filePath),
+          ],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    (window as any).activeTextEditor = makeEditor(filePath, body, 2);
+
+    const result = (panel as any).getStartingNode();
+
+    expect(result.node).toEqual({ table: "source.proj.pages.identifies" });
+  });
+
+  it("disambiguates the same table name declared under two sources in one file", () => {
+    const filePath = "/proj/models/sources/events.yml";
+    const body = [
+      "sources:",
+      "  - name: seg",
+      "    tables:",
+      "      - name: events", // line 3
+      "  - name: ga",
+      "    tables:",
+      "      - name: events", // line 6
+    ].join("\n");
+    const sourceMetaMap = new Map([
+      [
+        "seg",
+        {
+          package_name: "proj",
+          name: "seg",
+          tables: [sourceTable("events", filePath)],
+        },
+      ],
+      [
+        "ga",
+        {
+          package_name: "proj",
+          name: "ga",
+          tables: [sourceTable("events", filePath)],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    // Cursor on line 6 → ga's "events", not seg's (a name-only lookup
+    // would find seg's declaration line for both candidates).
+    (window as any).activeTextEditor = makeEditor(filePath, body, 6);
+
+    const result = (panel as any).getStartingNode();
+
+    expect(result.node).toEqual({ table: "source.proj.ga.events" });
+  });
+
+  it("records lastRenderedSourceKey even when createTable returns undefined", () => {
+    const filePath = "/proj/models/sources/identifies.yml";
+    const sourceMetaMap = new Map([
+      [
+        "seg",
+        {
+          package_name: "proj",
+          name: "seg",
+          tables: [sourceTable("identifies", filePath)],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    (panel as any).dbtLineageService = {
+      createTable: jest.fn().mockReturnValue(undefined),
+    };
+    (window as any).activeTextEditor = makeEditor(
+      filePath,
+      "sources:\n  - name: seg\n    tables:\n      - name: identifies\n",
+    );
+
+    (panel as any).getStartingNode();
+
+    // The selection guard compares against this key; leaving it undefined on
+    // a failed createTable would re-trigger a full render on every cursor
+    // move until the service call succeeds.
+    expect((panel as any).lastRenderedSourceKey).toBe(
+      "source.proj.seg.identifies",
+    );
+  });
+
+  it("resolves the source only once per cursor-move render", () => {
+    const filePath = "/proj/models/sources/identifies.yml";
+    const sourceMetaMap = new Map([
+      [
+        "seg",
+        {
+          package_name: "proj",
+          name: "seg",
+          tables: [sourceTable("identifies", filePath)],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    const editor = makeEditor(
+      filePath,
+      "sources:\n  - name: seg\n    tables:\n      - name: identifies\n",
+      3,
+    );
+    (window as any).activeTextEditor = editor;
+    const resolveSpy = jest.spyOn(
+      panel as any,
+      "resolveSourceStartingNode" as any,
+    );
+
+    (panel as any).changedTextEditorSelection(editor);
+
+    // The guard's resolution is threaded into the render path; without the
+    // threading this is 2 (guard + getStartingNode), iterating
+    // sourceMetaMap twice per cursor move.
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (panel as any)._panel.webview.postMessage,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "render",
+        args: expect.objectContaining({
+          node: { table: "source.proj.seg.identifies" },
+        }),
+      }),
+    );
   });
 
   it("shows the missing-lineage message for a YAML that defines no source in this file", () => {

--- a/src/test/suite/newLineagePanel.test.ts
+++ b/src/test/suite/newLineagePanel.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { window, workspace } from "vscode";
 import { NewLineagePanel } from "../../webview_provider/newLineagePanel";
 
@@ -195,5 +202,224 @@ describe("NewLineagePanel", () => {
         true,
       );
     });
+  });
+});
+
+describe("NewLineagePanel — source YAML rooting", () => {
+  let panel: NewLineagePanel;
+
+  // Build a fake TextEditor over a source YAML body.
+  const makeEditor = (filePath: string, body: string, cursorLine = 0) => {
+    const lines = body.split("\n");
+    return {
+      document: {
+        fileName: filePath,
+        uri: { fsPath: filePath, path: filePath },
+        lineCount: lines.length,
+        lineAt: (line: number) => ({ text: lines[line] ?? "" }),
+      },
+      selection: { active: { line: cursorLine } },
+    };
+  };
+
+  const sourceTable = (name: string, filePath: string) => ({
+    name,
+    identifier: name,
+    path: filePath,
+    description: "",
+    columns: {},
+  });
+
+  const makeEvent = (sourceMetaMap: Map<string, any>) => ({
+    event: {
+      sourceMetaMap,
+      nodeMetaMap: { lookupByBaseName: jest.fn().mockReturnValue(undefined) },
+      functionMetaMap: new Map(),
+    },
+  });
+
+  beforeEach(() => {
+    panel = Object.create(NewLineagePanel.prototype);
+    (panel as any)._panel = { webview: { postMessage: jest.fn() } };
+    (panel as any).altimate = { enabled: jest.fn().mockReturnValue(false) };
+    (panel as any).dbtTerminal = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    };
+    (panel as any).dbtLineageService = {
+      createTable: jest.fn((_e: unknown, _u: unknown, key: string) => ({
+        table: key,
+      })),
+    };
+    (window as any).activeTextEditor = undefined;
+  });
+
+  afterEach(() => {
+    (window as any).activeTextEditor = undefined;
+  });
+
+  it("builds the source.<pkg>.<source>.<table> key for tables in a file", () => {
+    const filePath = "/proj/models/sources/identifies.yml";
+    const sourceMetaMap = new Map([
+      [
+        "segment_website_production",
+        {
+          package_name: "proj",
+          name: "segment_website_production",
+          tables: [sourceTable("identifies", filePath)],
+        },
+      ],
+    ]);
+    const matches = (panel as any).getSourceTablesForFile(
+      sourceMetaMap,
+      filePath,
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].key).toBe(
+      "source.proj.segment_website_production.identifies",
+    );
+  });
+
+  it("roots automatically at the only source table in the file", () => {
+    const filePath = "/proj/models/sources/identifies.yml";
+    const sourceMetaMap = new Map([
+      [
+        "segment_website_production",
+        {
+          package_name: "proj",
+          name: "segment_website_production",
+          tables: [sourceTable("identifies", filePath)],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    (window as any).activeTextEditor = makeEditor(
+      filePath,
+      "sources:\n  - name: segment_website_production\n    tables:\n      - name: identifies\n",
+    );
+
+    const result = (panel as any).getStartingNode();
+
+    expect(result.node).toEqual({
+      table: "source.proj.segment_website_production.identifies",
+    });
+    expect((panel as any).dbtLineageService.createTable).toHaveBeenCalledWith(
+      expect.anything(),
+      filePath,
+      "source.proj.segment_website_production.identifies",
+    );
+  });
+
+  it("picks the source table the cursor sits within when the file has many", () => {
+    const filePath = "/proj/models/sources/multi.yml";
+    const body = [
+      "sources:",
+      "  - name: seg",
+      "    tables:",
+      "      - name: identifies", // line 3
+      "      - name: tracks", //      line 4
+      "      - name: pages", //       line 5
+    ].join("\n");
+    const sourceMetaMap = new Map([
+      [
+        "seg",
+        {
+          package_name: "proj",
+          name: "seg",
+          tables: [
+            sourceTable("identifies", filePath),
+            sourceTable("tracks", filePath),
+            sourceTable("pages", filePath),
+          ],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    // Cursor on line 4 → the "tracks" table.
+    (window as any).activeTextEditor = makeEditor(filePath, body, 4);
+
+    const result = (panel as any).getStartingNode();
+
+    expect(result.node).toEqual({ table: "source.proj.seg.tracks" });
+  });
+
+  it("falls back to the first table when the cursor is above every declaration", () => {
+    const filePath = "/proj/models/sources/multi.yml";
+    const body = [
+      "sources:",
+      "  - name: seg",
+      "    tables:",
+      "      - name: identifies",
+      "      - name: tracks",
+    ].join("\n");
+    const sourceMetaMap = new Map([
+      [
+        "seg",
+        {
+          package_name: "proj",
+          name: "seg",
+          tables: [
+            sourceTable("identifies", filePath),
+            sourceTable("tracks", filePath),
+          ],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    // Cursor on line 0 (the `sources:` line), above any table name.
+    (window as any).activeTextEditor = makeEditor(filePath, body, 0);
+
+    const result = (panel as any).getStartingNode();
+
+    expect(result.node).toEqual({ table: "source.proj.seg.identifies" });
+  });
+
+  it("shows the missing-lineage message for a YAML that defines no source in this file", () => {
+    const filePath = "/proj/models/staging/schema.yml";
+    // The only source lives in a different file.
+    const sourceMetaMap = new Map([
+      [
+        "seg",
+        {
+          package_name: "proj",
+          name: "seg",
+          tables: [sourceTable("identifies", "/proj/models/sources/other.yml")],
+        },
+      ],
+    ]);
+    (panel as any).queryManifestService = {
+      getEventByCurrentProject: jest
+        .fn()
+        .mockReturnValue(makeEvent(sourceMetaMap)),
+      getProject: jest.fn().mockReturnValue(undefined),
+    };
+    (window as any).activeTextEditor = makeEditor(
+      filePath,
+      "models:\n  - name: stg_orders\n",
+    );
+
+    const result = (panel as any).getStartingNode();
+
+    expect(result.node).toBeUndefined();
+    expect(result.missingLineageMessage).toEqual(
+      expect.objectContaining({ type: "warning" }),
+    );
+    expect((panel as any).dbtLineageService.createTable).not.toHaveBeenCalled();
   });
 });

--- a/src/webview_provider/lineagePanel.ts
+++ b/src/webview_provider/lineagePanel.ts
@@ -24,6 +24,7 @@ export interface LineagePanelView extends WebviewViewProvider {
   eventMapChanged(eventMap: Map<string, ManifestCacheProjectAddedEvent>): void;
   changedActiveColorTheme(): void;
   changedActiveTextEditor(event: TextEditor | undefined): void;
+  changedTextEditorSelection(editor: TextEditor): void;
   handleCommand(message: { command: string; args: any }): Promise<void> | void;
 }
 
@@ -58,6 +59,13 @@ export class LineagePanel implements WebviewViewProvider, Disposable {
     window.onDidChangeActiveTextEditor((event: TextEditor | undefined) => {
       this.getPanel().changedActiveTextEditor(event);
     });
+    window.onDidChangeTextEditorSelection(
+      (event) => {
+        this.getPanel().changedTextEditorSelection(event.textEditor);
+      },
+      null,
+      this.disposables,
+    );
   }
 
   private getPanel() {

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -5,6 +5,7 @@ import {
   NodeMetaData,
   RESOURCE_TYPE_FUNCTION,
   RESOURCE_TYPE_SOURCE,
+  SourceMetaMap,
   SourceTable,
   Table,
 } from "@altimateai/dbt-integration";
@@ -16,6 +17,7 @@ import {
   ColorThemeKind,
   commands,
   ProgressLocation,
+  TextDocument,
   TextEditor,
   Webview,
   window,
@@ -35,6 +37,10 @@ import { extendErrorWithSupportLinks } from "../utils";
 import { AltimateWebviewProvider } from "./altimateWebviewProvider";
 import { LineagePanelView } from "./lineagePanel";
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 class DerivedCancellationTokenSource extends CancellationTokenSource {
   constructor(linkedToken: CancellationToken) {
     super();
@@ -52,6 +58,10 @@ export class NewLineagePanel
   protected panelDescription = "Lineage panel";
   private cllProgressResolve: () => void = () => {};
   private cancellationTokenSource: CancellationTokenSource | undefined;
+  // The source unique_id the panel last rooted at when a source YAML is the
+  // active file. Used to avoid redundant re-renders on every cursor move; the
+  // panel only re-roots when the cursor moves onto a different source table.
+  private lastRenderedSourceKey: string | undefined;
 
   public constructor(
     protected dbtProjectContainer: DBTProjectContainer,
@@ -82,6 +92,37 @@ export class NewLineagePanel
       return;
     }
     if (!this._panel) {
+      return;
+    }
+    // A different file is now active; forget the previously rooted source so a
+    // source YAML re-rooted later (or on return) is always re-rendered.
+    this.lastRenderedSourceKey = undefined;
+    this.renderStartingNode();
+  }
+
+  // Re-root the lineage when the cursor moves to a different source table
+  // within an open source YAML. This is what makes opening a `sources:` file
+  // and clicking on a `- name:` entry show that source's lineage, mirroring the
+  // dbt Cloud IDE. Guarded so ordinary cursor movement (same table, or any
+  // non-source file) never triggers a redundant re-render.
+  public changedTextEditorSelection(editor: TextEditor) {
+    if (!this._panel) {
+      return;
+    }
+    if (editor !== window.activeTextEditor) {
+      return;
+    }
+    const ext = path.extname(editor.document.fileName).toLowerCase();
+    if (!NewLineagePanel.SOURCE_YAML_EXTENSIONS.includes(ext)) {
+      return;
+    }
+    const event = this.queryManifestService.getEventByCurrentProject();
+    if (!event?.event) {
+      return;
+    }
+    const resolved = this.resolveSourceStartingNode(event.event, editor);
+    const key = resolved?.key;
+    if (key === this.lastRenderedSourceKey) {
       return;
     }
     this.renderStartingNode();
@@ -626,6 +667,11 @@ export class NewLineagePanel
 
   private static readonly DBT_FILE_EXTENSIONS = [".sql", ".py", ".csv"];
 
+  // Sources are declared in YAML, which has no 1:1 file→node mapping (one file
+  // can define many sources/tables). These extensions opt a file into the
+  // cursor-aware source resolution in `getStartingNode`.
+  private static readonly SOURCE_YAML_EXTENSIONS = [".yml", ".yaml"];
+
   private getFilename(): string | undefined {
     const editor = window.activeTextEditor;
     if (!editor) {
@@ -718,6 +764,24 @@ export class NewLineagePanel
       return { node, aiEnabled };
     }
 
+    // Source YAML: a model/seed/function basename never matches, so by here the
+    // active file may be a `sources:` definition. Root at the source the cursor
+    // is on (or the file's only source table).
+    if (NewLineagePanel.SOURCE_YAML_EXTENSIONS.includes(ext)) {
+      const resolved = this.resolveSourceStartingNode(event.event, editor);
+      if (resolved) {
+        const node = this.dbtLineageService.createTable(
+          event.event,
+          resolved.table.path ?? url,
+          resolved.key,
+        );
+        if (node) {
+          this.lastRenderedSourceKey = resolved.key;
+          return { node, aiEnabled };
+        }
+      }
+    }
+
     // Only report this as telemetry for actual dbt files. A non-dbt file (e.g. a
     // .sh/.md script) can never be a dbt node, so the panel re-rendering on every
     // editor switch would otherwise emit this event constantly — pure noise. Keep
@@ -732,6 +796,96 @@ export class NewLineagePanel
       aiEnabled,
       missingLineageMessage: this.getMissingLineageMessage(),
     };
+  }
+
+  // Resolve which source table the active YAML file should root the lineage at.
+  // Returns the dbt unique_id key (`source.<pkg>.<source>.<table>`) and the
+  // matched table. Prefers the table the cursor is on/under; falls back to the
+  // file's single table, then to the first declared table for determinism.
+  private resolveSourceStartingNode(
+    event: ManifestCacheProjectAddedEvent,
+    editor: TextEditor,
+  ): { key: string; sourceName: string; table: SourceTable } | undefined {
+    const { sourceMetaMap } = event;
+    const matches = this.getSourceTablesForFile(
+      sourceMetaMap,
+      editor.document.uri.fsPath,
+    );
+    if (matches.length === 0) {
+      return undefined;
+    }
+    if (matches.length === 1) {
+      return matches[0];
+    }
+    return this.pickSourceTableByCursor(matches, editor) ?? matches[0];
+  }
+
+  // All source tables whose definition file is `filePath`. One YAML can declare
+  // several sources, each with several tables, so this can return many matches.
+  private getSourceTablesForFile(
+    sourceMetaMap: SourceMetaMap,
+    filePath: string,
+  ): { key: string; sourceName: string; table: SourceTable }[] {
+    const target = path.normalize(filePath);
+    const matches: { key: string; sourceName: string; table: SourceTable }[] =
+      [];
+    for (const source of sourceMetaMap.values()) {
+      for (const table of source.tables) {
+        if (!table.path) {
+          continue;
+        }
+        if (path.normalize(table.path) !== target) {
+          continue;
+        }
+        matches.push({
+          key: `${RESOURCE_TYPE_SOURCE}.${source.package_name}.${source.name}.${table.name}`,
+          sourceName: source.name,
+          table,
+        });
+      }
+    }
+    return matches;
+  }
+
+  // Of the candidate tables in the file, pick the one whose `name:` declaration
+  // is the closest line at or above the cursor — i.e. the table the cursor sits
+  // within. Returns undefined when the cursor is above every declaration.
+  private pickSourceTableByCursor(
+    matches: { key: string; sourceName: string; table: SourceTable }[],
+    editor: TextEditor,
+  ): { key: string; sourceName: string; table: SourceTable } | undefined {
+    const cursorLine = editor.selection.active.line;
+    let best:
+      | { key: string; sourceName: string; table: SourceTable }
+      | undefined;
+    let bestLine = -1;
+    for (const match of matches) {
+      const declLine = this.findSourceTableLine(
+        editor.document,
+        match.table.name,
+      );
+      if (declLine >= 0 && declLine <= cursorLine && declLine > bestLine) {
+        best = match;
+        bestLine = declLine;
+      }
+    }
+    return best;
+  }
+
+  // Line number of a `- name: <table>` declaration in the document, or -1.
+  private findSourceTableLine(
+    document: TextDocument,
+    tableName: string,
+  ): number {
+    const pattern = new RegExp(
+      `^\\s*-?\\s*name:\\s*["']?${escapeRegExp(tableName)}["']?\\s*$`,
+    );
+    for (let line = 0; line < document.lineCount; line++) {
+      if (pattern.test(document.lineAt(line).text)) {
+        return line;
+      }
+    }
+    return -1;
   }
 
   protected renderWebviewView(webview: Webview) {

--- a/src/webview_provider/newLineagePanel.ts
+++ b/src/webview_provider/newLineagePanel.ts
@@ -23,6 +23,7 @@ import {
   window,
   workspace,
 } from "vscode";
+import { isMap, isScalar, isSeq, parseDocument } from "yaml";
 import { AltimateRequest } from "../altimate";
 import { DBTProject } from "../dbt_client/dbtProject";
 import { DBTProjectContainer } from "../dbt_client/dbtProjectContainer";
@@ -37,8 +38,23 @@ import { extendErrorWithSupportLinks } from "../utils";
 import { AltimateWebviewProvider } from "./altimateWebviewProvider";
 import { LineagePanelView } from "./lineagePanel";
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+// A source table resolved to the dbt unique_id key the lineage should root at
+// (`source.<pkg>.<source>.<table>`).
+interface ResolvedSourceTable {
+  key: string;
+  sourceName: string;
+  table: SourceTable;
+}
+
+// 0-based line of `offset` within `text`.
+function lineAtOffset(text: string, offset: number): number {
+  let line = 0;
+  for (let i = 0; i < offset && i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) {
+      line++;
+    }
+  }
+  return line;
 }
 
 class DerivedCancellationTokenSource extends CancellationTokenSource {
@@ -125,7 +141,9 @@ export class NewLineagePanel
     if (key === this.lastRenderedSourceKey) {
       return;
     }
-    this.renderStartingNode();
+    // Thread the resolution into the render so getStartingNode doesn't have
+    // to traverse sourceMetaMap a second time for the same cursor position.
+    this.renderStartingNode(resolved);
   }
 
   eventMapChanged(eventMap: Map<string, ManifestCacheProjectAddedEvent>): void {
@@ -160,13 +178,13 @@ export class NewLineagePanel
     this.renderStartingNode();
   }
 
-  private renderStartingNode() {
+  private renderStartingNode(resolvedSource?: ResolvedSourceTable) {
     if (!this._panel) {
       return;
     }
     this._panel.webview.postMessage({
       command: "render",
-      args: this.getStartingNode(),
+      args: this.getStartingNode(resolvedSource),
     });
   }
 
@@ -704,7 +722,7 @@ export class NewLineagePanel
     return { message, type: "warning" };
   }
 
-  private getStartingNode():
+  private getStartingNode(resolvedSource?: ResolvedSourceTable):
     | {
         node?: Table;
         aiEnabled: boolean;
@@ -768,15 +786,19 @@ export class NewLineagePanel
     // active file may be a `sources:` definition. Root at the source the cursor
     // is on (or the file's only source table).
     if (NewLineagePanel.SOURCE_YAML_EXTENSIONS.includes(ext)) {
-      const resolved = this.resolveSourceStartingNode(event.event, editor);
+      const resolved =
+        resolvedSource ?? this.resolveSourceStartingNode(event.event, editor);
       if (resolved) {
+        // Record the key before the createTable null-check: if the service
+        // fails for this key, the selection guard must still short-circuit
+        // instead of re-triggering a full render on every cursor move.
+        this.lastRenderedSourceKey = resolved.key;
         const node = this.dbtLineageService.createTable(
           event.event,
           resolved.table.path ?? url,
           resolved.key,
         );
         if (node) {
-          this.lastRenderedSourceKey = resolved.key;
           return { node, aiEnabled };
         }
       }
@@ -805,7 +827,7 @@ export class NewLineagePanel
   private resolveSourceStartingNode(
     event: ManifestCacheProjectAddedEvent,
     editor: TextEditor,
-  ): { key: string; sourceName: string; table: SourceTable } | undefined {
+  ): ResolvedSourceTable | undefined {
     const { sourceMetaMap } = event;
     const matches = this.getSourceTablesForFile(
       sourceMetaMap,
@@ -825,10 +847,9 @@ export class NewLineagePanel
   private getSourceTablesForFile(
     sourceMetaMap: SourceMetaMap,
     filePath: string,
-  ): { key: string; sourceName: string; table: SourceTable }[] {
+  ): ResolvedSourceTable[] {
     const target = path.normalize(filePath);
-    const matches: { key: string; sourceName: string; table: SourceTable }[] =
-      [];
+    const matches: ResolvedSourceTable[] = [];
     for (const source of sourceMetaMap.values()) {
       for (const table of source.tables) {
         if (!table.path) {
@@ -851,19 +872,16 @@ export class NewLineagePanel
   // is the closest line at or above the cursor — i.e. the table the cursor sits
   // within. Returns undefined when the cursor is above every declaration.
   private pickSourceTableByCursor(
-    matches: { key: string; sourceName: string; table: SourceTable }[],
+    matches: ResolvedSourceTable[],
     editor: TextEditor,
-  ): { key: string; sourceName: string; table: SourceTable } | undefined {
+  ): ResolvedSourceTable | undefined {
     const cursorLine = editor.selection.active.line;
-    let best:
-      | { key: string; sourceName: string; table: SourceTable }
-      | undefined;
+    const declLines = this.findSourceTableLines(editor.document);
+    let best: ResolvedSourceTable | undefined;
     let bestLine = -1;
     for (const match of matches) {
-      const declLine = this.findSourceTableLine(
-        editor.document,
-        match.table.name,
-      );
+      const declLine =
+        declLines.get(`${match.sourceName}.${match.table.name}`) ?? -1;
       if (declLine >= 0 && declLine <= cursorLine && declLine > bestLine) {
         best = match;
         bestLine = declLine;
@@ -872,20 +890,55 @@ export class NewLineagePanel
     return best;
   }
 
-  // Line number of a `- name: <table>` declaration in the document, or -1.
-  private findSourceTableLine(
-    document: TextDocument,
-    tableName: string,
-  ): number {
-    const pattern = new RegExp(
-      `^\\s*-?\\s*name:\\s*["']?${escapeRegExp(tableName)}["']?\\s*$`,
-    );
-    for (let line = 0; line < document.lineCount; line++) {
-      if (pattern.test(document.lineAt(line).text)) {
-        return line;
+  // Line numbers of the `- name: <table>` declarations inside each source's
+  // `tables:` block, keyed by `<source>.<table>`. Walks the YAML AST so a
+  // source-level `name:`, a model name in a mixed-purpose schema file, or a
+  // column that happens to share a table's name is never mistaken for a table
+  // declaration — and the same table name under two sources in one file maps
+  // to two distinct lines.
+  private findSourceTableLines(document: TextDocument): Map<string, number> {
+    const declLines = new Map<string, number>();
+    const text = document.getText();
+    let parsed;
+    try {
+      parsed = parseDocument(text);
+    } catch {
+      // Mid-edit YAML can be arbitrarily broken; fall back to "no
+      // declarations found" and let the caller use its first-match default.
+      return declLines;
+    }
+    const sources = parsed.get("sources");
+    if (!isSeq(sources)) {
+      return declLines;
+    }
+    for (const source of sources.items) {
+      if (!isMap(source)) {
+        continue;
+      }
+      const sourceName = source.get("name");
+      const tables = source.get("tables");
+      if (typeof sourceName !== "string" || !isSeq(tables)) {
+        continue;
+      }
+      for (const table of tables.items) {
+        if (!isMap(table)) {
+          continue;
+        }
+        const nameNode = table.get("name", true);
+        if (!isScalar(nameNode) || typeof nameNode.value !== "string") {
+          continue;
+        }
+        const offset = nameNode.range?.[0];
+        if (offset === undefined) {
+          continue;
+        }
+        declLines.set(
+          `${sourceName}.${nameNode.value}`,
+          lineAtOffset(text, offset),
+        );
       }
     }
-    return -1;
+    return declLines;
   }
 
   protected renderWebviewView(webview: Webview) {


### PR DESCRIPTION
## What

The model lineage panel can now root the graph at a **source** when a source-definition YAML is the active file. Previously, opening a `sources:` YAML showed *"A valid dbt file (model, seed etc.) needs to be open and active in the editor area above to view lineage"* and rendered nothing — even though the source node renders fine when reached from a downstream model. dbt Cloud's IDE roots at the source in this case; this brings the extension to parity.

## Why

`getStartingNode()` resolved the starting node purely from the active file's basename and only consulted models/seeds/snapshots (`nodeMetaMap`) and functions (`functionMetaMap`). Two gaps:

- `.yml`/`.yaml` were not recognized, and
- there was no `sourceMetaMap` lookup,

so a source could never originate the graph. The graph and rendering layers already handle source nodes (`createTable`/`handleCommand` have a source branch); only the entry point was missing. This is a consumer-side change — no `@altimateai/dbt-integration` change required.

## How

When the active file is a source YAML, `getStartingNode()` now maps the file to its declared source tables (via each table's `path`) and roots at one:

- **one** source table in the file → root automatically
- **several** → root at the table the cursor is within (closest `name:` declaration at or above the caret), falling back to the first declared table for determinism
- a YAML that declares **no** source in this file (e.g. a model `schema.yml`) → unchanged behavior/message

A `onDidChangeTextEditorSelection` listener re-roots live as the caret moves between tables in a multi-source file, guarded so it only re-renders when the resolved source actually changes (no churn on ordinary cursor movement or in non-source files).

### A note on multi-source files

The cursor is the disambiguator rather than an auto-popup quick-pick: a modal picker firing on every render/selection-change would be intrusive. If a dedicated "pick source" command is wanted on top of this, it can be layered on later.

## Tests

Unit tests added to `newLineagePanel.test.ts`:
- source key construction (`source.<pkg>.<source>.<table>`)
- single-table auto-root
- cursor-based table selection in a multi-table file
- first-table fallback when the caret is above every declaration
- non-source YAML → missing-lineage message, `createTable` not called

`tsc --noEmit` clean; jest suite green; prettier + eslint clean.

## Verification

End-to-end in code-server against a DuckDB dbt project: a source defined in YAML (`models/sources/segment.yml` → `segment_website_production.identifies`) plus a downstream model (`bronze_segment_identifies.sql`) that reads it. **Same file, same cursor (Ln 8, on `- name: identifies`)** for both builds; only the extension backend bundle differs (webview unchanged).

**Before** (current `master` build) — opening the source YAML shows the generic message, no graph:

![before](https://raw.githubusercontent.com/AltimateAI/vscode-dbt-power-user/screenshots/source-lineage-rooting/before-missing-message.png)

**After** (this branch) — the panel roots at the source and renders `SRC identifies → MDL bronze_segment_identifies`, matching the dbt Cloud IDE:

![after](https://raw.githubusercontent.com/AltimateAI/vscode-dbt-power-user/screenshots/source-lineage-rooting/after-source-rooted-lineage.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lineage panel now roots/re-roots lineage for dbt source YAML (`.yml`/`.yaml`) based on the cursor position, supports cursor-aware disambiguation between tables, and avoids redundant re-renders when the selection hasn’t meaningfully changed.
  * Added handling for editor selection-change events so lineage updates track where the cursor is.

* **Tests**
  * Added/expanded Jest coverage for YAML source table discovery, cursor-based table selection (including fallback behavior), correct warning/no-op when no matching source exists, and ensuring resolution/render calls happen once per update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->