### PR TITLE
fix: stop What's New links opening two browser tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.63.0",
+      "version": "0.64.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/AltimateAI/vscode-dbt-power-user/issues"
   },
-  "version": "0.63.0",
+  "version": "0.64.0",
   "engines": {
     "vscode": "^1.95.0",
     "node": ">=20.0.0"

--- a/webview_panels/package-lock.json
+++ b/webview_panels/package-lock.json
@@ -8,7 +8,7 @@
       "name": "webview_panels",
       "version": "0.0.0",
       "dependencies": {
-        "@altimateai/ui-components": "0.0.86",
+        "@altimateai/ui-components": "^0.0.87",
         "@ant-design/pro-chat": "^1.15.2",
         "@finos/perspective": "^2.10.0",
         "@finos/perspective-viewer": "^2.10.0",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@altimateai/ui-components": {
-      "version": "0.0.86",
-      "resolved": "https://registry.npmjs.org/@altimateai/ui-components/-/ui-components-0.0.86.tgz",
-      "integrity": "sha512-D+wdEMAEVL3SOX9u+H8acFrmqC0FGGBbWNrphmNFmbDUh4M3IVSke5F4NMiAIV8t8qWGZ5XICoEAnS340qLAPw==",
+      "version": "0.0.87",
+      "resolved": "https://registry.npmjs.org/@altimateai/ui-components/-/ui-components-0.0.87.tgz",
+      "integrity": "sha512-aRcZDjBVqlsN7Dt85XvAMBsK6u5OtR/7USs2eK6DfitxdIZcWvJe8bmotfoR32HJT162RgiWrtu4EVj35ppbOA==",
       "dependencies": {
         "@ai-sdk/react": "^3.0.14",
         "@floating-ui/react": "^0.27.16",

--- a/webview_panels/package.json
+++ b/webview_panels/package.json
@@ -18,7 +18,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@altimateai/ui-components": "0.0.86",
+    "@altimateai/ui-components": "^0.0.87",
     "@ant-design/pro-chat": "^1.15.2",
     "@finos/perspective": "^2.10.0",
     "@finos/perspective-viewer": "^2.10.0",

--- a/webview_panels/src/modules/whatsNew/WhatsNew.tsx
+++ b/webview_panels/src/modules/whatsNew/WhatsNew.tsx
@@ -311,6 +311,10 @@ const WhatsNew = (): JSX.Element => {
             title={`Open ${FULL_CHANGELOG_URL} in your browser`}
             onClick={(e) => {
               e.preventDefault();
+              // Also stop the click reaching VS Code's own webview anchor handler,
+              // which would open the URL a second time (once via our openURL, once
+              // via the host's native external-link handling).
+              e.stopPropagation();
               onFullChangelog("error_state");
             }}
           >
@@ -343,6 +347,10 @@ const WhatsNew = (): JSX.Element => {
           title="Open altimate.ai in your browser"
           onClick={(e) => {
             e.preventDefault();
+            // Also stop the click reaching VS Code's own webview anchor handler,
+            // which would open the URL a second time (once via our openURL, once
+            // via the host's native external-link handling).
+            e.stopPropagation();
             onSiteLink("logo");
           }}
         >
@@ -355,6 +363,10 @@ const WhatsNew = (): JSX.Element => {
             title={`Open ${FULL_CHANGELOG_URL} in your browser`}
             onClick={(e) => {
               e.preventDefault();
+              // Also stop the click reaching VS Code's own webview anchor handler,
+              // which would open the URL a second time (once via our openURL, once
+              // via the host's native external-link handling).
+              e.stopPropagation();
               onFullChangelog("topbar");
             }}
           >
@@ -366,6 +378,10 @@ const WhatsNew = (): JSX.Element => {
             title="Open altimate.ai in your browser"
             onClick={(e) => {
               e.preventDefault();
+              // Also stop the click reaching VS Code's own webview anchor handler,
+              // which would open the URL a second time (once via our openURL, once
+              // via the host's native external-link handling).
+              e.stopPropagation();
               onSiteLink("topbar");
             }}
           >
@@ -392,6 +408,10 @@ const WhatsNew = (): JSX.Element => {
             title={`Open ${manifest.base_url} in your browser`}
             onClick={(e) => {
               e.preventDefault();
+              // Also stop the click reaching VS Code's own webview anchor handler,
+              // which would open the URL a second time (once via our openURL, once
+              // via the host's native external-link handling).
+              e.stopPropagation();
               onFullChangelog("cta");
             }}
           >
@@ -411,6 +431,10 @@ const WhatsNew = (): JSX.Element => {
                 title={`Open ${link.url} in your browser`}
                 onClick={(e) => {
                   e.preventDefault();
+                  // Also stop the click reaching VS Code's own webview anchor handler,
+                  // which would open the URL a second time (once via our openURL, once
+                  // via the host's native external-link handling).
+                  e.stopPropagation();
                   onProductLink(link.label, link.url);
                 }}
               >
@@ -570,6 +594,10 @@ const WhatsNew = (): JSX.Element => {
           title={`Open ${FULL_CHANGELOG_URL} in your browser`}
           onClick={(e) => {
             e.preventDefault();
+            // Also stop the click reaching VS Code's own webview anchor handler,
+            // which would open the URL a second time (once via our openURL, once
+            // via the host's native external-link handling).
+            e.stopPropagation();
             onFullChangelog("footer");
           }}
         >

--- a/webview_panels/src/modules/whatsNew/WhatsNew.tsx
+++ b/webview_panels/src/modules/whatsNew/WhatsNew.tsx
@@ -4,7 +4,14 @@ import {
 } from "@modules/app/requestExecutor";
 import { panelLogger } from "@modules/logger";
 import { TelemetryEvents } from "@telemetryEvents";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import "./fonts.scss";
 import {
   AltimateWordmark,
@@ -82,6 +89,23 @@ const PRODUCT_LINKS = [
 
 const FULL_CHANGELOG_URL = "https://altimate.ai/changelog";
 const ALTIMATE_SITE_URL = "https://altimate.ai";
+
+/**
+ * Click handler for a link that opens outside the editor.
+ *
+ * `preventDefault` stops the webview iframe navigating to the href, and
+ * `stopPropagation` stops the click reaching VS Code's own webview anchor
+ * handler, which would otherwise open the URL a second time — once through our
+ * `openURL` message, once through the host's native external-link handling.
+ * The href stays on the element so it remains a real, focusable link.
+ */
+const openExternal =
+  (open: () => void) =>
+  (e: MouseEvent<HTMLAnchorElement>): void => {
+    e.preventDefault();
+    e.stopPropagation();
+    open();
+  };
 
 const monthKey = (iso: string): string => iso.slice(0, 7);
 
@@ -309,14 +333,7 @@ const WhatsNew = (): JSX.Element => {
           <a
             href={FULL_CHANGELOG_URL}
             title={`Open ${FULL_CHANGELOG_URL} in your browser`}
-            onClick={(e) => {
-              e.preventDefault();
-              // Also stop the click reaching VS Code's own webview anchor handler,
-              // which would open the URL a second time (once via our openURL, once
-              // via the host's native external-link handling).
-              e.stopPropagation();
-              onFullChangelog("error_state");
-            }}
+            onClick={openExternal(() => onFullChangelog("error_state"))}
           >
             Open the full changelog →
           </a>
@@ -345,14 +362,7 @@ const WhatsNew = (): JSX.Element => {
           href="https://altimate.ai"
           aria-label="Altimate AI"
           title="Open altimate.ai in your browser"
-          onClick={(e) => {
-            e.preventDefault();
-            // Also stop the click reaching VS Code's own webview anchor handler,
-            // which would open the URL a second time (once via our openURL, once
-            // via the host's native external-link handling).
-            e.stopPropagation();
-            onSiteLink("logo");
-          }}
+          onClick={openExternal(() => onSiteLink("logo"))}
         >
           <AltimateWordmark />
         </a>
@@ -361,14 +371,7 @@ const WhatsNew = (): JSX.Element => {
             className={classes.topbarLink}
             href={FULL_CHANGELOG_URL}
             title={`Open ${FULL_CHANGELOG_URL} in your browser`}
-            onClick={(e) => {
-              e.preventDefault();
-              // Also stop the click reaching VS Code's own webview anchor handler,
-              // which would open the URL a second time (once via our openURL, once
-              // via the host's native external-link handling).
-              e.stopPropagation();
-              onFullChangelog("topbar");
-            }}
+            onClick={openExternal(() => onFullChangelog("topbar"))}
           >
             Full changelog
           </a>
@@ -376,14 +379,7 @@ const WhatsNew = (): JSX.Element => {
             className={classes.topbarLink}
             href="https://altimate.ai"
             title="Open altimate.ai in your browser"
-            onClick={(e) => {
-              e.preventDefault();
-              // Also stop the click reaching VS Code's own webview anchor handler,
-              // which would open the URL a second time (once via our openURL, once
-              // via the host's native external-link handling).
-              e.stopPropagation();
-              onSiteLink("topbar");
-            }}
+            onClick={openExternal(() => onSiteLink("topbar"))}
           >
             altimate.ai
           </a>
@@ -406,14 +402,7 @@ const WhatsNew = (): JSX.Element => {
             className={classes.cta}
             href={manifest.base_url}
             title={`Open ${manifest.base_url} in your browser`}
-            onClick={(e) => {
-              e.preventDefault();
-              // Also stop the click reaching VS Code's own webview anchor handler,
-              // which would open the URL a second time (once via our openURL, once
-              // via the host's native external-link handling).
-              e.stopPropagation();
-              onFullChangelog("cta");
-            }}
+            onClick={openExternal(() => onFullChangelog("cta"))}
           >
             View full changelog
             <ArrowIcon />
@@ -429,14 +418,7 @@ const WhatsNew = (): JSX.Element => {
                 className={classes.asideLink}
                 href={link.url}
                 title={`Open ${link.url} in your browser`}
-                onClick={(e) => {
-                  e.preventDefault();
-                  // Also stop the click reaching VS Code's own webview anchor handler,
-                  // which would open the URL a second time (once via our openURL, once
-                  // via the host's native external-link handling).
-                  e.stopPropagation();
-                  onProductLink(link.label, link.url);
-                }}
+                onClick={openExternal(() => onProductLink(link.label, link.url))}
               >
                 {link.label}
                 <ExternalArrowIcon className={classes.asideArrow} />
@@ -592,14 +574,7 @@ const WhatsNew = (): JSX.Element => {
         <a
           href={FULL_CHANGELOG_URL}
           title={`Open ${FULL_CHANGELOG_URL} in your browser`}
-          onClick={(e) => {
-            e.preventDefault();
-            // Also stop the click reaching VS Code's own webview anchor handler,
-            // which would open the URL a second time (once via our openURL, once
-            // via the host's native external-link handling).
-            e.stopPropagation();
-            onFullChangelog("footer");
-          }}
+          onClick={openExternal(() => onFullChangelog("footer"))}
         >
           See the full platform changelog →
         </a>


### PR DESCRIPTION
## What

External links in the What's New panel opened **two browser tabs** per click. Fix: add `stopPropagation()` to all seven link handlers.

## Root cause

Each link carries both an `href` (for real-link semantics — focusable, announced as a link, hover URL) and an `onClick` that calls `preventDefault()` and routes the open through the host's `openURL`. `preventDefault()` stops the iframe from navigating, but the click still **bubbled to VS Code's own webview anchor handler**, which opened the same URL a second time via the host's native external-link handling. One click → two opens.

Adding `stopPropagation()` keeps the click from reaching the native handler, so only our controlled `openURL` path fires. The `href` stays, so accessibility is unchanged.

Applied to all seven handlers: the four "Also from Altimate AI" product links, the topbar changelog + altimate.ai links, the hero CTA, and the footer.

## Verification (code-server E2E)

Driven in a real webview (code-server on this branch), one trusted mouse click per link:

| | before | after |
|---|---|---|
| product link (`onProductLink`) | tab opens immediately **+** a second on confirming the prompt = **2 tabs** | one prompt → **1 tab** |
| hero CTA (`onFullChangelog`) | — | one prompt → **1 tab** |

The premature immediate-open is gone; each click now yields exactly one tab.

## Scope note

Reproduced and fixed in **code-server** (browser-based VS Code), where "open external" is a browser tab and both the extension's `openExternal` and the webview's native anchor handler fire. Whether native VS Code (Electron) exhibits the same double-open was **not** verified here — Electron routes external opens differently and may not run the second handler. The fix is a no-op in the single-open case, so it is safe regardless.

Fixes the double-open finding from QA (tracked in the internal ticket).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external links in the What’s New panel opening twice by preventing the webview host from also handling the click.
* **Improvements**
  * Updated link handling across the changelog entry, product links, header, footer, and main call-to-action to ensure consistent external navigation behavior.
* **Chores**
  * Bumped the extension version to 0.64.0.
  * Updated the `@altimateai/ui-components` dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Version

Bumps to **0.64.0**.

Minor rather than patch on purpose. 0.63.0 shipped the What's New panel but **never showed it to anyone**: the auto-open compares against a `whatsNew.lastSeenVersion` marker that the feature itself introduces, so on its debut release no user had one and everybody hit the fresh-install early return. Anyone who ran 0.63.0 now *has* that marker, so a minor bump is what actually surfaces the page for them — a patch release would leave it hidden for another cycle.

So this release does two things: ships the double-open fix, and makes the What's New page appear for the first time.

## Also carries: ui-components 0.0.87

Bumps `@altimateai/ui-components` 0.0.86 → 0.0.87 so #3010 (AI-7764 — lineage Depth-controls disabled state + CLL nudges) rides into the extension's lineage panel with this release.

Verified in code-server: `tsc` clean (no API drift), webview builds clean, and the lineage panel renders the `customers` model graph with the updated `TableDetails`/Depth controls and **0 console errors**.