### PR TITLE
fix: guide instead of erroring when sqlfmt isn't installed

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -61,11 +61,24 @@ export class DbtDocumentFormattingEditProvider implements DocumentFormattingEdit
       "--quiet",
       ...sqlFmtAdditionalParamsSetting,
     ];
+    const sqlFmtPath = await this.resolveSqlFmtPath();
+    if (!sqlFmtPath) {
+      // sqlfmt not installed is an expected, user-actionable configuration
+      // state, not a runtime failure. Emit a distinct non-error signal and
+      // guide the user to install it, instead of classifying it as a
+      // formatDbtModelApplyDiffError (reserved for genuine sqlfmt execution or
+      // diff-processing failures). SqlFmtAvailabilityNotifier already prompts
+      // to install on first file open.
+      this.telemetry.sendTelemetryEvent("formatDbtModelSqlfmtNotInstalled");
+      window.showWarningMessage(
+        'sqlfmt not found. Install it (e.g. `uv tool install "shandy-sqlfmt[jinjafmt]"` or ' +
+          '`pipx install "shandy-sqlfmt[jinjafmt]"`), set the `dbt.sqlFmtPath` setting to the ' +
+          "sqlfmt binary, or restart VS Code to pick up PATH changes.",
+      );
+      return [];
+    }
+
     try {
-      const sqlFmtPath = await this.resolveSqlFmtPath();
-      if (!sqlFmtPath) {
-        throw new Error("sqlfmt not found");
-      }
       this.telemetry.sendTelemetryEvent("formatDbtModel", {
         sqlFmtPath: sqlFmtPathSetting ? "setting" : "path",
       });
@@ -103,11 +116,7 @@ export class DbtDocumentFormattingEditProvider implements DocumentFormattingEdit
       this.telemetry.sendTelemetryError("formatDbtModelApplyDiffError", error);
       window.showErrorMessage(
         extendErrorWithSupportLinks(
-          'Could not run sqlfmt. If sqlfmt is installed (e.g. via `uv tool install "shandy-sqlfmt[jinjafmt]"` or `pipx install "shandy-sqlfmt[jinjafmt]"`), ' +
-            "try setting the `dbt.sqlFmtPath` setting to the full path of the sqlfmt binary, " +
-            "or restart VS Code to pick up PATH changes. Detailed error: " +
-            error +
-            ".",
+          "Could not run sqlfmt. Detailed error: " + error + ".",
         ),
       );
     }

--- a/src/test/suite/dbtDocumentFormattingEditProvider.test.ts
+++ b/src/test/suite/dbtDocumentFormattingEditProvider.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { window, workspace } from "vscode";
+import { DbtDocumentFormattingEditProvider } from "../../document_formatting_edit_provider/dbtDocumentFormattingEditProvider";
+
+// The formatter must NOT report a missing sqlfmt binary as a
+// `formatDbtModelApplyDiffError` telemetry error — that's an expected,
+// user-actionable config state. It emits a non-error
+// `formatDbtModelSqlfmtNotInstalled` event + a warning instead, and reserves
+// the error event for genuine sqlfmt execution / diff-processing failures.
+
+function makeTelemetry() {
+  return {
+    sendTelemetryEvent: jest.fn(),
+    sendTelemetryError: jest.fn(),
+  } as any;
+}
+
+function makeExecution(result: {
+  stderr?: string;
+  reject?: Error;
+}) {
+  return {
+    createCommandProcessExecution: jest.fn(() => ({
+      complete: jest.fn(() =>
+        result.reject
+          ? Promise.reject(result.reject)
+          : Promise.resolve({ stderr: result.stderr ?? "" }),
+      ),
+    })),
+  } as any;
+}
+
+const pythonEnvironment = {
+  getResolvedConfigValue: jest.fn().mockReturnValue(""),
+} as any;
+
+const doc = { getText: () => "select 1", uri: { fsPath: "m.sql" } } as any;
+
+function makeProvider(exec: any, telemetry: any) {
+  return new DbtDocumentFormattingEditProvider(
+    exec,
+    telemetry,
+    pythonEnvironment,
+  );
+}
+
+describe("DbtDocumentFormattingEditProvider sqlfmt telemetry", () => {
+  beforeEach(() => {
+    // The default config mock's get() ignores the default arg; make it honor
+    // it so `get("sqlFmtAdditionalParams", [])` returns [] instead of undefined.
+    (workspace.getConfiguration as jest.Mock).mockReturnValue({
+      get: jest.fn((_key: string, def: unknown) => def),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not emit an error event when sqlfmt is not installed", async () => {
+    const telemetry = makeTelemetry();
+    const provider = makeProvider(makeExecution({}), telemetry);
+    jest
+      .spyOn(provider as any, "resolveSqlFmtPath")
+      .mockResolvedValue(undefined);
+
+    const edits = await (provider as any).executeSqlFmt(doc);
+
+    expect(edits).toEqual([]);
+    expect(telemetry.sendTelemetryError).not.toHaveBeenCalled();
+    expect(telemetry.sendTelemetryEvent).toHaveBeenCalledWith(
+      "formatDbtModelSqlfmtNotInstalled",
+    );
+    expect(window.showWarningMessage).toHaveBeenCalledTimes(1);
+    expect(window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it("emits formatDbtModel (not the not-installed event) on a successful run", async () => {
+    const telemetry = makeTelemetry();
+    const provider = makeProvider(makeExecution({ stderr: "" }), telemetry);
+    jest
+      .spyOn(provider as any, "resolveSqlFmtPath")
+      .mockResolvedValue("/usr/bin/sqlfmt");
+
+    const edits = await (provider as any).executeSqlFmt(doc);
+
+    expect(edits).toEqual([]);
+    expect(telemetry.sendTelemetryEvent).toHaveBeenCalledWith("formatDbtModel", {
+      sqlFmtPath: "path",
+    });
+    expect(telemetry.sendTelemetryEvent).not.toHaveBeenCalledWith(
+      "formatDbtModelSqlfmtNotInstalled",
+    );
+    expect(telemetry.sendTelemetryError).not.toHaveBeenCalled();
+  });
+
+  it("still emits formatDbtModelApplyDiffError for a genuine sqlfmt failure", async () => {
+    const telemetry = makeTelemetry();
+    const provider = makeProvider(
+      makeExecution({ stderr: "sqlfmt exploded" }),
+      telemetry,
+    );
+    jest
+      .spyOn(provider as any, "resolveSqlFmtPath")
+      .mockResolvedValue("/usr/bin/sqlfmt");
+    // Force the diff-processing path to fail so the error branch is exercised.
+    jest.spyOn(provider as any, "processDiffOutput").mockImplementation(() => {
+      throw new Error("bad diff");
+    });
+
+    await (provider as any).executeSqlFmt(doc);
+
+    expect(telemetry.sendTelemetryError).toHaveBeenCalledWith(
+      "formatDbtModelApplyDiffError",
+      expect.anything(),
+    );
+    expect(telemetry.sendTelemetryEvent).not.toHaveBeenCalledWith(
+      "formatDbtModelSqlfmtNotInstalled",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Running **Format Document** on a dbt model when `sqlfmt` isn't installed emits a `formatDbtModelApplyDiffError` telemetry **error** and shows an error toast. That classifies an expected, user-actionable configuration state (an optional tool simply isn't installed) as a runtime failure. The one-time sqlfmt install notifier reduced how many users reach this, but the format command itself still fires the error event — it remains a recurring `formatDbtModelApplyDiffError` cluster on the current release.

## Change

`executeSqlFmt` resolved the sqlfmt path *inside* the same `try` whose `catch` reports `formatDbtModelApplyDiffError`, so "sqlfmt not found" was funnelled into the error path. This PR pulls that check out:

- On `!sqlFmtPath`: emit a distinct non-error `formatDbtModelSqlfmtNotInstalled` event and show a **warning** with install guidance, then return no edits.
- `formatDbtModelApplyDiffError` is now reserved for genuine sqlfmt execution / diff-processing failures (unchanged).

No behavior change when sqlfmt *is* installed.

## Verification

Reproduced in the code-server harness on current `master` (0.61.7, sqlfmt absent):

- **Before:** Format Document → `Error: Could not run sqlfmt … Error: sqlfmt not found` toast + `formatDbtModelApplyDiffError`.
- **After:** Format Document → `Warning: sqlfmt not found. Install it …` toast; no `formatDbtModelApplyDiffError` (the non-error `formatDbtModelSqlfmtNotInstalled` event fires instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
