### PR TITLE
chore: add lockfile-lint CI check

### DIFF
--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -1,0 +1,39 @@
+name: Lockfile Lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  lockfile-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Guards against lockfiles generated behind a private/corporate registry
+      # proxy: every "resolved" URL must point to the public npm registry over
+      # https and carry an integrity hash. Catches leaked internal hostnames and
+      # lockfile-injection attacks before they land on master.
+      - name: Validate package-lock.json
+        run: >-
+          npx -y lockfile-lint@4
+          --path package-lock.json
+          --type npm
+          --allowed-hosts npm
+          --validate-https
+          --validate-integrity
+      - name: Validate webview_panels/package-lock.json
+        run: >-
+          npx -y lockfile-lint@4
+          --path webview_panels/package-lock.json
+          --type npm
+          --allowed-hosts npm
+          --validate-https
+          --validate-integrity

--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -17,13 +17,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       # Guards against lockfiles generated behind a private/corporate registry
       # proxy: every "resolved" URL must point to the public npm registry over
       # https and carry an integrity hash. Catches leaked internal hostnames and
       # lockfile-injection attacks before they land on master.
       - name: Validate package-lock.json
         run: >-
-          npx -y lockfile-lint@4
+          npx -y lockfile-lint@4.14.1
           --path package-lock.json
           --type npm
           --allowed-hosts npm
@@ -31,7 +33,7 @@ jobs:
           --validate-integrity
       - name: Validate webview_panels/package-lock.json
         run: >-
-          npx -y lockfile-lint@4
+          npx -y lockfile-lint@4.14.1
           --path webview_panels/package-lock.json
           --type npm
           --allowed-hosts npm


### PR DESCRIPTION
## Overview

Adds a `Lockfile Lint` GitHub Actions workflow that validates both `package-lock.json` files on every PR and push to `master`.

Each lockfile is checked so that every `resolved` URL:
- points to the **public npm registry** (`--allowed-hosts npm`),
- uses **https** (`--validate-https`), and
- carries an **integrity** hash (`--validate-integrity`).

### Why

Lockfiles regenerated behind a private/corporate registry proxy rewrite their `resolved` URLs to an internal host (sometimes over plain HTTP). Committing those into this — the only public Altimate repo — leaks an internal hostname and breaks `npm install` reproducibility for everyone else. The same check also blocks the lockfile-injection attack vector, where a `resolved` URL is repointed at an attacker-controlled host.

This guard would have caught exactly that pattern in a recent contribution.

### Notes

- Runs `lockfile-lint` via `npx` with a pinned major (`@4`), so **no new dependency** is added to either lockfile.
- Verified against the current `master` lockfiles: both pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new “Lockfile Lint” GitHub Actions workflow that runs on pushes and pull requests targeting the main branch.
  * Validates both the root and webview panel lockfiles.
  * Enforces that dependency `resolved` URLs use the public npm registry and require HTTPS connectivity, along with integrity hash checks for dependency entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->