### PR TITLE
fix: bump @altimateai/dbt-integration to ^0.3.8 for dbt-core 1.12 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.3.7",
+        "@altimateai/dbt-integration": "^0.3.8",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.7.tgz",
-      "integrity": "sha512-Ovw86l3X59g746dsdkRyc+v2mM3y3lxK9WspCEVpRvf08r3ykBh4npmFSGLazqj8IySU/t0ZdlnNBar92oIBsw==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.8.tgz",
+      "integrity": "sha512-U8E4bZbL24NRr9NqZjCvqcJ/hFi/nRW6Puo7+l2M1e7jDobx+JAQhelxwBVX9/1u1xPZTU6En0DLbEWKoo3IcQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1295,7 +1295,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.3.7",
+    "@altimateai/dbt-integration": "^0.3.8",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",


### PR DESCRIPTION
## What

Bumps `@altimateai/dbt-integration` `^0.3.7` → `^0.3.8` to pick up the dbt-core 1.12 serialization fix (AltimateAI/altimate-dbt-integration#144, released in 0.3.8).

Fixes #2038.

## Why

dbt-core >= 1.12.0 adds a `threading.Lock` to every `CompiledNode`. dbt-integration 0.3.7's `to_dict` leaked the raw lock into python-bridge JSON serialization, so query preview, doc generation, and metadata fetch all fail with `TypeError: must be real number, not _thread.lock` (reported across Databricks, Snowflake, Trino, and Fabric Spark in #2038; also intermittent under Python 3.13, which forces dbt-core >= 1.12). All runtime python files (`node_python_bridge.py`, `dbt_core_integration.py`, `dbt_utils.py`, altimate packages) are copied from the package dist at build time — the dependency bump alone delivers the fix, no extension code change.

## Verification (full stack)

Real extension in docker code-server, dbt-core 1.12.0 + dbt-duckdb, jaffle-shop fixture; the only variable between runs is the dbt-integration package. Evidence also posted on AltimateAI/altimate-dbt-integration#149.

| Before (0.3.7) | After (0.3.8 candidate) |
|---|---|
| ![before](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/5bcdaba1f7c793a7d512c3f246616f93724652b8/dbt112-lock-release/before-query-preview-thread-lock-2038.png) | ![after](https://raw.githubusercontent.com/ralphstodomingo/altimate-pr-assets/5bcdaba1f7c793a7d512c3f246616f93724652b8/dbt112-lock-release/after-query-preview-results-2038.png) |
| Execute dbt SQL fails: `must be real number, not _thread.lock` | Same model: Preview 100 rows in 1.6s |

## Status

- [ ] `package-lock.json` refresh pending `0.3.8` on npm (publishes when AltimateAI/altimate-dbt-integration#149 merges and `v0.3.8` is released) — CI will be red until that commit lands; it follows within minutes of the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwKEMFXkk8GZvtckw5d6xj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dbt integration package to the latest compatible release, including maintenance improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->