### PR TITLE
bump: 0.62.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.62.0",
+      "version": "0.62.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/AltimateAI/vscode-dbt-power-user/issues"
   },
-  "version": "0.62.0",
+  "version": "0.62.1",
   "engines": {
     "vscode": "^1.95.0",
     "node": ">=20.0.0"


### PR DESCRIPTION
## Overview

### Problem

`0.62.0` is already published to the VS Code Marketplace (2026-07-20 02:31 UTC, all platforms, stable). The phantom-project / multiple-windows fix (#2031) merged to `master` at 06:30 UTC — roughly four hours **after** that publish — so it is not in the released build. Confirmed by ancestry: the `0.62.0` tag does not contain #2031's commit.

Since a published version cannot be re-tagged, shipping the fix needs a new version.

### Solution

Patch bump `0.62.0` → `0.62.1`. Version lines only — `package.json` plus both `package-lock.json` entries, applied via `npm version` so they stay consistent. No dependency or source changes; `@altimateai/dbt-integration` stays at `^0.3.7`.

### What 0.62.1 will ship that 0.62.0 did not

- **#2031** — prevents phantom dbt project registration under `dbt_packages/`. The config file watcher was registering `dbt_project.yml` files that `dbt deps` writes during a project's initialization, cascading into repeated project registrations and, on Windows, a console window per spawned process.
- The `windowsHide` spawn hardening, which reaches the bundle via `@altimateai/dbt-integration@0.3.7` (already on `master`, bundled at build time).

### How to test

Version-only change; correctness is that the release tag matches `package.json`. The release workflow verifies this and fails the publish on mismatch.

`master` is green at `7200a0ba` (ci.yml, Tests, Lockfile Lint all passing), and #2031's own CI passed on every platform including all Windows lanes.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension version to 0.62.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->