### PR TITLE
bump: 0.64.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.64.2",
+      "version": "0.64.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/AltimateAI/vscode-dbt-power-user/issues"
   },
-  "version": "0.64.2",
+  "version": "0.64.3",
   "engines": {
     "vscode": "^1.95.0",
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

Version bump `0.64.2` → `0.64.3` (`package.json` + `package-lock.json` only) to release the changes merged since 0.64.2:

- #2059 — `fix: bump @altimateai/dbt-integration to ^0.3.8 for dbt-core 1.12 support` (fixes #2038)
- #2057 — `fix: repair the macOS CI integration test jobs`
- #2050 — `chore: upload the packaged VSIX as a PR artifact`

## What goes out

Query preview, doc generation, and metadata fetch work again on **dbt-core >= 1.12.0** — dbt-integration 0.3.8 fixes the `TypeError: must be real number, not _thread.lock` crash caused by dbt-core 1.12 adding a `threading.Lock` to `CompiledNode` (reported across Databricks, Snowflake, Trino, and Fabric Spark in #2038). Full-stack before/after verification is on #2059. #2057 and #2050 are CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013S9dDk3qa8Y9Mm9fdUtFdP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension to version 0.64.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->