### PR TITLE
docs: correct REVIEW.md inaccuracies flagged by automated review

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -52,9 +52,9 @@ Trace the actual caller chain before flagging: who invokes this, with what value
 
 ## Repo invariants & landmines
 
-- Dbt integration backends (Core/Cloud/CoreCommand/Fusion) are consolidated behind a single `DbtIntegrationClient` (bound in `src/inversify.config.ts`, backed by `@altimateai/dbt-integration`); the backend is chosen at runtime via the `dbtIntegration` setting (`core`/`cloud`/`corecommand`/`fusion`) — a backend-specific fix rarely applies unmodified to the others, so check which one(s) the PR touches.
+- `DBTProjectIntegrationAdapter` (`src/inversify.config.ts` ~L720-745) wraps four separate backend factories — Core/Cloud/Fusion/CoreCommand `*ProjectIntegration` classes — and picks one at runtime via the `dbtIntegration` setting (`core`/`cloud`/`corecommand`/`fusion`); a backend-specific fix rarely applies unmodified to the others, so check which one(s) the PR touches. (`DbtIntegrationClient` is a separate shared HTTP client, not the backend selector.)
 - `webview_panels/` is a separate Vite/React app (own `package.json`, built via `panel:webviews` before `rsbuild build`) — changes don't take effect until both build steps run.
-- The Jupyter kernel bridge is a separate execution context from the TS extension host; errors there surface asynchronously and need their own guarding, not TS-side try/catch alone.
+- The Python bridge (`dbt_core_integration.py`, vendored from `@altimateai/dbt-integration` and copied at build time by `rsbuild.config.ts`) and the Jupyter kernel are separate execution contexts from the TS extension host; errors there surface asynchronously and need their own guarding, not TS-side try/catch alone.
 - `docker-setup/` supports E2E verification against code-server + `jaffle-shop-duckdb` — use this to verify UI/activation changes end-to-end when unit tests can't.
 
 ## Known-intentional — don't flag


### PR DESCRIPTION
Round 3 fix to `REVIEW.md`, correcting two inaccuracies introduced in the round-2 pass (#2026) and flagged by automated review:

- **DI architecture claim.** Previously said the Core/Cloud/Fusion/CoreCommand backends are "consolidated behind a single `DbtIntegrationClient`." Verified against `src/inversify.config.ts` (~L720-745): they're still four separate factories (`DBTCoreProjectIntegration`/`DBTCloudProjectIntegration`/`DBTFusionCommandProjectIntegration`/`DBTCoreCommandProjectIntegration`), wired into `DBTProjectIntegrationAdapter`, which selects one at runtime via the `dbtIntegration` setting. `DbtIntegrationClient` is a separate, unrelated shared HTTP client bound elsewhere in the same file — not the backend selector.
- **Python bridge removal claim.** Previously omitted the dbt Python bridge, implying `dbt_core_integration.py` no longer exists. Verified against `rsbuild.config.ts`: it's still copied at build time (now vendored from `node_modules/@altimateai/dbt-integration/dist/...` rather than being a first-party file) alongside `node_python_bridge.py`. Restored this in the "Repo invariants & landmines" section.

Kept the file at 9,320 bytes (`wc -c`), under the 9,500-byte budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to reviewer guidance; no runtime or CI behavior changes.
> 
> **Overview**
> Updates **Repo invariants & landmines** in `REVIEW.md` so reviewers don’t follow two wrong mental models from the prior pass.
> 
> The dbt backend selection bullet now names **`DBTProjectIntegrationAdapter`** (~L720–745 in `inversify.config.ts`) as the runtime switch over four backend factories (Core/Cloud/Fusion/CoreCommand via `dbtIntegration`), and explicitly states that **`DbtIntegrationClient`** is a separate shared HTTP client, not the backend selector.
> 
> The async-execution bullet is expanded to include the **Python bridge** (`dbt_core_integration.py`, vendored from `@altimateai/dbt-integration` and copied at build time in `rsbuild.config.ts`) alongside the Jupyter kernel as execution contexts outside the TS host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d16995c906b7ab8b0c58142740ae800762980685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the dbt integration selection guidance in the repository checklist, including how the available backend options are chosen.
  * Updated the execution-context note to better distinguish the Python bridge and Jupyter kernel as separate contexts with their own safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->