### PR TITLE
docs: correct REVIEW.md inaccuracies flagged by automated review

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,66 +1,66 @@
 # REVIEW.md — vscode-dbt-power-user
 
-TypeScript VSCode extension (Inversify DI, `src/`) + React/Redux webview panels (`webview_panels/`) that makes VSCode work with dbt™ — autocomplete, lineage, query preview/execution, doc generation, an MCP server, and DataPilot AI chat.
+TypeScript VSCode extension (Inversify DI, `src/`) + React/Redux webview panels (`webview_panels/`) for dbt™ — autocomplete, lineage, query execution, doc gen, an MCP server, and DataPilot AI chat.
 
 ## Goal: catch what CI cannot
 
-This repo already runs `eslint`, `tsc --noEmit`-equivalent compile, `jest` with coverage, and `lockfile-lint` in CI, plus a pre-commit `husky` hook. Kilo's job is the layer above that: crashes from unguarded `undefined`/`null` on VS Code and dbt-manifest data, async/race bugs in extension activation and webview messaging, telemetry-serialization edge cases, and multi-root-workspace path handling — the classes of bug this repo's own fix-commit history shows repeating.
+This repo already runs `eslint`, `tsc --noEmit`-equivalent compile, `jest` with coverage, and `lockfile-lint` in CI, plus a pre-commit `husky` hook. Kilo's job is the layer above: crashes from unguarded `undefined`/`null` on VS Code and dbt-manifest data, async/race bugs in activation and webview messaging, telemetry-serialization edge cases, and multi-root-workspace path handling — bug classes this repo's fix history shows repeating.
 
 ## Don't duplicate CI — never flag
 
-- Formatting/style already enforced by `eslint --ext ts` (`npm run lint`) — don't flag spacing, import order, or other auto-fixable style.
-- Type errors already caught by `tsc -p ./` (`test-compile` / `compile` scripts) — don't flag things the compiler would reject.
-- Test presence/coverage is tracked via `codecov.yml` + `jest --coverage` — flag *missing regression tests for a fix*, not raw coverage percentage.
+- Formatting/style already enforced by `eslint --ext ts` — don't flag spacing, import order, or other auto-fixable style.
+- Type errors already caught by `tsc -p ./` — don't flag things the compiler would reject.
+- Test coverage is tracked via `codecov.yml` + `jest --coverage` — flag *missing regression tests for a fix*, not raw coverage percentage.
 - `lockfile-lint.yml` already guards `package-lock.json` integrity — don't re-review lockfile diffs line by line.
-- Pre-existing issues in code the PR doesn't touch — note only if the PR's own change makes the pre-existing issue newly reachable.
+- Pre-existing issues in code the PR doesn't touch — note only if the PR's change makes it newly reachable.
 
 ## Evidence standard — no speculation
 
-Trace the actual caller chain before flagging: who invokes this, with what values, what happens on the undefined/error path. This repo's reviewers hold the same bar — a "stale `mcpExtensionApi` reference" finding was withdrawn after tracing `updateMcpExtensionApi()` to its single caller in `activate()` and confirming no re-invocation path exists. An untraced-but-plausible claim is worse than no comment.
+Trace the actual caller chain before flagging: who invokes this, with what values, what happens on the undefined/error path. Reviewers hold the same bar — a "stale `mcpExtensionApi` reference" finding was withdrawn after tracing `updateMcpExtensionApi()` to its single caller in `activate()` with no re-invocation path. An untraced-but-plausible claim is worse than no comment.
 
 ## Severity calibration
 
-- **Critical** — crashes extension activation or a core provider (autocomplete, lineage, query execution) for a common input shape; unhandled promise rejections that escape `catchAllError`; data corruption in YAML/manifest writes (e.g. writing both `tests:` and `data_tests:`).
-- **Warning** — logic bugs that silently produce wrong results without crashing (substring-vs-exact matches, stale telemetry attributes, race conditions with a narrow window), missing error surfacing to the user (console-only `catch` with no UI feedback).
-- **Nit** — `any` creep against the repo's `unknown`-preferred convention, dead/unused exports, telemetry naming-convention drift (`sendTelemetryError` keys should end in `Error`).
+- **Critical** — crashes extension activation or a core provider (autocomplete, lineage, query execution) for a common input shape; unhandled promise rejections escaping `catchAllError`; data corruption in YAML/manifest writes (e.g. writing both `tests:` and `data_tests:`).
+- **Warning** — logic bugs that silently produce wrong results without crashing (substring-vs-exact matches, stale telemetry attributes, narrow-window races), missing error surfacing to the user (console-only `catch` with no UI feedback).
+- **Nit** — `any` creep against the repo's `unknown`-preferred convention, dead/unused exports, telemetry naming drift (`sendTelemetryError` keys should end in `Error`).
 
 ## Focus areas — bug classes this repo actually ships
 
-1. **Unguarded `undefined`/`null` from VS Code APIs and dbt manifest data (~8+ fixes).** Recurring pattern: code assumes `uri.fsPath`, `range.start`, `data_type`, macro `type`, or command-palette args are always populated. *Flag when* a handler reads a nested property off a VS Code event, URI, or manifest node without a null/undefined check. *Verify* the call site can actually be reached with a partial/absent value (e.g. palette invocation with no args, a manifest node missing optional fields).
+1. **Unguarded `undefined`/`null` from VS Code APIs and dbt manifest data (~8+ fixes).** Pattern: code assumes `uri.fsPath`, `range.start`, `data_type`, macro `type`, or palette args are populated. *Flag* a handler reading a nested property off a VS Code event/URI/manifest node without a null check. *Verify* the call site can be reached with a partial/absent value (e.g. palette call with no args, manifest node missing optional fields).
 
-2. **Async/race conditions in activation, webview messaging, and telemetry (~5+ fixes: `webview:ready` postMessage race, `versionRefreshSeq` monotonic counter, DuckDB lock, concurrent `sqlfmt` notifications).** *Flag when* two async paths can write shared state (telemetry `customAttributes`, a singleton lock, a "shown already" flag) without an ordering guard. *Check* whether a monotonic sequence number or explicit await-ordering is needed — the established fix here is a `seq` counter re-checked after each `await`, not a mutex.
+2. **Async/race conditions in activation, webview messaging, and telemetry (~5+ fixes: `webview:ready` postMessage race, `versionRefreshSeq` counter, DuckDB lock, concurrent `sqlfmt` notifications).** *Flag* two async paths writing shared state (telemetry `customAttributes`, a singleton lock, a "shown already" flag) without an ordering guard. The established fix is a `seq` counter re-checked after each `await`, not a mutex.
 
-3. **Telemetry error serialization on non-Error throwables (~3 fixes: `safeSerializeTelemetryValue`, `extendErrorWithSupportLinks`, redactor-proof structured fields).** *Flag when* a `catch` passes the caught value straight into `sendTelemetryError`/Sentry without confirming it's an `Error` — circular objects, `BigInt`, strings, and non-Error throwables have each crashed the crash-handler here before. *Verify* a guarded serialize-with-fallback is used, not raw `JSON.stringify`.
+3. **Telemetry error serialization on non-Error throwables (~3 fixes: `safeSerializeTelemetryValue`, `extendErrorWithSupportLinks`, redactor-proof fields).** *Flag* a `catch` passing the caught value straight into `sendTelemetryError`/Sentry without confirming it's an `Error` — circular objects, `BigInt`, strings, and non-Error throwables have each crashed the crash-handler here. *Verify* a guarded serialize-with-fallback is used, not raw `JSON.stringify`.
 
-4. **Telemetry naming/attribute hygiene (~2 fixes + explicit reviewer convention: `-Error` suffix on `sendTelemetryError` keys; stale `customAttributes` leaking across project switches).** *Flag* a new `sendTelemetryError("SomeEvent", ...)` whose key doesn't end in `Error`. *Check* a project-scoped attribute (e.g. `dbtCloudVariant`, `pythonVersion`) is cleared/overwritten on every path, including early-return branches, not just the happy path.
+4. **Telemetry naming/attribute hygiene (~2 fixes + convention: `-Error` suffix on `sendTelemetryError` keys; stale `customAttributes` leaking across project switches).** *Flag* a new `sendTelemetryError("SomeEvent", ...)` whose key doesn't end in `Error`. *Check* a project-scoped attribute (e.g. `dbtCloudVariant`) is cleared/overwritten on every path, including early returns.
 
-5. **Substring matching where exact equality is needed (model/table name lookups).** Confirmed bug: `.filter((ut) => ut.model.includes(modelName))` matched `orders`, `order_items`, `customer_orders` when looking up unit tests for `order.sql`. *Flag when* a model/table/column comparison uses `.includes()`/`.startsWith()`/a naive regex instead of exact match against a `unique_id` — check whether a sibling function already resolves precisely (e.g. via `lookupByBaseName`) and this one should match it.
+5. **Substring matching where exact equality is needed (model/table lookups).** Confirmed bug: `.filter((ut) => ut.model.includes(modelName))` matched `orders`, `order_items`, `customer_orders` for `order.sql`. *Flag* a comparison using `.includes()`/`.startsWith()`/regex instead of exact match against a `unique_id` — check whether a sibling function already resolves precisely (e.g. `lookupByBaseName`) and this one should match it.
 
-6. **Multi-root workspace and path/variable resolution (~4 fixes: per-folder `.env` loading, `${workspaceFolder}`/`${env:VAR}` resolution, lineage across multi-root, `DBT_PROFILES_DIR` relative paths).** *Flag when* a path/env-var/settings lookup assumes a single workspace folder. *Verify* the code iterates `workspace.workspaceFolders` (not just `[0]`) and resolves `${workspaceFolder}`/`${env:...}` tokens before use.
+6. **Multi-root workspace and path/variable resolution (~4 fixes: per-folder `.env` loading, `${workspaceFolder}`/`${env:VAR}` resolution, multi-root lineage, `DBT_PROFILES_DIR` relative paths).** *Flag* a path/env-var lookup that assumes a single workspace folder. *Verify* the code iterates `workspace.workspaceFolders` (not just `[0]`) and resolves `${workspaceFolder}`/`${env:...}` tokens before use.
 
-7. **YAML/schema mutation correctness (docs editor writing both `tests:`/`data_tests:`; MCP tool `$schema` stripping for Gemini; YAML-AST walking vs. regex for table declarations).** *Flag* regex-based YAML text manipulation beyond a trivial string replace — this repo moved to `parseDocument`/AST walking after regex produced real name-collision bugs. *Check* a new schema/doc write doesn't reintroduce a duplicate or conflicting key.
+7. **YAML/schema mutation correctness (docs editor writing both `tests:`/`data_tests:`; MCP `$schema` stripping for Gemini; YAML-AST walking vs. regex).** *Flag* regex-based YAML text manipulation beyond a trivial replace — this repo moved to `parseDocument`/AST walking after regex caused name-collision bugs. *Check* a new schema/doc write doesn't reintroduce a duplicate or conflicting key.
 
-8. **`any` type creep against the repo's `unknown`-preferred convention.** *Flag* new `as any`/`any[]`/`(x: any) =>` introduced by the diff (not pre-existing) — reviewers have called this out explicitly and suggested a narrow inline type instead.
+8. **`any` type creep against the repo's `unknown`-preferred convention.** *Flag* new `as any`/`any[]`/`(x: any) =>` introduced by the diff (not pre-existing) — reviewers suggest a narrow inline type instead.
 
-9. **Cross-platform / packaging fragility (npm pack+tar for `altimate-core`, `.node` binary copying, lockfile symlink resolution, Windows vs POSIX venv paths in dbt-core detection).** *Flag* a new hardcoded POSIX path (`bin/python`, forward-slash joins) in code that also runs on Windows CI — the fix pattern derives the path per-platform (`Scripts/python.exe` vs `bin/python`).
+9. **Cross-platform / packaging fragility (npm pack+tar for `altimate-core`, `.node` binary copying, lockfile symlinks, Windows vs POSIX venv paths).** *Flag* a new hardcoded POSIX path (`bin/python`, forward-slash joins) in code that runs on Windows CI too — the fix derives the path per-platform (`Scripts/python.exe` vs `bin/python`).
 
-10. **Inversify DI binding-mode mismatches.** *Verify before flagging* — a class bound via `.toDynamicValue()` legitimately doesn't need `@injectable()`/constructor reflection; only `.to(Class)`/`.toSelf()` bindings require it. Check `src/inversify.config.ts` before flagging a "missing `@injectable()`".
+10. **Inversify DI binding-mode mismatches.** *Verify before flagging* — a class bound via `.toDynamicValue()` legitimately doesn't need `@injectable()`; only `.to(Class)`/`.toSelf()` bindings require it. Check `src/inversify.config.ts` before flagging a "missing `@injectable()`".
 
-11. **Activation error routing (swallowing real errors vs. expected "no dbt project").** *Flag* an activation-level `catch` that either surfaces `NoProjectsFound` as a hard error, or swallows a genuinely unexpected error (`EMFILE`, `EACCES`, python-bridge failure) alongside it. *Verify* the specific exception type is checked, not a blanket catch-and-classify.
+11. **Activation error routing (swallowing real errors vs. expected "no dbt project").** *Flag* an activation `catch` that surfaces `NoProjectsFound` as a hard error, or swallows a genuinely unexpected error (`EMFILE`, `EACCES`, integration-bridge failure) alongside it. *Verify* the specific exception type is checked, not a blanket catch-and-classify.
 
-12. **Timeout/OOM in external process or cloud calls (sqlfmt discovery, MCP body timeout, CDK `BucketDeployment` Lambda OOM on docs deploy).** *Flag* a new subprocess/HTTP call to `sqlfmt`, dbt CLI, or an MCP endpoint with no timeout, or a timeout not cleared on success (a past bug left `setTimeout` alive after successful settlement).
+12. **Timeout/OOM in external process or cloud calls (sqlfmt discovery, MCP body timeout, CDK `BucketDeployment` Lambda OOM on docs deploy).** *Flag* a new subprocess/HTTP call to `sqlfmt`, dbt CLI, or an MCP endpoint with no timeout, or a timeout not cleared on success (a past bug left `setTimeout` alive after success).
 
 ## Repo invariants & landmines
 
-- Dbt integration backends (Core/Cloud/CoreCommand/Fusion) are consolidated behind a single `DbtIntegrationClient` (bound in `src/inversify.config.ts`), backed by the external `@altimateai/dbt-integration` library; the concrete backend is selected at runtime via the `dbtIntegration` setting (`core`/`cloud`/`corecommand`/`fusion`) — a fix that's backend-specific rarely applies unmodified to the other backends, so check which one(s) the PR needs to touch.
-- `webview_panels/` is a separate Vite/React app (own `package.json`, built via `panel:webviews` before the main `rsbuild build`) — changes there don't take effect until both build steps run.
+- Dbt integration backends (Core/Cloud/CoreCommand/Fusion) are consolidated behind a single `DbtIntegrationClient` (bound in `src/inversify.config.ts`, backed by `@altimateai/dbt-integration`); the backend is chosen at runtime via the `dbtIntegration` setting (`core`/`cloud`/`corecommand`/`fusion`) — a backend-specific fix rarely applies unmodified to the others, so check which one(s) the PR touches.
+- `webview_panels/` is a separate Vite/React app (own `package.json`, built via `panel:webviews` before `rsbuild build`) — changes don't take effect until both build steps run.
 - The Jupyter kernel bridge is a separate execution context from the TS extension host; errors there surface asynchronously and need their own guarding, not TS-side try/catch alone.
-- `docker-setup/` supports E2E verification against code-server + `jaffle-shop-duckdb` — reviewers use this to verify UI/activation changes end-to-end when unit tests can't cover it.
+- `docker-setup/` supports E2E verification against code-server + `jaffle-shop-duckdb` — use this to verify UI/activation changes end-to-end when unit tests can't.
 
 ## Known-intentional — don't flag
 
-- Stylistic nits reviewers have explicitly deferred ("not being followed in the repo for now, will create a separate PR if needed") — don't re-raise the same ask on every PR.
-- `@inject("DBTTerminal")`-style parameter decorators that are inert under `toDynamicValue` binding — intentional, they just document the token.
+- Stylistic nits reviewers have explicitly deferred — don't re-raise the same ask on every PR.
+- `@inject("DBTTerminal")`-style decorators inert under `toDynamicValue` binding — intentional, they just document the token.
 - `sweep.yaml` / bot-authored housekeeping PRs and dependency bumps with no behavior change — light-touch review only.
 
 ## High-blast-radius — never auto-edit
@@ -73,4 +73,4 @@ Trace the actual caller chain before flagging: who invokes this, with what value
 
 ## Comment style
 
-Exact-line comments, one finding per comment, most severe first. Prefer a concrete suggested diff over prose when the fix is small. Skip deep review of trivial diffs (typo fixes, dependency bumps, doc-only changes) — say `lgtm`. Don't repeat a finding another automated reviewer (e.g. CodeRabbit) already raised in the same PR thread.
+Exact-line comments, one finding per comment, most severe first. Prefer a concrete suggested diff over prose when the fix is small. Skip deep review of trivial diffs (typos, dependency bumps, doc-only changes) — say `lgtm`. Don't repeat a finding another automated reviewer (e.g. CodeRabbit) already raised in the same thread.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,6 +1,6 @@
 # REVIEW.md — vscode-dbt-power-user
 
-TypeScript VSCode extension (Inversify DI, `src/`) + React/Redux webview panels (`webview_panels/`) + a Python bridge (`dbt_core_integration.py` et al.) that makes VSCode work with dbt™ — autocomplete, lineage, query preview/execution, doc generation, an MCP server, and DataPilot AI chat.
+TypeScript VSCode extension (Inversify DI, `src/`) + React/Redux webview panels (`webview_panels/`) that makes VSCode work with dbt™ — autocomplete, lineage, query preview/execution, doc generation, an MCP server, and DataPilot AI chat.
 
 ## Goal: catch what CI cannot
 
@@ -52,9 +52,9 @@ Trace the actual caller chain before flagging: who invokes this, with what value
 
 ## Repo invariants & landmines
 
-- Multiple dbt integration backends exist (`dbtCoreIntegration.ts`, `dbtCloudIntegration.ts`, `dbtFusionCommandIntegration.ts`) — a fix for one (e.g. Core) rarely applies unmodified to Cloud/Fusion; check whether the PR needs to touch all three.
+- Dbt integration backends (Core/Cloud/CoreCommand/Fusion) are consolidated behind a single `DbtIntegrationClient` (bound in `src/inversify.config.ts`), backed by the external `@altimateai/dbt-integration` library; the concrete backend is selected at runtime via the `dbtIntegration` setting (`core`/`cloud`/`corecommand`/`fusion`) — a fix that's backend-specific rarely applies unmodified to the other backends, so check which one(s) the PR needs to touch.
 - `webview_panels/` is a separate Vite/React app (own `package.json`, built via `panel:webviews` before the main `rsbuild build`) — changes there don't take effect until both build steps run.
-- The Python bridge (`dbt_core_integration.py`, Jupyter kernel) is a separate execution context from the TS extension host; errors there surface asynchronously and need their own guarding, not TS-side try/catch alone.
+- The Jupyter kernel bridge is a separate execution context from the TS extension host; errors there surface asynchronously and need their own guarding, not TS-side try/catch alone.
 - `docker-setup/` supports E2E verification against code-server + `jaffle-shop-duckdb` — reviewers use this to verify UI/activation changes end-to-end when unit tests can't cover it.
 
 ## Known-intentional — don't flag


### PR DESCRIPTION
## Summary

Follow-up to #2025 (merged). Corrects two inaccuracies in `REVIEW.md` flagged by automated review, verified against current `master`:

- Removed stale references to `dbtCoreIntegration.ts` / `dbtCloudIntegration.ts` / `dbtFusionCommandIntegration.ts` — these no longer exist. The dbt integration backends are now consolidated into a single `DbtIntegrationClient` (bound in `src/inversify.config.ts`), backed by the external `@altimateai/dbt-integration` library, with the active backend selected at runtime via the `dbtIntegration` setting (`core`/`cloud`/`corecommand`/`fusion`).
- Removed references to `dbt_core_integration.py`, which no longer exists (removed when the dbt integration was extracted into the library).

## Test plan

- [x] Verified via `find`/`grep` that none of the three `*Integration.ts` files or `dbt_core_integration.py` exist in the repo
- [x] Verified `DbtIntegrationClient` binding in `src/inversify.config.ts` and its import from `@altimateai/dbt-integration`
- [x] Verified the `dbtIntegration` runtime config key and its `core` default
- [x] `wc -m REVIEW.md` stays under 10,000 (9,983)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to internal review guidance; no runtime or CI behavior is affected.
> 
> **Overview**
> Updates **REVIEW.md** so automated review guidance matches the current codebase, not the pre–library-extraction layout.
> 
> The overview and **Repo invariants** sections now describe a single runtime-selected **`DbtIntegrationClient`** (via `src/inversify.config.ts` and `@altimateai/dbt-integration`, with the `dbtIntegration` setting) instead of separate `*Integration.ts` files and **`dbt_core_integration.py`**. Execution-context notes point at the **Jupyter kernel bridge** rather than a Python dbt bridge.
> 
> Most other edits **tighten wording** in existing sections (CI scope, severity, focus areas, comment style) without changing review policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac494d5a97e49eb03c54a54001221a34f65c2415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the repo overview in the review guide to more clearly describe the TS VS Code extension and its dbt-focused capabilities (autocomplete, lineage, query execution, docs).
  * Revised “Repo invariants & landmines” guidance to reflect a single runtime-selected dbt integration path and to better distinguish the Jupyter kernel bridge from the extension host.
  * Reapplied guidance for exact-line comments formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->