### PR TITLE
fix: align Node-22 posture — engines.node floor >=20 + test across editor Node range (20/22/24)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,10 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        node-version: ["20", "22", "24"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -19,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node-version }}
           cache: "npm"
           cache-dependency-path: |
             package-lock.json
@@ -65,14 +67,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.os }}
+          name: test-results-${{ matrix.os }}-node${{ matrix.node-version }}
           path: test-results/
 
       - name: Upload coverage results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.os }}
+          name: coverage-${{ matrix.os }}-node${{ matrix.node-version }}
           path: |
             coverage/
             .nyc_output/
@@ -84,5 +86,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/
           flags: unittests
-          name: codecov-${{ matrix.os }}
+          name: codecov-${{ matrix.os }}-node${{ matrix.node-version }}
           fail_ci_if_error: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.61.6",
+  "version": "0.61.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.61.6",
+      "version": "0.61.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -85,6 +85,7 @@
         "webpack": "^5.106.2"
       },
       "engines": {
+        "node": ">=20.0.0",
         "vscode": "^1.95.0"
       }
     },
@@ -3586,6 +3587,32 @@
         "@vscode/vsce-sign-win32-x64": "2.0.2"
       }
     },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.2.tgz",
+      "integrity": "sha512-E80YvqhtZCLUv3YAf9+tIbbqoinWLCO/B3j03yQPbjT3ZIHCliKZlsy1peNc4XNZ5uIb87Jn0HWx/ZbPXviuAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.2.tgz",
+      "integrity": "sha512-n1WC15MSMvTaeJ5KjWCzo0nzjydwxLyoHiMJHu1Ov0VWTZiddasmOQHekA47tFRycnt4FsQrlkSCTdgHppn6bw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
     "node_modules/@vscode/vsce-sign-darwin-arm64": {
       "version": "2.0.2",
       "cpu": [
@@ -3595,6 +3622,84 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.2.tgz",
+      "integrity": "sha512-MCjPrQ5MY/QVoZ6n0D92jcRb7eYvxAujG/AH2yM6lI0BspvJQxp0o9s5oiAM9r32r9tkLpiy5s2icsbwefAQIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.2.tgz",
+      "integrity": "sha512-Fkb5jpbfhZKVw3xwR6t7WYfwKZktVGNXdg1m08uEx1anO0oUPUkoQRsNm4QniL3hmfw0ijg00YA6TrxCRkPVOQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.2.tgz",
+      "integrity": "sha512-Ybeu7cA6+/koxszsORXX0OJk9N0GgfHq70Wqi4vv2iJCZvBrOWwcIrxKjvFtwyDgdeQzgPheH5nhLVl5eQy7WA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.2.tgz",
+      "integrity": "sha512-NsPPFVtLaTlVJKOiTnO8Cl78LZNWy0Q8iAg+LlBiCDEgC12Gt4WXOSs2pmcIjDYzj2kY4NwdeN1mBTaujYZaPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.2.tgz",
+      "integrity": "sha512-wPs848ymZ3Ny+Y1Qlyi7mcT6VSigG89FWQnp2qRYCyMhdJxOpA4lDwxzlpL8fG6xC8GjQjGDkwbkWUcCobvksQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.2.tgz",
+      "integrity": "sha512-pAiRN6qSAhDM5SVOIxgx+2xnoVUePHbRNC7OD2aOR3WltTKxxF25OfpK8h8UQ7A0BuRkSgREbB59DBlFk4iAeg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@vscode/vsce/node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "version": "0.61.7",
   "engines": {
     "vscode": "^1.95.0",
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
   },
   "capabilities": {
     "hoverProvider": true


### PR DESCRIPTION
Two small corrections to align power-user's Node-22 posture with the **real editor runtime range** (Cursor = Node 20.18.2 → VS Code = Node 24), rather than the single Node 22 the epic initially applied.

## 1. Floor `engines.node` at `>=20` (was `>=22`)

The extension activates in the editor's Node host — Node 20.18.2 on every Cursor version, 22–24 on VS Code. `>=22` overstates the true runtime minimum for an extension that ships to Cursor, and is inconsistent with `@altimateai/dbt-integration` (a dependency), which floors at `>=20`. `engines.node` isn't enforced for extensions, so this is a correctness/consistency fix with no behavior change.

## 2. Test across `[20, 22, 24]`, not Node 22 only

The test harness ran on Node 22 — a version *no* editor uses. Add a `node-version` axis `[20, 22, 24]` across the existing OS matrix so CI exercises the actual editor runtimes, including OS × native-ABI combinations (zeromq / python-bridge / altimate-core prebuilds are keyed by both platform and Node ABI). `fail-fast: false`; artifact names disambiguated by Node version to avoid upload collisions.

Together these make power-user *declare* and *verify* the same Node range it actually runs on. CI/build tooling for producing the VSIX stays on Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded test coverage in CI to run on multiple Node.js versions, improving validation across supported environments.
  * Updated uploaded test and coverage artifacts to clearly distinguish results from each operating system and Node.js version.
  * Lowered the minimum required Node.js version for the project to broaden compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->