### PR TITLE
chore: remove dead isDeleteChange method in SQL formatter

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -290,16 +290,4 @@ export class DbtDocumentFormattingEditProvider implements DocumentFormattingEdit
   ): change is parseDiff.NormalChange {
     return change.type === "normal";
   }
-
-  private isDeleteChange(
-    change: parseDiff.Change,
-  ): change is parseDiff.DeleteChange {
-    return (
-      /*
-          parseDiff reads sqlfmt's "\ No newline at end of file" diff output as a delete change.
-          This deceptive delete change should be skipped. So, adding an edge case to the expression.
-      */
-      change.type === "del" && change.content !== "\\ No newline at end of file"
-    );
-  }
 }


### PR DESCRIPTION
## Summary

Removes the dead `isDeleteChange` method in the SQL formatter — it has no callers.

## Background

`isDeleteChange` was wired into the original line-by-line diff algorithm to skip sqlfmt's `\ No newline at end of file` marker among delete changes. The chunk-range rewrite in #1789 reconstructs new content from add/normal changes and replaces whole old-ranges, so delete changes are no longer iterated — leaving `isDeleteChange` orphaned.

Investigation (App Insights + driving real sqlfmt 0.18 & 0.30) confirmed there is **no behavioral bug to fix here**: stock sqlfmt always emits the `\ No newline at end of file` marker on the **source** side, which `parse-diff` classifies as a `del` and the existing `isAddChange || isNormalChange` filter already excludes. The marker only leaks if classified as a synthetic `add` (formatted side missing a trailing newline), which stock sqlfmt never produces — and that path emits no telemetry anyway. So this is a pure dead-code cleanup, no behavior change.

## Changes

- Remove the unused `isDeleteChange` method.

## Testing

- `tsc --noEmit` and `prettier --check` clean. No behavior change (method had no callers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal helper method from document formatting provider to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->