### PR TITLE
ci: cap test and coverage artifact retention to 7 days

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           name: test-results-${{ matrix.os }}
           path: test-results/
+          retention-days: 7
 
       - name: Upload coverage results
         if: always()
@@ -77,6 +78,7 @@ jobs:
             coverage/
             .nyc_output/
             *.lcov
+          retention-days: 7
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary

- Added `retention-days: 7` to both `upload-artifact` steps in `tests.yml`:
  - `test-results-${{ matrix.os }}`
  - `coverage-${{ matrix.os }}`
- These are debug artifacts only; 7 days is ample for debugging a failed test run
- Was inheriting the 90-day org default

## Context

Part of an org-wide artifact retention cleanup. The org hit its GitHub Actions storage quota limit today, blocking all CI that uploads artifacts (including altimate-backend Unit Tests and Integration Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automatic cleanup of CI/CD artifacts with a 7-day retention period for test results and code coverage reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->