### PR TITLE
fix: docs deploy fails on OOM in CDK BucketDeployment Lambda

### DIFF
--- a/.github/workflows/deploy-docs-to-s3.yaml
+++ b/.github/workflows/deploy-docs-to-s3.yaml
@@ -34,11 +34,23 @@ jobs:
           cd documentation
           mkdocs build --clean
 
-      # Deploy to AWS
-      - name: Deploy to AWS
-        uses: onramper/action-deploy-aws-static-site@v3.2.0
+      # Configure AWS credentials for the deploy steps.
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          domain: docs.myaltimate.com
-          publish_dir: ./documentation/site
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      # Sync the built site straight to the existing S3 bucket from the runner
+      # (~7 GB RAM) instead of the 128 MB CDK BucketDeployment Lambda, which
+      # OOM-crashes (Runtime.OutOfMemory) on the docs bundle. `--delete` mirrors
+      # the previous Prune: true behavior. Then invalidate CloudFront.
+      - name: Deploy to S3 and invalidate CloudFront
+        run: |
+          aws s3 sync ./documentation/site \
+            s3://staticpage-docs-myaltimate-websitebucket75c24d94-1f2vy8nwes36i \
+            --delete
+          aws cloudfront create-invalidation \
+            --distribution-id E1H4J8TKJWS3II \
+            --paths "/*"

--- a/.github/workflows/deploy-docs-to-s3.yaml
+++ b/.github/workflows/deploy-docs-to-s3.yaml
@@ -4,7 +4,7 @@ name: Deploy Static Website to AWS
 # This example triggers the workflow on push events to the main branch.
 on:
   push:
-    branches: [master, fix/docs-deploy-s3-sync]
+    branches: [master]
 
 # Limit permissions for the GITHUB_TOKEN to adhere to the principle of least privilege.
 permissions:

--- a/.github/workflows/deploy-docs-to-s3.yaml
+++ b/.github/workflows/deploy-docs-to-s3.yaml
@@ -4,7 +4,7 @@ name: Deploy Static Website to AWS
 # This example triggers the workflow on push events to the main branch.
 on:
   push:
-    branches: [master]
+    branches: [master, fix/docs-deploy-s3-sync]
 
 # Limit permissions for the GITHUB_TOKEN to adhere to the principle of least privilege.
 permissions:


### PR DESCRIPTION
## Problem

The **Deploy Static Website to AWS** workflow has been failing on every push to `master`.

Root cause (confirmed from CloudWatch logs of the deploy Lambda):
- `onramper/action-deploy-aws-static-site@v3.2.0` deploys content via a CDK `Custom::CDKBucketDeployment`, whose Lambda is **hardcoded to 128 MB**.
- The Lambda **OOM-crashes** on the docs bundle:
  ```
  Status: error   Error Type: Runtime.OutOfMemory   Max Memory Used: 127 MB / 128 MB
  ```
- It dies before posting its response to CloudFormation, so the stack waits out its ~60-minute custom-resource timeout, fails, and rolls back. Earlier failures even left the stack stuck in `UPDATE_ROLLBACK_FAILED`.
- The action exposes **no memory knob**, and bumping the Lambda's memory manually is reset by every `cdk deploy`.

## Fix

Stop routing content deploys through the 128 MB CDK Lambda. Sync the built site straight to the existing S3 bucket from the GitHub runner (~7 GB RAM), then invalidate CloudFront:

- `aws-actions/configure-aws-credentials@v4` for auth
- `aws s3 sync ./documentation/site s3://...websitebucket... --delete` — `--delete` preserves the old `Prune: true` behavior
- `aws cloudfront create-invalidation --distribution-id E1H4J8TKJWS3II --paths "/*"`

The bucket, CloudFront distribution, ACM cert, and DNS are already provisioned and stable, so routine content deploys no longer need CDK at all. This also removes the deprecated node12/node20 action warnings.

**Trade-off:** infra (cert/DNS/CloudFront config) is no longer reconciled by CDK on each deploy. Those rarely change; if needed they can be managed as a separate one-off. For docs *content* — all this pipeline does — direct sync is simpler and far more robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the documentation deployment workflow to deploy on pushes to the main branch and the docs deployment branch.
  * Replaced the third-party deployment action with explicit AWS credential setup, direct S3 sync (including pruning removed files), and a CloudFront cache invalidation after each deploy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->