### PR TITLE
chore: bump @altimateai/dbt-integration to 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.61.7",
+  "version": "0.61.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.61.7",
+      "version": "0.61.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.3.4",
+        "@altimateai/dbt-integration": "^0.3.6",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.4.tgz",
-      "integrity": "sha512-H02msA+8qbUg4ULze3cbuKz07RtNgh2G3breQhAYVjHg/SpBUOkPYUfN2uSpnk0kVAIV/AsGmYsYt2cZ+CdlvQ==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.6.tgz",
+      "integrity": "sha512-BNcel9xNIo+0+GcZ3LXj9MbMaYjVeLrlXXEfuqotK/FdWXTY7273mpSt4z9fBOL8qHBifsZsqIX+EZdJvHxdvg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1285,7 +1285,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.3.4",
+    "@altimateai/dbt-integration": "^0.3.6",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",


### PR DESCRIPTION
## Status: waiting on dbt-integration 0.3.7

**Do not merge yet.** Retargeting from `0.3.6` to `0.3.7` — see below. The version/lockfile flip lands once 0.3.7 is published.

## What

Bumps `@altimateai/dbt-integration` and updates the lockfile, so the extension bundles a version carrying two things it needs.

## Why 0.3.7 and not 0.3.6

Originally opened as a `^0.3.6` bump to deliver the `windowsHide` spawn fix. That target is now superseded:

- **AltimateAI/altimate-dbt-integration#140** moves the packages-path exclusion rule into the library, exporting `isInsidePackagesPath`, `resolvePackagesInstallPath`, and `EXCLUDED_PROJECT_DIRS`.
- **#2031** now consumes exactly those exports, so it cannot compile against `0.3.6` (verified: the published `0.3.6` type declarations contain zero occurrences of all three symbols).

`0.3.7` will contain **both** the `windowsHide` fix and #140's new API, so a single bump serves both — no reason to land `0.3.6` first and bump again.

## Why a bump is required at all

The dependency is **bundled into `dist/` at build time**, so a library fix only reaches users once the extension is rebuilt against it. Note the caret range alone is not sufficient: `^0.3.4` already permits newer `0.3.x`, but `package-lock.json` pinned `0.3.4`, so `npm ci` in CI/release kept installing the old version. Both the range and the lockfile move here.

## Verification

Checked the **published npm artifacts** directly rather than trusting the range:

| Published version | `windowsHide` in dist | #140 API in `.d.ts` |
|---|---|---|
| `0.3.4` (current on master) | absent | absent |
| `0.3.6` | `windowsHide:true` | absent |
| `0.3.7` (pending) | expected present | expected present |

Will re-verify against the real `0.3.7` artifact once published, and update this table.

## Sequencing

1. dbt-integration #140 merges.
2. dbt-integration bumps to `0.3.7`, release cut, published to npm.
3. **This PR** flips to `^0.3.7` + lockfile, marked ready.
4. #2031 merges (it needs the API from step 1).
5. A power-user release carries this bump **and** #2031 — that release is what actually reaches the customer.

## Scope

Dependency bump only — no product code changes.