### PR TITLE
feat: surface Snowflake Native App hook in the query panel

### DIFF
--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -77,4 +77,5 @@ export enum TelemetryEvents {
   "AltimateCode/RunHistoryFixClick" = "AltimateCode/RunHistoryFixClick",
   "AltimateCode/TroubleshootCodeActionClick" = "AltimateCode/TroubleshootCodeActionClick",
   "DocumentationEditor/UnitTestGenerateClick" = "DocumentationEditor/UnitTestGenerateClick",
+  "QueryPanel/OptimizeWarehouseClick" = "QueryPanel/OptimizeWarehouseClick",
 }

--- a/webview_panels/src/assets/icons/index.tsx
+++ b/webview_panels/src/assets/icons/index.tsx
@@ -183,3 +183,7 @@ export const OpenNewIcon = (
 export const SparkleIcon = (
   props: HTMLAttributes<HTMLElement>,
 ): JSX.Element => <Icon icon="sparkle" {...props} />;
+
+export const ZapIcon = (props: HTMLAttributes<HTMLElement>): JSX.Element => (
+  <Icon icon="zap" {...props} />
+);

--- a/webview_panels/src/modules/queryPanel/QueryPanel.stories.tsx
+++ b/webview_panels/src/modules/queryPanel/QueryPanel.stories.tsx
@@ -86,6 +86,12 @@ export const DefaultQueryPanelView = {
         if (request.command === "getCurrentUser") {
           return user;
         }
+        if (request.command === "configEnabled") {
+          return true;
+        }
+        if (request.command === "getProjectAdapterType") {
+          return "snowflake";
+        }
         if (request.command === "getQueryPanelContext") {
           window.postMessage({
             command: "getContext",

--- a/webview_panels/src/modules/queryPanel/QueryPanel.tsx
+++ b/webview_panels/src/modules/queryPanel/QueryPanel.tsx
@@ -11,6 +11,7 @@ import { QueryPanelTitleTabState } from "./components/QueryPanelContents/types";
 import ClearResultsButton from "./components/clearResultsButton/ClearResultsButton";
 import HelpButton from "./components/help/HelpButton";
 import ShowInTabButton from "./components/openInTabButton/OpenInTabButton";
+import OptimizeWarehouseButton from "./components/optimizeWarehouseButton/OptimizeWarehouseButton";
 import QueryLimit from "./components/queryLimit/QueryLimit";
 import NewNotebookButton from "./components/runAdhocQueryButton/NewNotebook";
 import RunAdhocQueryButton from "./components/runAdhocQueryButton/RunAdhocQueryButton";
@@ -42,7 +43,7 @@ const QueryPanel = (): JSX.Element => {
         <Stack direction="column" style={{ flex: 1 }}>
           <QueryPanelTitle tabState={tabState} setTabState={changeTabState} />
         </Stack>
-        <Stack>
+        <Stack className={classes.toolbar}>
           {viewType === QueryPanelViewType.DEFAULT && (
             <>
               <QueryLimit />
@@ -62,6 +63,7 @@ const QueryPanel = (): JSX.Element => {
                   Profile Query
                 </Button>
               )}
+              <OptimizeWarehouseButton />
               <NewNotebookButton />
               <RunAdhocQueryButton />
               <ShowInTabButton />

--- a/webview_panels/src/modules/queryPanel/QueryPanel.tsx
+++ b/webview_panels/src/modules/queryPanel/QueryPanel.tsx
@@ -46,8 +46,6 @@ const QueryPanel = (): JSX.Element => {
           {viewType === QueryPanelViewType.DEFAULT && (
             <>
               <QueryLimit />
-              <NewNotebookButton />
-              <RunAdhocQueryButton />
               {hasData && (
                 <Button
                   color="primary"
@@ -61,11 +59,13 @@ const QueryPanel = (): JSX.Element => {
                     })
                   }
                 >
-                  Profile this query
+                  Profile Query
                 </Button>
               )}
-              <ClearResultsButton />
+              <NewNotebookButton />
+              <RunAdhocQueryButton />
               <ShowInTabButton />
+              <ClearResultsButton />
             </>
           )}
           <CreditsChip />

--- a/webview_panels/src/modules/queryPanel/components/optimizeWarehouseButton/OptimizeWarehouseButton.tsx
+++ b/webview_panels/src/modules/queryPanel/components/optimizeWarehouseButton/OptimizeWarehouseButton.tsx
@@ -1,0 +1,59 @@
+import { ZapIcon } from "@assets/icons";
+import { executeRequestInSync } from "@modules/app/requestExecutor";
+import { sendTelemetryEvent } from "@modules/documentationEditor/components/telemetry";
+import { panelLogger } from "@modules/logger";
+import { vscode } from "@modules/vscode";
+import { TelemetryEvents } from "@telemetryEvents";
+import { Button } from "@uicore";
+import { useEffect, useState } from "react";
+
+// Snowflake Marketplace listing for the Altimate Native App. Opened in an
+// external browser; the app is installed from Snowflake, not from the extension.
+const SNOWFLAKE_NATIVE_APP_URL =
+  "https://app.snowflake.com/marketplace/listing/GZTYZ1VSPRPWK/altimate-ai-altimate-lite-for-ai-and-warehouse-cost-optimization";
+
+const SNOWFLAKE_ADAPTER = "snowflake";
+
+const OptimizeWarehouseButton = (): JSX.Element | null => {
+  const [isSnowflake, setIsSnowflake] = useState(false);
+
+  useEffect(() => {
+    executeRequestInSync("getProjectAdapterType", {})
+      .then((adapter) =>
+        setIsSnowflake(
+          typeof adapter === "string" &&
+            adapter.toLowerCase() === SNOWFLAKE_ADAPTER,
+        ),
+      )
+      .catch((err) => {
+        // Stay hidden when the adapter can't be determined, so the button never
+        // surfaces to non-Snowflake users.
+        panelLogger.error("error while getting project adapter type", err);
+        setIsSnowflake(false);
+      });
+  }, []);
+
+  const handleClick = () => {
+    sendTelemetryEvent(TelemetryEvents["QueryPanel/OptimizeWarehouseClick"]);
+    vscode.postMessage({ command: "openURL", url: SNOWFLAKE_NATIVE_APP_URL });
+  };
+
+  if (!isSnowflake) {
+    return null;
+  }
+
+  return (
+    <Button
+      color="success"
+      icon={<ZapIcon />}
+      showTextAlways
+      onClick={handleClick}
+      title="Optimize your Snowflake warehouses with the Altimate Native App"
+      aria-label="optimize-warehouse"
+    >
+      Optimize Warehouse
+    </Button>
+  );
+};
+
+export default OptimizeWarehouseButton;

--- a/webview_panels/src/modules/queryPanel/components/runAdhocQueryButton/NewNotebook.tsx
+++ b/webview_panels/src/modules/queryPanel/components/runAdhocQueryButton/NewNotebook.tsx
@@ -29,8 +29,13 @@ const NewNotebookButton = (): JSX.Element | null => {
   return (
     <>
       <NewFeatureIndicator featureKey="new-notebook-button-clicked">
-        <Button outline onClick={handleClick}>
-          + New notebook
+        <Button
+          outline
+          onClick={handleClick}
+          title="New notebook"
+          aria-label="New notebook"
+        >
+          +N
         </Button>
       </NewFeatureIndicator>
     </>

--- a/webview_panels/src/modules/queryPanel/components/runAdhocQueryButton/RunAdhocQueryButton.tsx
+++ b/webview_panels/src/modules/queryPanel/components/runAdhocQueryButton/RunAdhocQueryButton.tsx
@@ -1,4 +1,3 @@
-import { AddIcon } from "@assets/icons";
 import { executeRequestInAsync } from "@modules/app/requestExecutor";
 import { Button } from "@uicore";
 
@@ -11,9 +10,9 @@ const RunAdhocQueryButton = (): JSX.Element => {
       aria-label="open-adhoc-query"
       outline
       onClick={handleClick}
-      icon={<AddIcon />}
+      title="New query"
     >
-      New query
+      +Q
     </Button>
   );
 };

--- a/webview_panels/src/modules/queryPanel/constants.ts
+++ b/webview_panels/src/modules/queryPanel/constants.ts
@@ -27,4 +27,16 @@ export const HINTS = [
     message: "Write & edit dbt tests in UI",
     link: "https://docs.myaltimate.com/test/writetests/",
   },
+  {
+    message: "Debug dbt project with altimate-code",
+    link: "https://help.altimate.ai/dbt-power-user/teammates/altimate-code",
+  },
+  {
+    message: "Ask how this column is calculated",
+    link: "https://help.altimate.ai/dbt-power-user/teammates/altimate-code",
+  },
+  {
+    message: "Autotune warehouses with Snowflake Native App",
+    link: "https://altimateai.github.io/altimate-snowflake-app/",
+  },
 ];

--- a/webview_panels/src/modules/queryPanel/querypanel.module.scss
+++ b/webview_panels/src/modules/queryPanel/querypanel.module.scss
@@ -186,3 +186,24 @@
 .searchInput::-webkit-search-cancel-button {
   display: none;
 }
+
+// Action toolbar. The labelled buttons keep their text on a single line so they
+// match the rest of the row's height; the row wraps once it runs out of width so
+// the trailing controls stay reachable in a narrow panel instead of clipping.
+.toolbar {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  row-gap: 0.5rem;
+
+  :global(.btn) {
+    white-space: nowrap;
+  }
+
+  // Filled variants ship without a border while outline variants carry a 1px
+  // one, leaving the solid buttons 2px shorter than their neighbours. A
+  // transparent border squares the heights up without altering the fill.
+  :global(.btn-primary),
+  :global(.btn-success) {
+    border: 1px solid transparent;
+  }
+}


### PR DESCRIPTION
Surfaces the Snowflake Native App hook in the query panel, together with the toolbar compaction that makes room for it and the remaining query-loader tips.

## Optimize Warehouse button

- **Snowflake users only.** Gated on the existing `getProjectAdapterType` request (the active project's adapter). This request already existed on the extension host and had no webview caller, so no backend change was needed. It **fails closed** — if the adapter can't be resolved the button stays hidden, so it never surfaces to non-Snowflake users.
- **Opens the Snowflake Marketplace listing** for the Native App in an external browser via the existing `openURL` command. The app is installed from Snowflake, so this is a link out rather than an in-panel flow. The URL is a single named constant.
- **Emits `QueryPanel/OptimizeWarehouseClick`** on every click.

## Toolbar

- `+ New notebook` → `+N` and `New query` → `+Q`, as always-visible chips with `title` tooltips. `New notebook` previously had no accessible label at all.
- Dropped `AddIcon` from `New query`. `Button` hides its text until hover when an `icon` is set, so it rendered as a bare `+` that expanded on hover while its neighbour always showed full text.
- `Profile this query` → `Profile Query`.
- Regrouped to the design: limit │ Profile Query, Optimize Warehouse │ `+N` `+Q` │ open-in-tab, clear results.
- **Labels stay on one line and the row wraps** once it runs out of width. Previously the labelled buttons wrapped their text and the trailing controls clipped out of reach in a narrow panel — adding a second labelled button made that materially worse.
- **Squared up button heights.** Filled variants ship without a border while outline variants carry a 1px one, leaving the solid buttons 2px shorter than their neighbours.

## Query loader tips

Adds the altimate-code and Snowflake Native App hints.

## Toolbar, before / after

Query panel at a narrow width (720px). Before, `+ New notebook` and `Profile this query` each wrap onto two lines, inflating the toolbar height — the whole point of the change is horizontal room:

![before](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/query-toolbar-rearrange/before-toolbar.png)

After, at the same width and with the new button present — every label on one line, all buttons the same height, and the row wraps rather than clipping the trailing controls out of reach:

![after](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/query-toolbar-rearrange/after-toolbar-720.png)

With more width, the whole row fits including the credits chip:

![full](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/query-toolbar-rearrange/after-full-toolbar.png)

## Query loader tips

The new Snowflake tip, with its docs link:

![tip](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/query-toolbar-rearrange/loader-tip-snowflake.png)

## Verification

`tsc --noEmit`, `eslint` and `prettier` clean on the changed files.

End-to-end in code-server against a real dbt project, using the packaged build.

**Non-Snowflake project (duckdb) — button correctly hidden:**

![duckdb](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/query-toolbar-rearrange/e2e-duckdb-hidden.png)

**Snowflake project — button visible, same height as its neighbours:**

![snowflake](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/query-toolbar-rearrange/e2e-snowflake-visible.png)

**Clicking it opens the Marketplace listing** — code-server's external-link prompt showing the resolved URL:

![openurl](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/main/query-toolbar-rearrange/e2e-openurl-dialog.png)

Measured after the layout fix, every toolbar button reports an identical 29.75px height, and both labelled buttons render on a single line.

## Notes for review

- `+N` only renders when `dbt.enableNotebooks` is on — unchanged by this PR. The Query Panel story now mocks the notebook and adapter gates so the full toolbar, including the gated button, renders in Storybook.
- The button is deliberately **not** gated on `hasData` — it is a promotional hook, not a result action, so it shows whenever a Snowflake project is active.
- `aria-label="open-adhoc-query"` on the new-query button is unchanged; nothing references it, but it is kept as a stable hook.
- The toolbar overflow behaviour was pre-existing: at narrow widths the trailing controls previously clipped out of reach rather than wrapping. That is fixed here because this PR adds a second labelled button and would otherwise have made it worse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Optimize Warehouse” action for Snowflake projects, linking to the Snowflake Native App.
  * Added new query panel guidance for debugging, column calculations, and warehouse optimization.
  * Added a Zap icon and improved toolbar organization.

* **Improvements**
  * Improved button labels, tooltips, accessibility, and toolbar responsiveness.
  * Aligned button sizing and styling across query actions.

* **Bug Fixes**
  * Fixed search input styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->