### PR TITLE
ci: add aireceipts pr-check (notice-only cost receipt)

### DIFF
--- a/.github/workflows/aireceipts.yml
+++ b/.github/workflows/aireceipts.yml
@@ -1,0 +1,12 @@
+name: aireceipts
+on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npx -y aireceipts-cli@latest pr-check
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds a **notice-only** aireceipts cost-receipt check (pr-check) — one self-contained workflow, no external reusable workflow, no org Actions-policy change. Never fails a build; posts an aireceipts cost receipt only once a branch carries an aireceipts receipt ref, otherwise a quiet no-op. Coexists with any existing check; remove anytime by deleting the file. Part of an org-wide aireceipts dogfood.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional third-party CLI workflow with minimal repo permissions; no application or auth code changes.
> 
> **Overview**
> Adds a new GitHub Actions workflow **aireceipts** that runs on every pull request.
> 
> On each PR it runs `npx -y aireceipts-cli@latest pr-check` with `GH_TOKEN` so the CLI can read the repo and comment. Workflow permissions are **contents: read** and **pull-requests: write** (for posting receipts). Per the PR intent, this is notice-only: it does not fail the check run when there is no receipt ref; it posts an aireceipts cost receipt when the branch has one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1623b4852e156bfdb34f1cd290da2a35b70b56a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated check for pull requests to help catch issues earlier and improve review consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->