### PR TITLE
fix: harden extendErrorWithSupportLinks against non-string and undefined errors

### DIFF
--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -196,15 +196,23 @@ describe("utils tests", () => {
       expect(
         () => (msg = extendErrorWithSupportLinks(undefined)),
       ).not.toThrow();
-      expect(msg).toContain(LINK);
-      expect(msg).not.toContain("undefined");
+      expect(msg).toBe(
+        "If the issue persists, please [contact us](https://www.altimate.ai/support) via chat or Slack",
+      );
     });
 
     it("does not throw on null", () => {
       let msg = "";
       expect(() => (msg = extendErrorWithSupportLinks(null))).not.toThrow();
+      expect(msg).toBe(
+        "If the issue persists, please [contact us](https://www.altimate.ai/support) via chat or Slack",
+      );
+    });
+
+    it("returns the bare support link without leading whitespace for an empty string", () => {
+      const msg = extendErrorWithSupportLinks("");
+      expect(msg).not.toMatch(/^\s/);
       expect(msg).toContain(LINK);
-      expect(msg).not.toContain("null");
     });
 
     it("uses Error.message for Error instances", () => {

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -175,9 +175,49 @@ describe("utils tests", () => {
     jest.useRealTimers();
   });
 
-  it("extendErrorWithSupportLinks appends link", () => {
-    const msg = extendErrorWithSupportLinks("problem");
-    expect(msg).toContain("contact us");
+  describe("extendErrorWithSupportLinks", () => {
+    const LINK = "contact us";
+
+    it("appends the support link to a string message", () => {
+      const msg = extendErrorWithSupportLinks("problem");
+      expect(msg).toBe(
+        "problem If the issue persists, please [contact us](https://www.altimate.ai/support) via chat or Slack",
+      );
+    });
+
+    it("does not double the separating space when message already ends in one", () => {
+      const msg = extendErrorWithSupportLinks("problem ");
+      expect(msg).not.toContain("problem  If");
+      expect(msg).toContain("problem If");
+    });
+
+    it("does not throw on undefined and omits 'undefined' from output", () => {
+      let msg = "";
+      expect(
+        () => (msg = extendErrorWithSupportLinks(undefined)),
+      ).not.toThrow();
+      expect(msg).toContain(LINK);
+      expect(msg).not.toContain("undefined");
+    });
+
+    it("does not throw on null", () => {
+      let msg = "";
+      expect(() => (msg = extendErrorWithSupportLinks(null))).not.toThrow();
+      expect(msg).toContain(LINK);
+      expect(msg).not.toContain("null");
+    });
+
+    it("uses Error.message for Error instances", () => {
+      const msg = extendErrorWithSupportLinks(new Error("boom"));
+      expect(msg).toContain("boom ");
+      expect(msg).toContain(LINK);
+    });
+
+    it("stringifies non-Error, non-string values", () => {
+      const msg = extendErrorWithSupportLinks(42);
+      expect(msg).toContain("42 ");
+      expect(msg).toContain(LINK);
+    });
   });
 
   it("stripANSI removes escape codes", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,8 +96,10 @@ export const setupWatcherHandler: (
 export function extendErrorWithSupportLinks(error: unknown): string {
   const message =
     error instanceof Error ? error.message : error == null ? "" : String(error);
+  const separator = message === "" || message.endsWith(" ") ? "" : " ";
   return (
-    (message.endsWith(" ") ? message : message + " ") +
+    message +
+    separator +
     "If the issue persists, please [contact us](https://www.altimate.ai/support) via chat or Slack"
   );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,9 +93,11 @@ export const setupWatcherHandler: (
   watcher.onDidDelete(() => handler()),
 ];
 
-export function extendErrorWithSupportLinks(error: string): string {
+export function extendErrorWithSupportLinks(error: unknown): string {
+  const message =
+    error instanceof Error ? error.message : error == null ? "" : String(error);
   return (
-    (error[-1] === " " ? error : error + " ") +
+    (message.endsWith(" ") ? message : message + " ") +
     "If the issue persists, please [contact us](https://www.altimate.ai/support) via chat or Slack"
   );
 }


### PR DESCRIPTION
## Summary

`extendErrorWithSupportLinks` (`src/utils.ts`) threw a second error on the error path and mangled non-string inputs.

It used `error[-1]` to check for a trailing space. JavaScript has no negative string indexing, so:

- **Throws on the error path.** ~20 call sites pass `(err as Error).message`. When the thrown value is not an `Error`, that message is `undefined`, and `undefined[-1]` throws `TypeError: Cannot read properties of undefined (reading '-1')` — turning an error-reporting helper into a new crash.
- **Dead dedup / lossy.** `error[-1]` is always `undefined`, so the `=== " "` trailing-space dedup never fired (doubled spaces), and a non-string object became `"[object Object] ..."`, dropping the real `.message`.

## Changes

- Accept `unknown` (matches the real inputs across call sites; widening, so no call-site breakage).
- Normalize: `error instanceof Error ? error.message : error == null ? "" : String(error)`.
- Use `endsWith(" ")` for the trailing-space check.
- Expand the existing util test with undefined, null, `Error`, non-string, and trailing-space cases.

## Testing

- `npx jest src/test/suite/utils.test.ts` — 23 passing (6 cover this helper).
- `tsc --noEmit` and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-message handling so various input types (strings, errors, null/undefined, others) are handled gracefully and support links are appended with correct spacing.

* **Tests**
  * Expanded test suite with focused cases covering string inputs, trailing-space behavior, null/undefined, Error objects, and non-string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->