### PR TITLE
ci: add aireceipts auto-attach hook (two-file kit)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,19 @@
       "command": "npx",
       "args": ["-y", "@azure/mcp@latest", "server", "start"]
     }
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y aireceipts-cli@latest hook pre-push",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,11 +8,18 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+      "args": [
+        "@playwright/mcp@latest"
+      ]
     },
     "azure": {
       "command": "npx",
-      "args": ["-y", "@azure/mcp@latest", "server", "start"]
+      "args": [
+        "-y",
+        "@azure/mcp@latest",
+        "server",
+        "start"
+      ]
     }
   },
   "hooks": {
@@ -23,7 +30,7 @@
           {
             "type": "command",
             "command": "npx -y aireceipts-cli@latest hook pre-push",
-            "timeout": 10
+            "timeout": 60
           }
         ]
       }


### PR DESCRIPTION
Adds the aireceipts auto-attach hook (second file of the two-file kit) by **merging** a `hooks.PreToolUse` entry into the existing `.claude/settings.json` — your `permissions` and `mcpServers` config is preserved unchanged.

The hook runs `npx -y aireceipts-cli@latest hook pre-push`: it **never blocks your push** (exits 0 always, no output) and only acts on a real branch push to `origin`, so receipts generate automatically for the existing `pr-check` workflow to post. This repo runs no other `refs/receipts/*` producer (no collision). Revert anytime. Part of the org-wide aireceipts dogfood (v0.6.0).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local Claude tooling config only; no app runtime, auth, or deployment paths change.
> 
> **Overview**
> Extends **`.claude/settings.json`** with a **`hooks.PreToolUse`** rule for **Bash** that runs **`npx -y aireceipts-cli@latest hook pre-push`** (60s timeout), so receipt generation can run before shell/git push actions without changing existing **`permissions`** or **`mcpServers`**.
> 
> MCP **`args`** arrays are reformatted to multi-line only; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e049ae5200765477d8e59d4c29cec89958f37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reformatted the local AI tool configuration to use multi-line array formatting for improved readability (behavior unchanged).
  * Added a pre-execution hook for shell-based actions that runs an `aireceipts-cli` pre-push check before operations proceed.
  * Included a 60-second timeout to keep the validation fast and responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->