### PR TITLE
fix: lazy-init git watching in SQL codelens to avoid "Git model not found" crash

### DIFF
--- a/src/code_lens_provider/sqlActionsCodeLensProvider.ts
+++ b/src/code_lens_provider/sqlActionsCodeLensProvider.ts
@@ -44,9 +44,17 @@ export class SqlActionsCodeLensProvider
     this._onDidChangeCodeLenses.event;
   private disposables: Disposable[] = [];
   private changedFiles = new Set<string>();
+  private gitWatcherInitialized = false;
 
   constructor(private altimateCodeChatService: AltimateCodeChatService) {
-    this.initGitWatcher();
+    // Git watching is initialized lazily (see `ensureGitWatcher`, called from
+    // `provideCodeLenses`) rather than here. This provider is constructed during
+    // extension activation, which races the built-in Git extension's own model
+    // initialization — `getAPI(1)` throws "Git model not found" in that window.
+    // Git is only needed to gate a single codelens ("Review changes with
+    // Altimate") on files with uncommitted changes, so we don't need it until a
+    // SQL/YAML file is actually opened — by which point git has activated and
+    // the race is gone.
     this.disposables.push(
       window.onDidChangeActiveTextEditor((editor) => {
         if (editor) {
@@ -79,22 +87,46 @@ export class SqlActionsCodeLensProvider
     );
   }
 
+  private ensureGitWatcher() {
+    // Init exactly once, on first codelens request. The flag is set up front so
+    // a failed/racing attempt never re-attaches duplicate watchers.
+    if (this.gitWatcherInitialized) {
+      return;
+    }
+    this.gitWatcherInitialized = true;
+    this.initGitWatcher();
+  }
+
   private initGitWatcher() {
     const gitExt = extensions.getExtension("vscode.git");
     if (!gitExt) {
       return;
     }
     if (!gitExt.isActive) {
-      gitExt.activate().then(() => this.watchGitState());
+      gitExt.activate().then(
+        () => this.watchGitState(),
+        () => {
+          // Git extension failed to activate — codelens git decorations are
+          // best-effort, so skip silently rather than leaking an unhandled
+          // rejection.
+        },
+      );
       return;
     }
     this.watchGitState();
   }
 
   private watchGitState() {
-    const git: GitAPI | undefined = extensions
-      .getExtension("vscode.git")
-      ?.exports?.getAPI(1);
+    let git: GitAPI | undefined;
+    try {
+      git = extensions.getExtension("vscode.git")?.exports?.getAPI(1);
+    } catch {
+      // The built-in Git extension's getAPI(1) throws "Git model not found"
+      // when its model isn't initialized yet (lazy-activation race) or git is
+      // disabled. Git codelens decorations are best-effort — skip silently
+      // instead of surfacing an unhandled rejection (catchAllError).
+      return;
+    }
     if (!git) {
       return;
     }
@@ -149,6 +181,9 @@ export class SqlActionsCodeLensProvider
     document: TextDocument,
     _token: CancellationToken,
   ): ProviderResult<CodeLens[]> {
+    // Lazily start watching git the first time codelenses are requested — by
+    // now the Git extension has activated, so `getAPI(1)` won't throw.
+    this.ensureGitWatcher();
     if (document.fileName.endsWith(".sql")) {
       return this.provideSqlCodeLenses(document);
     }

--- a/src/test/mock/vscode.ts
+++ b/src/test/mock/vscode.ts
@@ -65,6 +65,18 @@ export class Location {
   }
 }
 
+export class CodeLens {
+  constructor(
+    public range: Range,
+    public command?: {
+      title: string;
+      command: string;
+      tooltip?: string;
+      arguments?: any[];
+    },
+  ) {}
+}
+
 export const DiagnosticSeverity = {
   Error: 0,
   Warning: 1,
@@ -130,6 +142,10 @@ export const window = {
   showInformationMessage: jest.fn().mockReturnValue(Promise.resolve()),
   showWarningMessage: jest.fn().mockReturnValue(Promise.resolve()),
   showErrorMessage: jest.fn().mockReturnValue(Promise.resolve()),
+  onDidChangeActiveTextEditor: jest
+    .fn()
+    .mockReturnValue({ dispose: jest.fn() }),
+  activeTextEditor: undefined as any,
   createOutputChannel: jest.fn().mockReturnValue({
     append: jest.fn(),
     appendLine: jest.fn(),

--- a/src/test/suite/sqlActionsCodeLensProvider.test.ts
+++ b/src/test/suite/sqlActionsCodeLensProvider.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { CodeLens, extensions } from "vscode";
+import { SqlActionsCodeLensProvider } from "../../code_lens_provider/sqlActionsCodeLensProvider";
+
+// Git watching in this provider exists only to gate the "Review changes with
+// Altimate" codelens on files with uncommitted changes. These tests cover:
+//  - git is not touched at construction (lazy init avoids the activation-time
+//    "Git model not found" race),
+//  - a throwing getAPI(1) degrades gracefully instead of crashing,
+//  - the Review lens is correctly gated on git change state.
+
+const getExtension = extensions.getExtension as jest.Mock;
+
+function makeChatService() {
+  return {
+    getRelativePath: jest.fn().mockReturnValue("models/x.sql"),
+    openChat: jest.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+function makeDoc(fsPath: string): any {
+  return { fileName: fsPath, uri: { fsPath } };
+}
+
+function makeRepo(changedPaths: string[]) {
+  return {
+    state: {
+      workingTreeChanges: changedPaths.map((p) => ({ uri: { fsPath: p } })),
+      indexChanges: [],
+      onDidChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+    },
+  };
+}
+
+function makeGitExt(opts: { repos?: any[]; throwGetAPI?: boolean }) {
+  return {
+    isActive: true,
+    activate: jest.fn().mockResolvedValue(undefined),
+    exports: {
+      getAPI: jest.fn(() => {
+        if (opts.throwGetAPI) {
+          throw new Error("Git model not found");
+        }
+        return {
+          repositories: opts.repos ?? [],
+          onDidOpenRepository: jest
+            .fn()
+            .mockReturnValue({ dispose: jest.fn() }),
+        };
+      }),
+    },
+  };
+}
+
+const token = {} as any;
+const titlesOf = (lenses: any): (string | undefined)[] =>
+  (lenses as CodeLens[]).map((l) => l.command?.title);
+
+describe("SqlActionsCodeLensProvider git watching", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not touch the git extension at construction (lazy init)", () => {
+    getExtension.mockReturnValue(makeGitExt({ repos: [] }));
+    const provider = new SqlActionsCodeLensProvider(makeChatService());
+
+    // Constructor must not read the git API — that races git activation.
+    expect(getExtension).not.toHaveBeenCalled();
+
+    provider.provideCodeLenses(makeDoc("a.sql"), token);
+    expect(getExtension).toHaveBeenCalledWith("vscode.git");
+  });
+
+  it("does not crash when getAPI(1) throws 'Git model not found'", () => {
+    getExtension.mockReturnValue(makeGitExt({ throwGetAPI: true }));
+    const provider = new SqlActionsCodeLensProvider(makeChatService());
+
+    let lenses: any;
+    expect(() => {
+      lenses = provider.provideCodeLenses(makeDoc("a.sql"), token);
+    }).not.toThrow();
+
+    const titles = titlesOf(lenses);
+    // Base lenses still returned; Review lens absent (no git state available).
+    expect(titles).toEqual(expect.arrayContaining(["$(play) Execute Query"]));
+    expect(titles.some((t) => t?.includes("Review"))).toBe(false);
+  });
+
+  it("includes the Review lens for a file with uncommitted git changes", () => {
+    const repo = makeRepo(["/repo/models/customers.sql"]);
+    getExtension.mockReturnValue(makeGitExt({ repos: [repo] }));
+    const provider = new SqlActionsCodeLensProvider(makeChatService());
+
+    const lenses = provider.provideCodeLenses(
+      makeDoc("/repo/models/customers.sql"),
+      token,
+    );
+    expect(titlesOf(lenses)).toContain("$(sparkle) Review");
+  });
+
+  it("omits the Review lens for a file with no git changes", () => {
+    const repo = makeRepo([]);
+    getExtension.mockReturnValue(makeGitExt({ repos: [repo] }));
+    const provider = new SqlActionsCodeLensProvider(makeChatService());
+
+    const lenses = provider.provideCodeLenses(
+      makeDoc("/repo/models/customers.sql"),
+      token,
+    );
+    expect(titlesOf(lenses).some((t) => t?.includes("Review"))).toBe(false);
+  });
+
+  it("initializes the git watcher only once across codelens requests", () => {
+    const gitExt = makeGitExt({ repos: [] });
+    getExtension.mockReturnValue(gitExt);
+    const provider = new SqlActionsCodeLensProvider(makeChatService());
+
+    provider.provideCodeLenses(makeDoc("a.sql"), token);
+    provider.provideCodeLenses(makeDoc("b.sql"), token);
+
+    expect(gitExt.exports.getAPI).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

`SqlActionsCodeLensProvider` reads the built-in Git extension API — `extensions.getExtension("vscode.git")?.exports?.getAPI(1)` — to know which files have uncommitted changes. `getAPI(1)` **throws** `Git model not found` when the Git extension's model isn't initialized yet (lazy-activation race) or git is disabled. That call ran from `initGitWatcher()` in the **constructor**, which executes during extension activation — exactly when the Git extension may not have finished initializing. The throw escaped an un-`.catch()`'d `.then()` and surfaced as a `catchAllError` unhandled-rejection telemetry event.

## Why does a SQL codelens provider need git?

Fair question — and the answer scopes the fix. Git is needed for exactly **one** codelens: `$(sparkle) Review` → "Review code changes with Altimate" (`dbtPowerUser.reviewCodeWithAltimate`), which is shown **only** on files that have uncommitted working-tree/index changes (so "review the changes you made" makes sense). Every other lens — Execute Query, Explain, Optimize, Document, and the YAML Run/Test/Document lenses — is git-independent.

So git is legitimately needed, but **only when the user is actually looking at a SQL/YAML file** — never at activation time. That's the key: the constructor had no reason to touch git.

## Change

Stop touching git during construction. Initialize the git watcher **lazily on the first `provideCodeLenses` call** (`ensureGitWatcher`, guarded to run once). By the time any codelens is requested, a SQL/YAML file is open and the Git extension has activated, so `getAPI(1)` no longer races its model init — the **root cause is removed, not masked**.

A `try/catch` around `getAPI(1)` (plus the two-arg `.then(onFulfilled, onRejected)` on `activate()`, since `activate()` returns a `Thenable` with no `.catch`) is retained as a belt, so a genuinely-unavailable git model (e.g. `git.enabled: false`) degrades gracefully instead of crashing.

### Why not just `try/catch` the throw and stop there?

A plain guard prevents the crash but has a hidden cost: `watchGitState()` only ran **once**, at construction. On exactly the machines that hit the race, the catch would fire and the **Review lens would be silently dead for the whole session** — trading a crash for a quietly missing feature. Lazy-init fixes the crash *and* keeps the feature working.

## Verification (code-server harness, current `master` @ 0.61.7)

**1. Feature preserved** — in a real git repo (`git init` the jaffle project + an uncommitted edit to `models/customers.sql`), the `$(sparkle) Review` lens appears on the modified file. This is the lazy git watcher attaching on first codelens request and populating `changedFiles`:

![Review codelens present on a modified model in a git repo](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/ai7237-telemetry/fixD-review-lens-git-repo.png)

**2. Crash gone** — with `"git.enabled": false`, opening a SQL file (which triggers the lazy init → `getAPI(1)` throw → caught) produces no `Git model not found` / `catchAllError` in the exthost log; extension activates cleanly:

```
=== search for Git model not found / watchGitState / catchAllError (should be ABSENT) ===
NONE — no crash
=== extension activated ===
1   # "Initialized dbt project"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL code lens “Review” actions by deferring Git setup until code lenses are requested, avoiding race conditions during extension activation.
  * Improved robustness when Git activation fails or when the Git model isn’t available (no unhandled errors).
  * Prevented repeated Git watcher initialization across multiple code lens updates.
* **Tests**
  * Added Jest coverage for lazy Git initialization, safe handling of “Git model not found,” and correct gating of “Review” lenses based on working-tree changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->