### PR TITLE
chore: rename `creditsListenerRegistrationFailed` to end in `Error`

### DIFF
--- a/src/dbtPowerUserExtension.ts
+++ b/src/dbtPowerUserExtension.ts
@@ -212,7 +212,7 @@ export class DBTPowerUserExtension implements Disposable {
         // Listener registration must never block activation; record it so a
         // version-skew failure is observable instead of silently swallowed.
         this.telemetry.sendTelemetryError(
-          "creditsListenerRegistrationFailed",
+          "creditsListenerRegistrationError",
           error,
         );
       }


### PR DESCRIPTION
## Problem

`eslint src --ext ts` fails on `master`:

```
src/dbtPowerUserExtension.ts
  217:9  error  First argument to sendTelemetryError must be an event name ending in 'Error'
```

#1941 added the rule enforcing the `-Error` suffix. #2022 then added a
`sendTelemetryError("creditsListenerRegistrationFailed", …)` call, which
doesn't conform. Both are on `master`, so husky's pre-commit hook now
blocks any commit that doesn't happen to pass `--fix`.

## Fix

Rename the event to `creditsListenerRegistrationError`.

This is the only violation in `src` — every other `sendTelemetryError`
call already ends in `Error`. The renamed event has only ever been emitted
from `master` since #2022 merged, so there is no meaningful history keyed
to the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Edp1fABmdFnnjzYAGKeDxz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry reporting for errors encountered while registering credits listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->