### PR TITLE
bump: 0.64.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.64.1",
+  "version": "0.64.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.64.1",
+      "version": "0.64.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/AltimateAI/vscode-dbt-power-user/issues"
   },
-  "version": "0.64.1",
+  "version": "0.64.2",
   "engines": {
     "vscode": "^1.95.0",
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

Version bump `0.64.1` → `0.64.2` (`package.json` + `package-lock.json` only) to release the changes merged since 0.64.1:

- #2056 — `chore: add UTM parameters to altimate.ai website links`

## What goes out

The ~58 altimate.ai links across the extension's surfaces — marketplace README, in-product strings (`package.nls.json`, What's New, onboarding wizard, lineage help), and docs — now carry `utm_source=dbt-power-user` + `utm_medium=marketplace|extension|docs`, so extension-driven website traffic attributes in analytics instead of reporting as Direct. No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9whkH8qHDzKWVa2H1xLWM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension version to 0.64.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->