### PR TITLE
bump: 0.64.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.64.0",
+      "version": "0.64.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/AltimateAI/vscode-dbt-power-user/issues"
   },
-  "version": "0.64.0",
+  "version": "0.64.1",
   "engines": {
     "vscode": "^1.95.0",
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

Version bump `0.64.0` → `0.64.1` (`package.json` + `package-lock.json` only) to release the changes merged since 0.64.0:

- #2034 — `fix: idempotent python-bridge teardown to stop ERR_IPC_DISCONNECTED masking query errors`
- #2051 — `docs(query-results): document Explain with Altimate Code and Profile this query`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XT9HSfkyG6vXQGaL5mYs1F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension version from 0.64.0 to 0.64.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->