### PR TITLE
docs: sync from help-docs (source of truth)

### DIFF
--- a/documentation/docs/arch/beta.md
+++ b/documentation/docs/arch/beta.md
@@ -1,16 +1,21 @@
+---
+title: dbt Cloud Integration — Beta Features
+description: "Beta features for dbt Cloud integration in Power User for dbt, including the API key requirement and preview limitations."
+---
+
 /// admonition | Only use the following steps for "dbt Cloud" environments. If you have a dbt Core environment, use the [required config instructions for "dbt Core" environments](../setup/reqdConfig.md). If you have a dbt Fusion environment, use the [required config instructions for "dbt Fusion" environments](../setup/reqdConfigFusion.md).
-    type: warning
+type: warning
 ///
 
 /// admonition | dbt Cloud integration is available as beta functionality
-    type: tip
+type: tip
 ///
 
 ## Enable dbt Cloud Integration by adding an API key
 
 dbt Cloud integration in Power User VSCode extension requires an API key. There are also multiple preview features in the extension including [generate dbt documentation](../document/generatedoc.md), [column lineage](../test/lineage.md), [query explanation](../develop/explanation.md), [generate dbt model from SQL](../develop/genmodelSQL.md) that are also enabled with an API key.
 
-/// details | You can get an API key for free by signing up at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
+/// details | You can get an API key for free by signing up at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
 
 <interactive demo to get an API key>
 
@@ -31,8 +36,8 @@ Go to the VSCode extension settings, and then add an API key and instance name.
 
 ## Use the setup wizard for configuration (recommended)
 
-/// admonition | Need to setup environment variables? Refer to this [section](https://docs.myaltimate.com/setup/optConfig/#environment-variables-setup)
-    type: warning
+/// admonition | Need to setup environment variables? Refer to this [section](/setup/optConfig/#environment-variables-setup)
+type: warning
 ///
 
 This method will save a bunch of time for you, and you can also validate your configuration. Setup wizard will help you in associating sql files with jinja-sql, selecting the right Python interpreter, make sure dbt dependencies are correctly installed etc. In the end, it will also validate your configuration.
@@ -48,7 +53,7 @@ You can start the setup wizard by clicking on dbt status icon in the bottom stat
 Click on the action button - "Select Python Interpreter" and choose your preferred python interpreter. Usually, choosing an interpreter that's recommended or mapped to your virtual environment software (e.g. venv) as per the list is a good idea. If you know the path of your Python environment, you can choose it from the list, or if the path is not present, you can enter it manually.
 
 /// admonition | If needed, please run 'where python' command on terminal to see if it shows path to Python interpreter that you are using.
-    type: tip
+type: tip
 ///
 
 **Install dbt**
@@ -61,7 +66,7 @@ Last step is clicking on button - "Validate Project" It will run a bunch of chec
 If there are some issues, it will tell you exactly what's wrong as well.
 
 /// admonition | If you still can't get the extension setup correctly, please check the [troubleshooting page](../troubleshooting.md)
-    type: tip
+type: tip
 ///
 
 ## Recorded Demo
@@ -86,7 +91,7 @@ A direct line of communication with our users is established with the authentica
 
 #### What if I don't want to use preview features or accidentally send data to Altimate?
 
-We understand the concern about using preview features and the risk of accidental data transmission. To address this, we have implemented stringent data security practices, which you can review in our [security FAQ](https://docs.myaltimate.com/arch/faq/). Our solutions have passed security reviews by several large organizations in the US, and we are open to undergoing similar reviews for your organization. Additionally, we are working on making some preview features available offline through our [open-source Python CLI package](https://github.com/AltimateAI/datapilot-cli).
+We understand the concern about using preview features and the risk of accidental data transmission. To address this, we have implemented stringent data security practices, which you can review in our [security FAQ](/arch/faq/). Our solutions have passed security reviews by several large organizations in the US, and we are open to undergoing similar reviews for your organization. Additionally, we are working on making some preview features available offline through our [open-source Python CLI package](https://github.com/AltimateAI/datapilot-cli).
 
 #### How are you addressing concerns about data transmission in preview features?
 

--- a/documentation/docs/arch/faq.md
+++ b/documentation/docs/arch/faq.md
@@ -1,10 +1,15 @@
-The dbt Power User extension is developed and maintained by [Altimate AI](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs). We are a software company based in the San Francisco Bay Area and have many large enterprise companies as customers.
+---
+title: FAQ — Power User for dbt
+description: "Frequently asked questions about Power User for dbt: company info, SOC 2 certification, security measures, and TLS encryption."
+---
+
+The Power User for dbt extension is developed and maintained by [Altimate AI](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link). We are a software company based in the San Francisco Bay Area and have many large enterprise companies as customers.
 We have done many security/governance reviews for these companies and we are SOC 2 Type 2 certified.
 
-Here is our [Privacy Policy](https://www.altimate.ai/privacy?utm_source=dbt-power-user&utm_medium=docs) and [Terms of Use](https://www.altimate.ai/terms?utm_source=dbt-power-user&utm_medium=docs).
+Here is our [Privacy Policy](https://www.altimate.ai/privacy?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) and [Terms of Use](https://www.altimate.ai/terms?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link).
 
-/// admonition | If you need us to do a security review with your IT / security teams, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: tip
+/// admonition | If you need us to do a security review with your IT / security teams, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: tip
 ///
 
 ### **Security Measures & Protocols**
@@ -37,8 +42,8 @@ Users are authenticated with email and password combinations in the SaaS UI. In 
 
 Yes, at Altimate AI, we have a robust disaster recovery plan in place. Our data is backed up frequently to ensure minimal data loss. In the event of any system failure, our recovery processes are designed to restore services within an hour. This quick recovery time minimizes disruptions and ensures the continuity of our services for our users.
 
-/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: tip
+/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: tip
 ///
 
 ---
@@ -68,8 +73,8 @@ At Altimate AI, we maintain a strict policy of not retaining data related to the
 We do not store any actual customer data, we only store aggregate statistics and metadata. As a result, GDPR data deletion requests do not need to be propagated to us because we do not store such data.
 Our customers typically do not request or require DPAs. However, we're happy to provide a DPA or review a vendor DPA if your organization needs it.
 
-/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: tip
+/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: tip
 ///
 
 ### 5. **What is your cookie policy?**
@@ -95,8 +100,8 @@ We employ strict data isolation and access controls. The multi-tenant architectu
 
 Currently, we do not use client data for model training, so there's no opt-in or opt-out mechanism. If our policy were to change in the future, we would provide users with clear communication and choices regarding the use of their data.
 
-/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: tip
+/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: tip
 ///
 
 ---
@@ -129,18 +134,18 @@ You can opt out of all telemetry by reaching out to us via the Intercom chat bui
 
 ### 3. **What metadata does the Altimate LLM Gateway collect?**
 
-| Metadata | Purpose |
-|----------|---------|
-| Number of prompt tokens | Usage tracking and billing |
-| Number of completion tokens | Usage tracking and billing |
-| Latency | Performance monitoring |
-| Model used | Routing optimization |
-| Anonymous prompt categorization (sampled) | Model ranking and routing |
+| Metadata                                  | Purpose                    |
+| ----------------------------------------- | -------------------------- |
+| Number of prompt tokens                   | Usage tracking and billing |
+| Number of completion tokens               | Usage tracking and billing |
+| Latency                                   | Performance monitoring     |
+| Model used                                | Routing optimization       |
+| Anonymous prompt categorization (sampled) | Model ranking and routing  |
 
 Prompt categorization is stored completely anonymously — never linked to your account or user ID. You can opt out via the Intercom chat in the [Altimate dashboard](https://app.myaltimate.com).
 
-/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: tip
+/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: tip
 ///
 
 ---
@@ -185,12 +190,12 @@ The above model attributes will be referenced in the following feature descripti
 
 - **dbt manifest file** In the SaaS mode - when you configure "DataPilot dbt integration", manifest files are uploaded to the SaaS instance.
 
-/// admonition | If you would like to connect your on-premise storage for manifest file uploads, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: info
+/// admonition | If you would like to connect your on-premise storage for manifest file uploads, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: info
 ///
 
 All of the details can be found in the code [here](https://github.com/AltimateAI/vscode-dbt-power-user/blob/master/src/altimate.ts). Please note that we only send meta-data, such as model schema and queries to the backend. We never send actual data to the backend and we do not store any of the meta-data.
 
-/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: tip
+/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: tip
 ///

--- a/documentation/docs/arch/llm-gateway.md
+++ b/documentation/docs/arch/llm-gateway.md
@@ -1,5 +1,7 @@
 ---
 status: new
+title: Altimate LLM Gateway — Power User for dbt
+description: "The Altimate LLM Gateway gives Power User for dbt dynamic model routing at 60–80% lower cost than direct LLM providers."
 ---
 
 # Altimate LLM Gateway
@@ -12,12 +14,12 @@ The gateway dynamically routes each request to the best model for the task acros
 
 ## Pricing
 
-| Plan | Price | Tokens/mo | $/M tokens | Overage (per 1M tokens) |
-|------|-------|-----------|------------|------------------------|
-| **Community** | $0/mo | 10M (one-time) | Free | BYOK only |
-| **Pro Tier 1** | $29/mo | 20M | $1.45 | $5/M tokens |
-| **Pro Tier 2** | $89/mo | 70M | $1.27 | $3/M tokens |
-| **Enterprise** | Custom | Custom | Custom | Negotiated |
+| Plan           | Price  | Tokens/mo      | $/M tokens | Overage (per 1M tokens) |
+| -------------- | ------ | -------------- | ---------- | ----------------------- |
+| **Community**  | $0/mo  | 10M (one-time) | Free       | BYOK only               |
+| **Pro Tier 1** | $29/mo | 20M            | $1.45      | $5/M tokens             |
+| **Pro Tier 2** | $89/mo | 70M            | $1.27      | $3/M tokens             |
+| **Enterprise** | Custom | Custom         | Custom     | Negotiated              |
 
 Tokens are counted as input + output combined. All tiers get access to all models — the upgrade incentive is volume, not capability.
 
@@ -25,24 +27,24 @@ Tokens are counted as input + output combined. All tiers get access to all model
 
 Buying 20M tokens directly from providers:
 
-| Model | Direct Cost (20M tokens) | With Altimate Pro Tier 1 | Savings |
-|-------|--------------------------|--------------------------|---------|
-| Sonnet 4.6 | ~$84 | **$29** | ~65% |
-| Opus 4.6 | ~$140 | **$29** | ~79% |
-| GPT-5.4 (short context) | ~$75 | **$29** | ~61% |
-| GPT-5.4 (long context) | ~$135 | **$29** | ~79% |
+| Model                   | Direct Cost (20M tokens) | With Altimate Pro Tier 1 | Savings |
+| ----------------------- | ------------------------ | ------------------------ | ------- |
+| Sonnet 4.6              | ~$84                     | **$29**                  | ~65%    |
+| Opus 4.6                | ~$140                    | **$29**                  | ~79%    |
+| GPT-5.4 (short context) | ~$75                     | **$29**                  | ~61%    |
+| GPT-5.4 (long context)  | ~$135                    | **$29**                  | ~79%    |
 
 With Altimate, you pay $29 flat regardless of which model handles your task. Buying the same 20M tokens directly from providers would cost $75-140 depending on the model — and you'd have to manage API keys, billing, and rate limits across multiple providers yourself.
 
 ## BYOK vs. Gateway
 
-| | BYOK (Bring Your Own Key) | Altimate LLM Gateway |
-|---|---|---|
-| **Cost** | Free and unlimited | Token-based pricing (10M tokens free) |
-| **API Keys** | You manage your own keys | No keys needed |
-| **Models** | Any model from your provider | Dynamic routing across best-in-class models |
-| **Data Path** | Direct to your provider — Altimate never sees it | Through Altimate — see [Security FAQ](faq.md#llm-ai-security) for data handling details |
-| **Best For** | Users with existing API keys or strict data residency requirements | Users who want simplicity and cost savings |
+|               | BYOK (Bring Your Own Key)                                          | Altimate LLM Gateway                                                                    |
+| ------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| **Cost**      | Free and unlimited                                                 | Token-based pricing (10M tokens free)                                                   |
+| **API Keys**  | You manage your own keys                                           | No keys needed                                                                          |
+| **Models**    | Any model from your provider                                       | Dynamic routing across best-in-class models                                             |
+| **Data Path** | Direct to your provider — Altimate never sees it                   | Through Altimate — see [Security FAQ](faq.md#llm-ai-security) for data handling details |
+| **Best For**  | Users with existing API keys or strict data residency requirements | Users who want simplicity and cost savings                                              |
 
 Both options are always available. You can use BYOK and the gateway side by side.
 
@@ -50,13 +52,13 @@ Both options are always available. You can use BYOK and the gateway side by side
 
 The gateway routes across the following models based on task complexity, context length, and quality requirements:
 
-| Model | Provider | Strengths |
-|-------|----------|-----------|
+| Model                 | Provider  | Strengths                                                   |
+| --------------------- | --------- | ----------------------------------------------------------- |
 | **Claude Sonnet 4.6** | Anthropic | Excellent price/performance for most data engineering tasks |
-| **Claude Opus 4.6** | Anthropic | Highest quality for complex reasoning and analysis |
-| **GPT-5.4** | OpenAI | Strong general-purpose capabilities |
-| **GPT-5.3** | OpenAI | Cost-effective for simpler tasks |
-| **GPT-5.4-mini** | OpenAI | Fast, lightweight tasks |
+| **Claude Opus 4.6**   | Anthropic | Highest quality for complex reasoning and analysis          |
+| **GPT-5.4**           | OpenAI    | Strong general-purpose capabilities                         |
+| **GPT-5.3**           | OpenAI    | Cost-effective for simpler tasks                            |
+| **GPT-5.4-mini**      | OpenAI    | Fast, lightweight tasks                                     |
 
 You don't choose the model — the gateway selects the optimal one for each request automatically.
 
@@ -77,15 +79,14 @@ The Altimate LLM Gateway is designed with enterprise security requirements in mi
 - AWS infrastructure in private VPC with network isolation
 - IAM-based RBAC with MFA enforcement for developer access
 
-
-/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: tip
+/// admonition | If you need us to do a security review with your IT/security teams, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: tip
 ///
 
 ## Getting Started
 
 1. Install the [Datamates extension](https://marketplace.visualstudio.com/items?itemName=altimateai.vscode-altimate-mcp-server) in your IDE
-2. Open the command palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and select **Datamates: Open Altimate Code Chat**
+2. Open the command palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and select **Altimate MCP: Open Altimate Code Chat**
 3. The Community plan with 10M free tokens is available immediately — no credit card required
 
-To upgrade or manage your plan, visit the [Altimate pricing page](https://www.altimate.ai/pricing?utm_source=dbt-power-user&utm_medium=docs).
+To upgrade or manage your plan, visit the [Altimate pricing page](https://www.altimate.ai/pricing?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link).

--- a/documentation/docs/arch/pricingfaq.md
+++ b/documentation/docs/arch/pricingfaq.md
@@ -1,10 +1,15 @@
-The Power User for dbt extension is developed and maintained by [Altimate AI](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs). We are a software company based in the San Francisco Bay Area, and have many large enterprise companies as customers.
+---
+title: Power User for dbt Pricing FAQ
+description: "Pricing FAQ for Power User for dbt: credit definitions, free vs paid features, and how to manage your plan."
+---
 
-### **Info about pricing plans is available on the [Pricing page](https://www.altimate.ai/pricing?utm_source=dbt-power-user&utm_medium=docs)**
+The Power User for dbt extension is developed and maintained by [Altimate AI](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link). We are a software company based in the San Francisco Bay Area, and have many large enterprise companies as customers.
+
+### **Info about pricing plans is available on the [Pricing page](https://www.altimate.ai/pricing?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)**
 
 ### 1. **Are you going to charge for current free features in the "power user for dbt" extension?**
 
-No. We have no plans to convert previously available free features into paid features. Newly developed features may be released with a credit quota for the free community plan. Please check the [pricing page](https://www.altimate.ai/pricing?utm_source=dbt-power-user&utm_medium=docs) for more details.
+No. We have no plans to convert previously available free features into paid features. Newly developed features may be released with a credit quota for the free community plan. Please check the [pricing page](https://www.altimate.ai/pricing?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) for more details.
 
 ### 2. **What exactly is credit for the feature?**
 
@@ -45,6 +50,17 @@ If the price of the monthly subscription is lower than the yearly subscription, 
 
 If you would like to make an immediate change to your subscription, make the change at a yearly plan level. It will be considered an upgrade and will be effective immediately.
 
-/// admonition | If you can't find your question here, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via Slack.
-    type: tip
+### 7. **Do free plan credits refresh every month?**
+
+No. Credits on the free community plan are a one-time allowance that lets you try out these features, they do not renew monthly. Any unused credits in your account remain available until used.
+
+Once your free credits are used, you can:
+
+- Upgrade to a paid subscription for a higher credit allowance, see the [pricing page](https://www.altimate.ai/pricing?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) for details, or
+- Continue using all non-credit features for free, features not listed in the table above remain free.
+
+Note: Free plan credits previously refreshed each month. As of July 2026, the free plan includes a one-time credit allowance instead.
+
+/// admonition | If you can't find your question here, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via Slack.
+type: tip
 ///

--- a/documentation/docs/develop/autocomplete.md
+++ b/documentation/docs/develop/autocomplete.md
@@ -1,3 +1,8 @@
+---
+title: Autocomplete — Power User for dbt
+description: "Power User for dbt adds autocomplete for model names, macros, and column names directly inside VS Code."
+---
+
 dbt-power user extension auto-completes model, macro, column names in the VSCode
 
 ## Models
@@ -70,13 +75,13 @@ Hover tooltips expose **Altimate Code** action links so you can ask AI questions
 ![Hover popup on a macro call showing "Explain what this macro does" and "Find risky usages"](images/hoverActionsMacro.png)
 
 /// admonition | Looking for column-level hover actions?
-    type: tip
+type: tip
 
 When you hover a column's `name:` value in `schema.yml`, two more Altimate Code actions appear — ✏️ **Suggest description** and 🧪 **Suggest tests**. Those live with the doc-generation flow on the [Generate documentation](../document/generatedoc.md#single-column-hover-shortcut) page.
 ///
 
 /// admonition | Hover actions delegate to the Datamates extension
-    type: info
+type: info
 
-Like all Altimate Code surfaces, hover actions open the chat panel provided by the **Datamates** extension (`altimateai.vscode-altimate-mcp-server`), which is installed as a dependency of dbt Power User. The bundled chat handles BYOK or [Altimate LLM Gateway](../arch/llm-gateway.md) routing.
+Like all Altimate Code surfaces, hover actions open the chat panel provided by the **Datamates** extension (`altimateai.vscode-altimate-mcp-server`), which is installed as a dependency of Power User for dbt. The bundled chat handles BYOK or [Altimate LLM Gateway](../arch/llm-gateway.md) routing.
 ///

--- a/documentation/docs/develop/clicktorun.md
+++ b/documentation/docs/develop/clicktorun.md
@@ -1,3 +1,8 @@
+---
+title: Click to Run dbt Models — Power User for dbt
+description: "Run dbt models, tests, and commands with a single click from the editor toolbar in Power User for dbt."
+---
+
 There are two methods to do it. You can either do it from the top right corner toolbar or from the extension side pane
 
 ### Method 1: Build and run models from the toolbar
@@ -11,7 +16,7 @@ The toolbar action to build models is present on the top right corner of the VSC
 ![extensionPanel](images/extensionPanel.gif)
 
 /// admonition | You cannot build models from the side panel
-    type: info
+type: info
 
 ///
 
@@ -21,12 +26,11 @@ When `dbt build`, `dbt run`, or `dbt test` fails, the extension surfaces a **Fix
 
 There are three places the button appears:
 
-| Failure point | Where you see it | Prompt sent to Altimate Code |
-|---|---|---|
-| Model fails at runtime (`run_results.json` contains an error) | Notification: *dbt: `my_model` failed* | Run command + failed resource names/types + error messages |
-| dbt exits **before** generating `run_results.json` (broken `ref()`, missing node, config error) | Notification: *dbt command failed: `dbt run --select my_model`* | Exact dbt CLI command (machine paths stripped) + full stderr |
-| Failed model / seed / snapshot in the **Run History** panel | Inline 💡 **Fix with Altimate Code** action on the failed row | Run command first, error in a fenced code block |
-
+| Failure point                                                                                   | Where you see it                                                | Prompt sent to Altimate Code                                 |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------ |
+| Model fails at runtime (`run_results.json` contains an error)                                   | Notification: _dbt: `my_model` failed_                          | Run command + failed resource names/types + error messages   |
+| dbt exits **before** generating `run_results.json` (broken `ref()`, missing node, config error) | Notification: _dbt command failed: `dbt run --select my_model`_ | Exact dbt CLI command (machine paths stripped) + full stderr |
+| Failed model / seed / snapshot in the **Run History** panel                                     | Inline 💡 **Fix with Altimate Code** action on the failed row   | Run command first, error in a fenced code block              |
 
 ![Failure toast on a dbt run with the "Fix with Altimate Code" button](images/fixWithAltimateRunFailure.png)
 

--- a/documentation/docs/develop/compiledCode.md
+++ b/documentation/docs/develop/compiledCode.md
@@ -1,3 +1,8 @@
+---
+title: Compiled SQL Preview — Power User for dbt
+description: "See the compiled SQL for any dbt model instantly in the VS Code sidebar with Power User for dbt."
+---
+
 ## Preview compiled code (SQL)
 
 The toolbar action to preview compiled code is present on the top right corner of the VSCode as shown in the image below:

--- a/documentation/docs/develop/explanation.md
+++ b/documentation/docs/develop/explanation.md
@@ -1,7 +1,12 @@
+---
+title: Model Explanation — Power User for dbt
+description: "Get AI-generated explanations of any dbt model or SQL query in plain English with Power User for dbt."
+---
+
 Query explanation is invaluable to understanding a complex piece of dbt or SQL code (especially written by others!).
 
 /// admonition | Requires the Datamates extension
-    type: info
+type: info
 
 Altimate Code features (Explain, Optimize, Change, Translate, Review) open a chat session through the **[Datamates](https://marketplace.visualstudio.com/items?itemName=altimateai.vscode-altimate-mcp-server)** extension. Make sure Datamates is installed and active before invoking these actions.
 ///
@@ -52,9 +57,9 @@ Altimate Code opens in a side-panel chat (powered by the Datamates extension). I
 </div>
 
 /// admonition | Please provide feedback on the generated explanations using thumbs up / down buttons. Your feedback will help us tremendously to improve this functionality.
-    type: tip
+type: tip
 ///
 
-/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
-    type: info
+/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: info
 ///

--- a/documentation/docs/develop/genmodelSQL.md
+++ b/documentation/docs/develop/genmodelSQL.md
@@ -1,9 +1,14 @@
+---
+title: Generate dbt Model from SQL — Power User for dbt
+description: "Convert raw SQL into a production-ready dbt model automatically with Power User for dbt's AI model generation."
+---
+
 You can convert existing SQL into dbt model as below. The extension automatically converts SQL to jinja-sql by populating right references.
 
 <Interactive demo for converting SQL to dbt model>
 
 <div style="position: relative; padding-bottom: calc(57.25% + 44px); height: 0;"><iframe src=https://app.supademo.com/embed/clntspo5o0ickpeygblm175kb frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
-/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
-    type: info
+/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: info
 ///

--- a/documentation/docs/develop/genmodelSource.md
+++ b/documentation/docs/develop/genmodelSource.md
@@ -1,3 +1,8 @@
+---
+title: Generate dbt Model from Source — Power User for dbt
+description: "Auto-generate a dbt model from a source table definition using AI in Power User for dbt."
+---
+
 Generating model from sources defined in yaml file is very easy as below:
 
 ![Generate model from source](images/generateModelSource.gif)
@@ -9,7 +14,7 @@ Generating model from sources defined in yaml file is very easy as below:
 ///
 
 /// admonition | Why does the generated model appear with the syntax {{ adapter.quote(column_name)}}?
-    type: info
+type: info
 
 This syntax provides a safe way for the adapter to quote the columns.
 Since the extension supports different adapters, this is the easiest way to ensure that it works for all of them.

--- a/documentation/docs/develop/optimize.md
+++ b/documentation/docs/develop/optimize.md
@@ -1,5 +1,7 @@
 ---
 status: new
+title: Optimize SQL with Altimate Code — Power User for dbt
+description: "Get AI-powered SQL optimization suggestions including join order, predicate pushdown, and query restructuring."
 ---
 
 # Optimize SQL with Altimate Code
@@ -7,7 +9,7 @@ status: new
 Optimize with Altimate analyzes a SQL query (or selected snippet) and suggests rewrites for performance — join order, predicate pushdown, redundant scans, unnecessary `DISTINCT` / `ORDER BY`, and dialect-specific anti-patterns.
 
 /// admonition | Requires the Datamates extension
-    type: info
+type: info
 
 Altimate Code features (Explain, Optimize, Change, Translate, Review) open a chat session through the **[Datamates](https://marketplace.visualstudio.com/items?itemName=altimateai.vscode-altimate-mcp-server)** extension. Make sure Datamates is installed and active before invoking these actions.
 ///
@@ -23,7 +25,7 @@ Open the right-click context menu on the file, expand the **Altimate Code** subm
 ![Right-click Altimate Code → Optimize](images/optimizeAltimateCodeRightClick.png)
 
 /// admonition | Where to find it
-    type: tip
+type: tip
 
 **Optimize with Altimate** is the second entry in the Altimate Code submenu (after Explain) and only appears on `.sql` / `.jinja-sql` files.
 ///
@@ -41,9 +43,9 @@ Altimate Code opens in a side panel and returns a rewritten query alongside an e
 ![Optimize result in Altimate Code](images/optimizeAltimateCodeResult.png)
 
 /// admonition | Please provide feedback on the suggestions using thumbs up / down buttons. Your feedback helps us improve this functionality.
-    type: tip
+type: tip
 ///
 
-/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
-    type: info
+/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: info
 ///

--- a/documentation/docs/develop/translateSQL.md
+++ b/documentation/docs/develop/translateSQL.md
@@ -1,7 +1,12 @@
+---
+title: Translate SQL Across Dialects — Power User for dbt
+description: "Translate SQL between warehouse dialects (Snowflake, BigQuery, Redshift, etc.) with one click in Power User for dbt."
+---
+
 You can translate SQL queries from one dialect to another using Altimate Code. For example, translate a query in Postgres SQL dialect to Snowflake SQL dialect.
 
 /// admonition | Requires the Datamates extension
-    type: info
+type: info
 
 The **Translate with Altimate** action opens a chat session through the **[Datamates](https://marketplace.visualstudio.com/items?itemName=altimateai.vscode-altimate-mcp-server)** extension. Make sure Datamates is installed and active before invoking it.
 ///
@@ -21,7 +26,7 @@ Open the right-click context menu on the `.sql` file, expand the **Altimate Code
 ![Right-click Altimate Code → Translate](images/rightClickTranslate.png)
 
 /// admonition | Where to find it
-    type: tip
+type: tip
 
 The Altimate Code submenu shows four default actions: **Explain**, **Optimize**, **Change**, and **Translate**. **Translate with Altimate** is the fourth entry and only appears on `.sql` / `.jinja-sql` files.
 ///
@@ -32,14 +37,14 @@ A two-step quick pick appears in VS Code:
 
 1. **Translate SQL — Step 1 of 2** — pick the **source dialect** (the current dialect of the SQL in the file).
 
-    ![Translate source prompt](images/translateSourcePrompt.png)
+   ![Translate source prompt](images/translateSourcePrompt.png)
 
 2. **Translate SQL — Step 2 of 2** — pick the **target dialect** (the dialect you want to translate to). The adapter type of your current dbt project is bubbled to the top of the list and marked "current project" — you can pick it or choose any other dialect.
 
-    ![Translate target prompt](images/translateTargetPrompt.png)
+   ![Translate target prompt](images/translateTargetPrompt.png)
 
 /// admonition | Translation works on the whole file. Altimate Code will treat the entire file as the source query.
-    type: info
+type: info
 ///
 
 ### Step 4: Review the translated SQL and explanation

--- a/documentation/docs/develop/updatemodel.md
+++ b/documentation/docs/develop/updatemodel.md
@@ -1,7 +1,12 @@
+---
+title: Update dbt Models with AI — Power User for dbt
+description: "Use AI to update and refactor existing dbt models based on natural language instructions in Power User for dbt."
+---
+
 Updating or changing an existing dbt (or SQL) model using natural language is straightforward through Altimate Code.
 
 /// admonition | Requires the Datamates extension
-    type: info
+type: info
 
 The **Change with Altimate** action opens a chat session through the **[Datamates](https://marketplace.visualstudio.com/items?itemName=altimateai.vscode-altimate-mcp-server)** extension. Make sure Datamates is installed and active before invoking it.
 ///
@@ -13,7 +18,7 @@ Open a `.sql` (or `.jinja-sql`) file. Optionally select the portion you want to 
 ![Right-click Altimate Code → Change](images/startAltimateCodeChange.png)
 
 /// admonition | Where to find it
-    type: tip
+type: tip
 
 The Altimate Code submenu shows four actions by default: **Explain**, **Optimize**, **Change**, and **Translate**. **Change with Altimate** is the third entry and only appears on `.sql` / `.jinja-sql` files.
 ///
@@ -33,9 +38,9 @@ Altimate Code shows an Accomplished summary listing every change it made (replac
 ![Apply changed code](images/accomplished_changes.png)
 
 /// admonition | Please provide feedback on the result using thumbs up / down buttons. Your feedback will help us tremendously to improve this functionality.
-    type: tip
+type: tip
 ///
 
-/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
-    type: info
+/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: info
 ///

--- a/documentation/docs/discover/setupui.md
+++ b/documentation/docs/discover/setupui.md
@@ -1,33 +1,38 @@
+---
+title: Setup dbt Docs & Lineage UI — Power User for dbt
+description: "Configure the SaaS UI to visualize dbt documentation and lineage graphs for your project in Power User for dbt."
+---
+
 This page covers the setup steps necessary to view your dbt documentation and lineage in the SaaS UI.
 The steps below ship your manifest.json and catalog.json projects to SaaS UI in order to visualize information like dbt model/column descriptions and column lineage.
 
 /// admonition | Please note that this lineage and documentation in UI functionality is not yet supported with dbt 1.8
-    type: info
+type: info
 ///
 
 /// admonition | If you want to re-create any existing dbt core integration using Connections, kindly delete the existing integration first and then create a fresh connection.
-    type: warning
+type: warning
 ///
 
 ## Step 1: Create a dbt Core Connection
 
 1. Navigate to **Settings -> Connections** and click **Create new connection**
 
-    ![DBT Core Connection](images/DBT_Cloud_Connection.png)
+   ![DBT Core Connection](images/DBT_Cloud_Connection.png)
 
 2. Select **dbt Core** as the connection type & provide the required connection name & description details
 
-    ![Create DBT Core Connection](images/DBT_Core_Create_Connection.png)
+   ![Create DBT Core Connection](images/DBT_Core_Create_Connection.png)
 
 3. Provide **Environment Name** & Click **Create Connection** to create the dbt Core connection
 
-    ![Final Create DBT Core Connection](images/DBT_Core_Create_Final_Connection.png)
+   ![Final Create DBT Core Connection](images/DBT_Core_Create_Final_Connection.png)
 
 | Field                  | Description                                                                                                                                                                                        |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Connection name        | Unique connection name, this can be mapped to your dbt Project                                                                                                                                     |
 | Connection description | A brief description of the connection (e.g., "Production dbt Core project for analytics")                                                                                                          |
-| Environment name       | Environment name can be based on which environment that you are going to upload manifest.json and catalog.json files from. For now, just add the value as "prod" for your production environments.  |
+| Environment name       | Environment name can be based on which environment that you are going to upload manifest.json and catalog.json files from. For now, just add the value as "prod" for your production environments. |
 
 ## Step 2: Install the open-source DataPilot CLI
 
@@ -43,8 +48,8 @@ Here's the link to the repo: [https://github.com/AltimateAI/datapilot-cli](https
 
 Go to **Settings -> Connections** page and click on the dbt core connection name for the connection created. Copy the command for uploading files in the overlay screen on the side.
 
-/// admonition | manifest and catalog files don't contain any information about your data. It's all metadata about your environment. Please feel free to check our [security page](https://docs.myaltimate.com/arch/faq/) for more info on how we protect your metadata.
-    type: info
+/// admonition | manifest and catalog files don't contain any information about your data. It's all metadata about your environment. Please feel free to check our [security page](/arch/faq/) for more info on how we protect your metadata.
+type: info
 ///
 
 ![DBT Core Connection Details](images/copyCommand.png)<br>
@@ -55,16 +60,16 @@ You need to update the following placeholders in the copied command -
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
 | Path/to/manifest/file          | This is path to your manifest file in the project directory. It's usually stored in the 'target' directory in your dbt project.    | ./target/manifest.json          |
 | Path/to/catalog/file           | This is the path to your catalog file in the project directory. It's usually stored in the 'target' directory in your dbt project. | ./target/catalog.json           |
-| Path/to/run-results/file       | Path to your run results file in the project directory                                                                              | ./target/run_results.json       |
-| Path/to/semantic-manifest/file | Path to your semantic manifest file in the project directory                                                                        | ./target/semantic_manifest.json |
-| Path/to/sources/file           | Path to your sources file in the project directory                                                                                  | ./target/sources.json           |
+| Path/to/run-results/file       | Path to your run results file in the project directory                                                                             | ./target/run_results.json       |
+| Path/to/semantic-manifest/file | Path to your semantic manifest file in the project directory                                                                       | ./target/semantic_manifest.json |
+| Path/to/sources/file           | Path to your sources file in the project directory                                                                                 | ./target/sources.json           |
 
 /// admonition | In addition to the required `manifest.json` and `catalog.json`, we now support uploading additional artifacts — `run_results.json`, `semantic_manifest.json`, and `sources.json` — for richer insights. These are optional but recommended for complete visibility into your dbt project.
-    type: info
+type: info
 ///
 
 /// admonition | If you are missing manifest.json or catalog.json files in the target directory, please run the `dbt build` and `dbt docs generate` commands. Also, you can add steps to upload the manifest and catalog files command in your dbt pipelines. That way, you will always have up-to-date documentation and lineage in UI without any manual steps.
-    type: tip
+type: tip
 ///
 
 Here's the sample output after running the command and successfully uploading your files.
@@ -78,7 +83,7 @@ Manifest and catalog ingestion has started. You can check the status at https://
 ```
 
 /// admonition | It takes a few minutes to upload the files and sync that info with the rest of the UI. You can check the status of the upload by going to the link provided in the command output.
-    type: tip
+type: tip
 ///
 
 ## Automating with CI/CD Pipelines
@@ -119,21 +124,20 @@ Before setting up the connection, create a service token in dbt Cloud with **Job
 6. **Custom URL** (optional): For custom dbt Cloud instances (defaults to `https://cloud.getdbt.com/api/v2/`)
 7. Click **Test Connection** to verify your setup
 8. Configure the sync schedule:
-    - **Scheduled**: Sync artifacts on a regular schedule. Select from Daily, Weekly, or Monthly frequency options and choose the time (UTC) when sync should occur (e.g., Daily at 12:00 AM UTC)
-    - **Real-time**: (Coming soon) Immediate sync when dbt Cloud runs complete
+   - **Scheduled**: Sync artifacts on a regular schedule. Select from Daily, Weekly, or Monthly frequency options and choose the time (UTC) when sync should occur (e.g., Daily at 12:00 AM UTC)
+   - **Real-time**: (Coming soon) Immediate sync when dbt Cloud runs complete
 9. Click **Create Connection**
 
 After creation, your dbt Cloud projects and environments will be automatically discovered.
+
 <div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.73; padding: 40px 0 40px 0;">
   <iframe src="https://app.supademo.com/embed/cml93jv5t01in180iqac81nl2?embed_v=2&utm_source=embed" loading="lazy" title="dbt Cloud Integration" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
 </div>
 
 /// admonition | Automatic syncing keeps your documentation and lineage always up-to-date without manual intervention
-    type: tip
+type: tip
 ///
 
 /// admonition | The dbt cloud connection deletion has a processing delay of a few hours. If you need to recreate the same connection immediately, contact us.
-    type: warning
+type: warning
 ///
-
-

--- a/documentation/docs/discover/viewdocs.md
+++ b/documentation/docs/discover/viewdocs.md
@@ -1,7 +1,14 @@
+---
+title: View dbt Documentation — Power User for dbt
+description: "Browse and search your dbt project documentation directly inside VS Code with Power User for dbt."
+video_id: JUuQM6Hxcwg
+video_upload_date: "2026-06-11T00:00:00Z"
+---
+
 This page highlights functionality for searching and viewing documentation for your DBT Projects. Please go to Code -> dbt from the navigation menu on the left-hand side to view all your dbt models, seeds, and other components.
 
 /// admonition | [Setups steps](./setupui.md) needed for the information to show in SaaS UI
-    type: warning
+type: warning
 ///
 
 ## Search and Filter
@@ -25,6 +32,6 @@ In addition to schemas, you can also view the actual code and compiled code in t
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/JUuQM6Hxcwg?si=HAAU3UQWHQR7LssQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-/// admonition | Using this feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs) Also, you need to perform the setup steps outlined on the [Setup UI page](setupui.md)
-    type: info
+/// admonition | Using this feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) Also, you need to perform the setup steps outlined on the [Setup UI page](setupui.md)
+type: info
 ///

--- a/documentation/docs/discover/viewlineage.md
+++ b/documentation/docs/discover/viewlineage.md
@@ -1,8 +1,15 @@
+---
+title: Model & Column Lineage — Power User for dbt
+description: "Visualize model-level and column-level lineage for your dbt project in the DataPilot SaaS UI."
+video_id: JUuQM6Hxcwg
+video_upload_date: "2026-06-11T00:00:00Z"
+---
+
 In the DataPilot SaaS UI, you can see model level as well as column level lineage. You can also see the types of changes that occurred during the column lineage traversal
 e.g. column was unchanged or alias was used
 
 /// admonition | [Setups steps](./setupui.md) needed for the information to show in SaaS UI
-    type: warning
+type: warning
 ///
 
 ## View Model Level Lineage
@@ -16,7 +23,7 @@ Click on the "View Details" button and go to the Lineage tab. You can expand the
 ![View Lineage](images/viewLineage.png)<br>
 
 /// admonition | If you click on the specific model in the lineage view, the lineage graph for only that model will be highlighted, as shown in the image above.
-    type: tip
+type: tip
 ///
 
 ## View Column Level Lineage
@@ -51,6 +58,6 @@ If code is available for a particular transformation, a small code icon is displ
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/JUuQM6Hxcwg?si=cT8KfuVBz-lm43WC&amp;start=116" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-/// admonition | Using this feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs) Also, you need to perform the setup steps outlined on the [Setup UI page](setupui.md)
-    type: info
+/// admonition | Using this feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) Also, you need to perform the setup steps outlined on the [Setup UI page](setupui.md)
+type: info
 ///

--- a/documentation/docs/document/docblocks.md
+++ b/documentation/docs/document/docblocks.md
@@ -1,6 +1,11 @@
+---
+title: Doc Blocks — Power User for dbt
+description: "Create and manage dbt doc blocks for reusable model and column descriptions across your dbt project."
+---
+
 # Support for dbt Doc Blocks
 
-dbt Power User provides comprehensive support for dbt doc blocks, allowing you to create, manage, and reference documentation blocks throughout your dbt project.
+Power User for dbt provides comprehensive support for dbt doc blocks, allowing you to create, manage, and reference documentation blocks throughout your dbt project.
 
 <div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.5470008952551477; padding: 40px 0 40px 0;"><iframe src="https://app.supademo.com/embed/cmc2au66hkebpsn1r4gfbewnf?embed_v=2" loading="lazy" title="Use Doc Blocks in dbt with the Power User for dbt Extension" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 

--- a/documentation/docs/document/generatedoc.md
+++ b/documentation/docs/document/generatedoc.md
@@ -1,3 +1,10 @@
+---
+title: Auto-Generate dbt Documentation
+description: "Bulk-generate dbt model and column documentation with AI in Power User for dbt. Set persona and length preferences."
+video_id: 8EuBDEuYZ2o
+video_upload_date: "2026-06-11T00:00:00Z"
+---
+
 Instead of writing documentation manually, you can generate the documentation!
 
 ### Single-column hover shortcut
@@ -15,7 +22,7 @@ The hover only fires on the **value** of a column's `name:` field — not on the
 models:
   - name: stg_customers
     columns:
-      - name: customer_id      # ← hover INSIDE these letters
+      - name: customer_id # ← hover INSIDE these letters
         description: primary key
 ```
 
@@ -24,7 +31,7 @@ The popup shows `(column) customer_id` on top with a divider, then the two actio
 ![Hover popup on a column name: in schema.yml showing "Suggest description" and "Suggest tests"](images/hoverActionsYamlColumn.png)
 
 /// admonition | Requires `yaml` or `jinja-yaml` language
-    type: info
+type: info
 
 The file's language ID (bottom-right of the editor) must be `yaml` or `jinja-yaml`. If the file shows as "Plain Text" or another language the hover won't fire. The file also has to live inside a workspace the extension recognizes as a dbt project.
 ///
@@ -51,7 +58,7 @@ When it comes to generating documentation, the following settings are available:
 Existing documentation (whether generated or written manually) can be further updated using regeneration functionality with DataPilot.
 
 /// admonition | Save changes in YAML file
-    type: tip
+type: tip
 You can save the changes in the existing or a new YAML file with save button at the bottom of the panel.
 If you see any issues with the content that's saved in the YAML file, please check the [optional config section](../setup/optConfig.md/#column-name-setup-for-yaml-file-updates).
 ///
@@ -75,7 +82,7 @@ Select the checkboxes for right columns in models and click on the "Propagate do
 You can personalize and coach the Documentation Writer AI teammate.
 
 /// admonition | Personalize and Coach Documentation Writer AI
-    type: tip
+type: tip
 Please check more info about how to personalize and coach documentation writer AI teammate [here](../teammates/coach.md).
 If you would like to learn more about AI teammates, please check this [doc page](../teammates/introduction.md)
 ///
@@ -93,7 +100,7 @@ Here's a demo of generating model and column descriptions:
 <div style="position: relative; padding-bottom: calc(86.34704370179949% + 42px); height: 0;"><iframe src="https://app.supademo.com/embed/cm8oeopuq03drzh0i0yyvsxw7" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
 /// admonition | Document generation or propagation requires an API key. You can get it by signing up for free at [www.altimate.ai](https://wwww.altimate.ai)
-    type: info
+type: info
 ///
 
 ### Recorded Demo

--- a/documentation/docs/document/write.md
+++ b/documentation/docs/document/write.md
@@ -1,9 +1,14 @@
+---
+title: Write dbt Documentation — Power User for dbt
+description: "Write and edit model descriptions, column docs, and schema.yml entries with AI assistance in Power User for dbt."
+---
+
 You can write descriptions for dbt models and columns in the Documentation Editor. The documentation editor also shows the descriptions that were written previously. Those previously written descriptions can be updated as well.
 
 For columns that are not referenced in the dbt model, you can click “sync with db” button to get those columns shown in the documentation editor.
 
 /// admonition | Save changes in YAML file
-    type: tip
+type: tip
 You can save the changes in the existing or a new YAML file with the save button at the bottom of the panel.
 If you see any issues with the content that's saved in the YAML file, please check the [optional config section](../setup/optConfig.md/#column-name-setup-for-yaml-file-updates).
 ///
@@ -13,5 +18,5 @@ If you see any issues with the content that's saved in the YAML file, please che
 <div style="position: relative; padding-bottom: calc(91.09497964721845% + 42px); height: 0;"><iframe src="https://app.supademo.com/embed/zNPSarhtOahAfzA-kw2jV" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
 /// admonition | You can also generate the documentation, please refer the section on [generate documentation](generatedoc.md)
-    type: tip
+type: tip
 ///

--- a/documentation/docs/govern/collaboration.md
+++ b/documentation/docs/govern/collaboration.md
@@ -1,9 +1,16 @@
+---
+title: Team Collaboration — Power User for dbt
+description: "Collaborate with your team on dbt models, reviews, and documentation using Power User for dbt's collaboration features."
+video_id: pI1U94j-pOI
+video_upload_date: "2026-06-11T00:00:00Z"
+---
+
 Collab functionality enables you to discuss code and documentation easily with the stakeholders via VSCode and UI. Many stakeholders are not comfortable using IDE directly; this functionality enables them also to have a discussion with technical users.
 
 ## Code Collaboration Workflow
 
 /// admonition | Code Collaboration workflow allows you to discuss code without creating a PR
-    type: tip
+type: tip
 ///
 
 ### Start a discussion
@@ -13,7 +20,7 @@ You can start a discussion at the file or code block levels (single or multiple 
 ![StartDiscussion](images/startDiscussion.png)<br>
 
 /// admonition | If you click on the display icon as shown in the image above, you can show details of the discussion previously started
-    type: tip
+type: tip
 ///
 
 When a discussion is started, the extension generates dbt docs and uploads those docs to the Altimate AI SaaS instance so that non-technical stakeholders can contribute to the discussion via SaaS UI as well.
@@ -25,7 +32,7 @@ Once the discussion is started, you can publish a comment and also tag other use
 ![Add comment](images/discussionText.png)<br>
 
 /// admonition | If you don't want to tag the user but still want to share the link with them, just copy the link from the comments box, and share it with them manually (Slack, Email etc.)
-    type: tip
+type: tip
 ///
 
 ### Email notification (if a user is tagged)
@@ -96,13 +103,13 @@ You can also view the lineage from the list of all exported lineage views availa
 ![Lineage List](images/lineageList.png)
 
 /// admonition | In order to view the lineage in SaaS UI from the link, a user needs to be registered in the same Altimate AI instance
-    type: info
+type: info
 ///
 
 ## Recorded Demo
 
 <iframe width="800" height="600" src="https://www.youtube.com/embed/pI1U94j-pOI?si=ckfDMYqeVgjBmg-7" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
-    type: info
+/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: info
 ///

--- a/documentation/docs/govern/governance.md
+++ b/documentation/docs/govern/governance.md
@@ -1,3 +1,10 @@
+---
+title: dbt Governance & Best Practices — Power User for dbt
+description: "Prevent shipping issues by scanning dbt models against best practices and governance rules in Power User for dbt."
+video_id: 3nJ9otNNIwQ
+video_upload_date: "2026-06-11T00:00:00Z"
+---
+
 Prevent issues from getting shipped to production! Project governance functionality lets you swiftly scan all dbt projects in your workspace against dbt best practices and organizational guidelines to quickly bring issues to your attention.
 
 ## Available via Extension & Python Package
@@ -5,7 +12,7 @@ Prevent issues from getting shipped to production! Project governance functional
 Project governance functionality is available in the power user extension and the open-source Python package.
 
 /// admonition | Also, the project governance functionality is available as a Python package, so the checks can be integrated in your Git, CI/CD workflows. More details [here](https://datapilot.readthedocs.io/en/latest/insights.html)
-    type: tip
+type: tip
 ///
 
 ## Configure Checks
@@ -26,7 +33,7 @@ Select the YAML file by clicking on "Select Config Path"
 ### SaaS Configuration of Checks
 
 /// admonition | SaaS configuration method allows you to share multiple configurations and reference those as per environments, teams, and projects.
-    type: tip
+type: tip
 ///
 
 First, navigate to governance menu item on left hand side nav and choose "new dbt Governance Config".
@@ -60,7 +67,7 @@ Select the right config for checks from the list
 Click the start scan button. You may be asked to install Altimate AI DataPilot package.
 
 /// admonition | DataPilot python package is [open source package](https://github.com/AltimateAI/datapilot), that's actually used to do governance checks with the power user extension
-    type: tip
+type: tip
 ///
 
 The scan usually runs in a few seconds, but depending on the size of your project and manifest / catalog files it may take longer.

--- a/documentation/docs/govern/multiproject.md
+++ b/documentation/docs/govern/multiproject.md
@@ -1,3 +1,8 @@
+---
+title: Multi-Project Support — Power User for dbt
+description: "Work across multiple dbt projects in a single VS Code workspace with Power User for dbt's multi-project support."
+---
+
 # Multi Project Support with dbt-loom
 
 Power User extension now supports dbt-loom, where native features like query preview, compiled code, column lineage support multi-project references.
@@ -8,7 +13,7 @@ Power User extension now supports dbt-loom, where native features like query pre
 - Sample project [example with dbt-loom configured](https://github.com/Bl3f/dbt-loom-example)
 
 /// admonition | Please make sure dbt_loom.config.yml file is in the root of your multi-project directory
-    type: warning
+type: warning
 ///
 
 ## Reference models from other projects in code via auto-complete

--- a/documentation/docs/govern/notebooks.md
+++ b/documentation/docs/govern/notebooks.md
@@ -1,3 +1,8 @@
+---
+title: Notebooks — Power User for dbt
+description: "Use notebook-style SQL cells for exploratory analysis and iterative dbt development in Power User for dbt."
+---
+
 **Why Notebooks?**
 
 Notebooks allow you to codify your usual ad-hoc data analysis, data preparation workflows, so they can be reused. For example, if you have a workflow for standard data analysis - check for duplicates, check timezone field, make sure only certain values are present for a "customer_type" column - you can create a notebook to codify these steps. Then, you can always trigger this notebook with a click of button for a table or data output of particular model to validate or clean the data. In these notebooks, you can create different 'cells' mapping to jinja-sql, python or markdown text in a single file, and you can execute these cells together.
@@ -11,7 +16,7 @@ You can also utilize some out-of-the-box notebook templates for common tasks - e
 Many times, this ad-hoc work is dependent on organizational best practices and the type of data that your team works on. So, these notebooks can be reused by your team members as well as extended teams. That's why we have enabled sharing - where you can share notebooks with other users in your Altimate AI saas instance. This is especially useful when you have popular notebooks spread across multiple code repositories.
 
 /// admonition | We would love to hear your feedback on what additional functionality we can build in this area. If you have encountered any issues in this functionality, please message us over [chat](https://app.myaltimate.com/contactus)
-    type: tip
+type: tip
 ///
 
 ## Enable notebooks in VSCode
@@ -23,7 +28,7 @@ You just need to add the following line to the settings.json file in your .vscod
 ```
 
 /// admonition | If you don't have the .vscode directory at the root of the repo, please create it
-    type: info
+type: info
 ///
 
 Then, reload or restart your VSCode.
@@ -51,7 +56,7 @@ After you are done, you can just save the notebook file like any other file in V
 There are a few ways in which you can trigger notebook templates.
 
 /// admonition | The notebook templates may use some standard Python packages, and VSCode may ask for your confirmation before installing the necessary packages
-    type: info
+type: info
 ///
 
 **There is a contextual notebook menu available at the top of the file when you open any SQL file in VSCode**
@@ -104,7 +109,7 @@ This template helps extract exposures from Metabase
 ![expoMetabase](images/expoMetabase.png)<br>
 
 /// admonition | We would love to hear your feedback on what additional templates or functionality we can build in this area. If you have encountered any issues in this functionality, please message us over [chat](https://app.myaltimate.com/contactus)
-    type: tip
+type: tip
 ///
 
 ## Share notebook

--- a/documentation/docs/govern/querybookmarks.md
+++ b/documentation/docs/govern/querybookmarks.md
@@ -1,3 +1,10 @@
+---
+title: Query Bookmarks — Power User for dbt
+description: "Save and organize frequently used SQL queries as bookmarks for quick access in Power User for dbt."
+video_id: 1TPAyE5EJ5Y
+video_upload_date: "2026-06-11T00:00:00Z"
+---
+
 # Query History and Bookmarks
 
 Now, you can see the history of all the SQL queries or dbt models you ran. So, you can re-run them to view and compare results to see how your data has changed between code changes. You can also look at the compiled SQL code of queries that were run previously.
@@ -7,7 +14,7 @@ Queries from the query history can also be bookmarked and tagged. So, you can re
 Users can also share their query bookmarks with other users in your org-specific DataPilot SaaS instance. That way, you can have a shared repository of the most useful queries across the team.
 
 /// admonition | Your VSCode session stores only the last 10 queries in the query history, and this info is stored locally on your machine and not in the SaaS instance.
-    type: info
+type: info
 ///
 
 ## View Query History
@@ -22,8 +29,8 @@ If you hover over the query from the history, you can perform a few actions, lik
 
 ![Execute History](images/executeHistory.png)<br>
 
-/// admonition | In this way, you can [compare query results](https://docs.myaltimate.com/test/queryResults/#compare-query-results) between different runs of your query
-    type: info
+/// admonition | In this way, you can [compare query results](/test/queryResults/#compare-query-results) between different runs of your query
+type: info
 ///
 
 ## Add Bookmark
@@ -33,7 +40,7 @@ If you execute some query frequently, you can also bookmark that query by clicki
 ![Bookmark Query](images/addBookmark.png)<br>
 
 /// admonition | You can add tags to your queries for better organization. You can also search your bookmarks by text or by tags. Many users use tags to categorize queries based on a specific purpose or a project.
-    type: tip
+type: tip
 ///
 
 ## Share Bookmark
@@ -52,6 +59,6 @@ Query or bookmark code can be easily viewed by clicking on the query. Also, this
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/1TPAyE5EJ5Y?si=JQqP2cXIEu_AUvwU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
-    type: info
+/// admonition | This feature requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: info
 ///

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -1,246 +1,145 @@
-# Accelerate dbt and SQL Development by 3x
+---
+title: Power User for dbt
+description: "Power User for dbt is the best VS Code extension for dbt. Develop, test, document, and optimize dbt and SQL 3× faster."
+hide:
+  - toc
+---
 
+<div class="ak-eyebrow">Power User for dbt</div>
 
-Welcome to the docs for [dbt Power User VSCode Extension](https://marketplace.visualstudio.com/items?itemName=innoverio.vscode-dbt-power-user), an [open sourced](https://github.com/AltimateAI/vscode-dbt-power-user) extension created by [Altimate AI](https://www.altimate.ai/?utm_source=dbt-power-user&utm_medium=docs).
+# Best dbt extension for VS Code / Cursor.
 
-It offers various features across three important phases of dbt and SQL work - develop, test, and collaborate.
+<p class="ak-sub">
+Develop, test, document and optimize dbt and SQL <strong>3× faster</strong> with autocomplete, lineage, query preview, test and doc generation, and AI teammates.
+</p>
 
-<div class="html-in-md">
-
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Accelerate dbt and SQL Development by 3x</title>
-    <style>
-        .container {
-            max-width: 1000px;
-            margin: 0 auto;
-            padding: 15px;
-            background: linear-gradient(145deg, var(--bg-secondary), var(--bg-primary));
-            border-radius: 20px;
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: text;
-            box-shadow: 0 10px 30px var(--shadow-color);
-        }
-        .workflow {
-            display: flex;
-            flex-direction: column;
-            margin-bottom: 20px;
-        }
-        .steps {
-            display: flex;
-            justify-content: space-between;
-            width: 100%;
-            position: relative;
-            margin-bottom: 20px;
-        }
-        .step {
-            background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
-            font-size: 20px;
-            padding: 10px;
-            border-radius: 12px;
-            text-align: center;
-            z-index: 1;
-            width: 45%;
-            box-shadow: 0 4px 20px rgba(66, 133, 244, 0.3);
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-        }
-        .step:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(66, 133, 244, 0.4);
-        }
-        .details {
-            display: flex;
-            justify-content: space-between;
-            gap: 20px;
-        }
-        .column {
-            width: 45%;
-            padding: 10px;
-            border-radius: 15px;
-            background: transparent;
-            position: relative; 
-            border: 1px solid var(--border-color);
-            box-shadow: 0 4px 15px var(--shadow-color);
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-        }
-        .column:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
-        }
-        ul {
-            /* padding-left: 20px;
-            margin: 0; */
-        }
-        li {
-            margin-bottom: 15px;
-            position: relative;
-            padding-left: 10px;
-        }
-        li:last-child {
-            margin-bottom: 0;
-        }
-        a {
-            color: var(--text-secondary);
-            text-decoration: none;
-            transition: color 0.3s ease;
-            position: relative;
-        }
-        a:hover {
-            color: var(--gradient-end);
-        }
-        a::after {
-            content: '';
-            position: absolute;
-            width: 100%;
-            height: 2px;
-            bottom: -2px;
-            left: 0;
-            background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
-            transform: scaleX(0);
-            transform-origin: right;
-            transition: transform 0.3s ease;
-        }
-        a:hover::after {
-            transform: scaleX(1);
-            transform-origin: left;
-        }
-        .connecting-line {
-            width: 3px;
-            height: 20px;
-            background: linear-gradient(180deg, var(--gradient-start), var(--gradient-end));
-            margin: 0 auto;
-            box-shadow: 0 2px 8px rgba(66, 133, 244, 0.2);
-        }
-    </style>
-</head>
-<body>
-    <div class="container">        
-        <div class="workflow">
-            <div class="steps">
-                <div class="arrow"></div>
-                <div class="step">Develop</div>
-                <div class="step">Test</div>
-                <div class="step">Collaborate</div>
-            </div>
-        </div>
-        <div class="details">
-            <div class="column">
-                <ul>
-                    <li><a href="test/sqlvisualizer">SQL Visualizer</a></li>
-                    <li><a href="develop/explanation">Query Explanation</a></li>
-                    <li><a href="develop/genmodelsource">Auto-gen dbt from source</a></li>
-                    <li><a href="develop/genmodelSQL">Auto-gen dbt from SQL</a> </li>
-                    <li><a href="develop/autocomplete">Auto-complete code</a> </li>
-                    <li><a href="develop/clicktorun"> Click to Run Models</a></li>
-                    <li><a href="develop/translateSQL">Query Translation</a></li>
-                    <li><a href="develop/compiledCode">Compiled SQL preview</a></li>
-                </ul>
-            </div>
-            <div class="column">
-                <ul>
-                    <li><a href="test/queryResults">Preview query results and analysis</a></li>
-                    <li><a href="test/writetests">Tests Generation</a></li>
-                    <li><a href="test/lineage">Column lineage with code visibility</a></li>
-                    <li><a href="test/defertoprod">Defer to prod</a></li>
-                    <li><a href="test/sqlvalidation">SQL validation without execution</a></li>
-                </ul>
-            </div>
-            <div class="column">
-                <ul>
-                    <li><a href="govern/collaboration">Collaboration workflows</a></li>
-                    <li><a href="document/generatedoc">Documentation generation</a></li>
-                    <li><a href="govern/governance">Project governance in IDE, Git, CI/CD</a></li>
-                    <li><a href="discover/viewlineage">SaaS UI for dbt docs and lineage</a></li>
-                    <li><a href="govern/querybookmarks">Query history and Query bookmarks</a></li>
-                </ul>
-            </div>
-        </div>
-    </div>
-</body>
-</html>
-
+<div class="ak-cta-row">
+  <a class="ak-btn ak-btn-primary" href="/setup/installation/">Install the extension</a>
+  <a class="ak-btn ak-btn-secondary" href="/setup/faq/">Read the FAQ</a>
 </div>
 
 ## Datamates with AI Teammates
 
-The Power User extension is part of the Datamates Platform. Datamates Platform offers the functionality to automate and accelerate the work of data teams in various areas
-of platform engineering, data engineering, and analytics engineering. Datamates Platform consists of many AI teammates to help data teams with their work. For example, there is a documentation generator teammate that's specifically developed to handle data documentation work.
+The Power User extension is part of the [Datamates Platform](/datamates/user-guide/home/). Datamates automates and accelerates data teams across platform engineering, data engineering, and analytics engineering through purpose-built AI teammates.
 
-These AI teammates are available as part of the power user extension to offer the functionality ranging from dbt models, docs, tests generation to SQL translation & explanation. AI teammates can be coached by you and personalized for your specific requirements. To learn more - please check this section on [coaching AI teammates](./teammates/coach.md).
+These teammates are available directly inside the extension, covering dbt model, doc, and test generation to SQL translation and explanation. They can be coached and personalized for your specific requirements. See [coaching AI teammates](./teammates/coach.md) to get started.
 
-<br>
-## Feature Comparison
+<div class="nt-cards nt-grid cols-3" markdown>
 
-The dbt Power User Extension has great features out of the box. Add a free [Altimate api key](setup/reqdConfig.md#enable-saas-features-by-adding-api-key) to unlock all the features in "With Altimate AI Key" below.
+<div class="nt-card" markdown>
+<div class="nt-card-content" markdown>
+<div class="ak-card-icon">
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+</div>
 
-<div class="html-in-md">
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Feature Comparison</title>
-</head>
-<body>
-    <div class="container">        
-        <div class="workflow">
-            <div class="steps">
-                <div class="arrow"></div>
-                <div class="step">dbt Power Users Extension</div>
-                <div class="step">With Altimate AI Key</div>
-            </div>
-        </div>
-        <div class="details">
-            <div class="column">
-                <ul>
-                    <li><a href="test/sqlvisualizer">SQL Visualizer</a></li>
-                    <li><a href="test/lineage/#model-lineage">Data Lineage: Model Level </a></li>
-                    <li><a href="develop/genmodelsource">Auto-gen dbt from source</a></li>
-                    <li><a href="develop/autocomplete">Auto-complete code</a> </li>
-                    <li><a href="develop/clicktorun">Click to Run Models</a></li>
-                    <li><a href="develop/compiledCode">Compiled SQL preview</a></li>
-                    <li><a href="test/queryResults">Preview query results and analysis</a></li>
-                    <li><a href="test/defertoprod">Defer to prod</a></li>
-                    <li><a href="test/sqlvalidation">SQL validation without execution</a></li>
-                </ul>
-            </div>
-            <div class="column">
-                <ul>
-                    <li><a href="https://datamates-docs.myaltimate.com/user-guide/home/">Datamates</a></li> 
-                    <li><a href="test/lineage/#column-lineage">Data Lineage: Column Level </a></li>
-                    <li><a href="develop/explanation">Query Explanation AI</a></li>
-                    <li><a href="develop/translateSQL">Query Translation AI</a></li>
-                    <li><a href="develop/genmodelSQL">Auto-gen dbt from SQL</a> </li>
-                    <li><a href="test/writetests">Tests Generation AI</a></li>
-                    <li><a href="document/generatedoc">Documentation Generation AI</a></li>
-                    <li><a href="teammates/coach">Coach & Personalize AI Teammates</a></li>
-                    <li><a href="govern/collaboration#start-a-discussion">Code Collaboration</a></li>
-                    <li><a href="govern/collaboration#start-a-discussion_1">Documentation Collaboration</a></li>
-                    <li><a href="govern/collaboration#lineage-export-workflow">Data Lineage - Export</a></li>
-                    <li><a href="govern/collaboration#view-lineage-in-saas">Data Lineage - SaaS UI</a></li>
-                    <li><a href="govern/governance#configure-checks">Project Governance - VS Code </a></li>              
-                    <li><a href="govern/governance#available-via-extension-python-package">Project Governance - CI/CD </a></li>              
-                    <li><a href="govern/governance#saas-configuration-of-checks">Project Governance - SaaS UI</a></li>         
-                    <li><a href="discover/viewlineage">dbt Docs - SaaS UI (dbt core or cloud)</a></li>
-                    <li><a href="govern/querybookmarks">Query History</a></li>
-                    <li><a href="govern/querybookmarks">Query Bookmarks</a></li>
-                    <li><a href="govern/querybookmarks">Query Sharing</a></li>
-                    
-                </ul>
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+### [Setup](/setup/installation/)
+
+Install the extension and configure dbt Core, Cloud or Fusion.
+
+</div>
+</div>
+
+<div class="nt-card" markdown>
+<div class="nt-card-content" markdown>
+<div class="ak-card-icon">
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+</div>
+
+### [Develop](/develop/autocomplete/)
+
+Autocomplete, compiled SQL, model generation, optimize and translate.
+
+</div>
+</div>
+
+<div class="nt-card" markdown>
+<div class="nt-card-content" markdown>
+<div class="ak-card-icon">
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+</div>
+
+### [Test](/test/queryResults/)
+
+Query results, CTEs, the SQL visualizer, tests and column lineage.
+
+</div>
+</div>
+
+<div class="nt-card" markdown>
+<div class="nt-card-content" markdown>
+<div class="ak-card-icon">
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>
+</div>
+
+### [Document](/document/write/)
+
+Write and generate documentation, with doc-block support.
+
+</div>
+</div>
+
+<div class="nt-card" markdown>
+<div class="nt-card-content" markdown>
+<div class="ak-card-icon">
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+</div>
+
+### [Collaborate](/govern/governance/)
+
+Governance, notebooks, multi-project and query bookmarks.
+
+</div>
+</div>
+
+<div class="nt-card" markdown>
+<div class="nt-card-content" markdown>
+<div class="ak-card-icon">
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+</div>
+
+### [Discover](/discover/setupui/)
+
+Browser-based docs and column lineage from the SaaS UI.
+
+</div>
+</div>
 
 </div>
 
+## Feature Comparison
+
+The extension works great out of the box. Add a free [Altimate API key](setup/reqdConfig.md#enable-saas-features-by-adding-api-key) to unlock the AI-powered features.
+
+| Power User for dbt Extension                             | With Altimate AI Key                                                                  |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [SQL Visualizer](test/sqlvisualizer)                     | [Datamates Platform](/datamates/user-guide/home/)                                     |
+| [Data Lineage: Model Level](test/lineage/#model-lineage) | [Data Lineage: Column Level](test/lineage/#column-lineage)                            |
+| [Auto-gen dbt from source](develop/genmodelsource)       | [Query Explanation AI](develop/explanation)                                           |
+| [Auto-complete code](develop/autocomplete)               | [Query Translation AI](develop/translateSQL)                                          |
+| [Click to Run Models](develop/clicktorun)                | [Auto-gen dbt from SQL](develop/genmodelSQL)                                          |
+| [Compiled SQL preview](develop/compiledCode)             | [Tests Generation AI](test/writetests)                                                |
+| [Preview query results](test/queryResults)               | [Documentation Generation AI](document/generatedoc)                                   |
+| [Defer to prod](test/defertoprod)                        | [Coach & Personalize AI Teammates](teammates/coach)                                   |
+| [SQL validation without execution](test/sqlvalidation)   | [Code Collaboration](govern/collaboration#start-a-discussion)                         |
+| —                                                        | [Documentation Collaboration](govern/collaboration#start-a-discussion_1)              |
+| —                                                        | [Data Lineage Export](govern/collaboration#lineage-export-workflow)                   |
+| —                                                        | [Data Lineage SaaS UI](govern/collaboration#view-lineage-in-saas)                     |
+| —                                                        | [Project Governance: VS Code](govern/governance#configure-checks)                     |
+| —                                                        | [Project Governance: CI/CD](govern/governance#available-via-extension-python-package) |
+| —                                                        | [Project Governance: SaaS UI](govern/governance#saas-configuration-of-checks)         |
+| —                                                        | [dbt Docs SaaS UI](discover/viewlineage)                                              |
+| —                                                        | [Query History & Bookmarks](govern/querybookmarks)                                    |
+| —                                                        | [Query Sharing](govern/querybookmarks)                                                |
+
+## Other Altimate products
+
+- [Altimate Code](/code/) — The open-source data engineering harness.
+- [Altimate MCP](/datamates/) — A local-first MCP server for your data stack.
+- [Altimate Lite for Snowflake](/snowflake-native-app/) — More out of your Snowflake compute, without your data leaving your account.
+- [Altimate Platform](https://altimate.ai/platform?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) — Enterprise cost optimization for [Snowflake](https://altimate.ai/use-cases/altimate-for-snowflake?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) and [Databricks](https://altimate.ai/use-cases/altimate-for-databricks?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link).
+
 ## Support
 
-Power user extension and Datamates Platform is developed and maintained by [Altimate AI team](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs).
-Please join the dbt Community Slack Channel [#tools-dbt-power-user](https://getdbt.slack.com/archives/C05KPDGRMDW) to meet with the community of users of the extension.
+The extension and Datamates Platform are developed and maintained by [Altimate AI](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link). Join the dbt Community Slack channel [#tools-dbt-power-user](https://getdbt.slack.com/archives/C05KPDGRMDW) to connect with other users.
 
-If you run into issues, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via Slack or chat
+If you run into issues, [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via Slack or chat.

--- a/documentation/docs/setup/configuration.md
+++ b/documentation/docs/setup/configuration.md
@@ -1,6 +1,11 @@
+---
+title: Configuration Reference — Power User for dbt
+description: "Full configuration reference for Power User for dbt VS Code extension settings, API keys, and project options."
+---
+
 # Configuration Settings
 
-This page provides a comprehensive overview of all available configuration settings in the dbt Power User extension. The settings are organized by category for easy reference.
+This page provides a comprehensive overview of all available configuration settings in the Power User for dbt extension. The settings are organized by category for easy reference.
 
 ## Core Settings
 

--- a/documentation/docs/setup/cursor_installation_workaround.md
+++ b/documentation/docs/setup/cursor_installation_workaround.md
@@ -1,16 +1,21 @@
+---
+title: Cursor Installation Workaround — Power User for dbt
+description: "Workaround for installing Power User for dbt in Cursor IDE when the standard marketplace install does not work."
+---
+
 # Cursor IDE: Installation Workaround
 
 /// admonition | Known Cursor Issue
-    type: warning
+type: warning
 
-Some Cursor IDE users experience the dbt Power User extension installation freezing for several minutes, followed by a **"Failed to fetch"** error dialog. This is a **known issue on Cursor's side** and has been reported and acknowledged by the Cursor team. See the [Cursor forum thread](https://forum.cursor.com/t/dbt-power-user-extension-installation-freezes-with-repeated-extensionquery-requests-and-failed-to-fetch-error/149385/4) for details.
+Some Cursor IDE users experience the Power User for dbt extension installation freezing for several minutes, followed by a **"Failed to fetch"** error dialog. This is a **known issue on Cursor's side** and has been reported and acknowledged by the Cursor team. See the [Cursor forum thread](https://forum.cursor.com/t/dbt-power-user-extension-installation-freezes-with-repeated-extensionquery-requests-and-failed-to-fetch-error/149385/4) for details.
 
 Until the Cursor team resolves this, please try the workarounds below.
 ///
 
 ## Problem
 
-When installing the dbt Power User extension in Cursor IDE:
+When installing the Power User for dbt extension in Cursor IDE:
 
 1. The installation **freezes for several minutes** with repeated `extensionQuery` requests.
 2. An error dialog appears with a **"Failed to fetch"** message.
@@ -24,50 +29,50 @@ This workaround tricks Cursor into recognizing the extension entry, then lets yo
 
 **Step 1.** Open the Cursor extensions metadata file at:
 
-| Platform | Path |
-|----------|------|
-| macOS / Linux | `~/.cursor/extensions/extensions.json` |
-| Windows | `%USERPROFILE%\.cursor\extensions\extensions.json` |
+| Platform      | Path                                               |
+| ------------- | -------------------------------------------------- |
+| macOS / Linux | `~/.cursor/extensions/extensions.json`             |
+| Windows       | `%USERPROFILE%\.cursor\extensions\extensions.json` |
 
 **Step 2.** Add the following JSON object to the array in that file:
 
 /// admonition | Update the paths
-    type: tip
+type: tip
 
 Replace `<YOUR_HOME_DIR>` with your actual home directory path (e.g. `/Users/jane`, `/home/jane`, or `C:/Users/jane`).
 ///
 
 ```json
 {
-    "identifier": {
-        "id": "innoverio.vscode-dbt-power-user"
-    },
-    "version": "0.59.1",
-    "location": {
-        "$mid": 1,
-        "fsPath": "<YOUR_HOME_DIR>/.cursor/extensions/innoverio.vscode-dbt-power-user-0.59.1-universal",
-        "path": "<YOUR_HOME_DIR>/.cursor/extensions/innoverio.vscode-dbt-power-user-0.59.1-universal",
-        "scheme": "file"
-    },
-    "relativeLocation": "innoverio.vscode-dbt-power-user-0.59.1-universal",
-    "metadata": {
-        "installedTimestamp": 1768889206275,
-        "pinned": false,
-        "source": "gallery",
-        "id": "4e4743d1-e423-44b9-88a4-d639da0996d1",
-        "publisherId": "4a9e9d34-3546-42a6-971d-5a640a726245",
-        "publisherDisplayName": "Altimate Inc.",
-        "targetPlatform": "universal",
-        "updated": false,
-        "private": false,
-        "isPreReleaseVersion": false,
-        "hasPreReleaseVersion": false
-    }
+  "identifier": {
+    "id": "innoverio.vscode-dbt-power-user"
+  },
+  "version": "0.59.1",
+  "location": {
+    "$mid": 1,
+    "fsPath": "<YOUR_HOME_DIR>/.cursor/extensions/innoverio.vscode-dbt-power-user-0.59.1-universal",
+    "path": "<YOUR_HOME_DIR>/.cursor/extensions/innoverio.vscode-dbt-power-user-0.59.1-universal",
+    "scheme": "file"
+  },
+  "relativeLocation": "innoverio.vscode-dbt-power-user-0.59.1-universal",
+  "metadata": {
+    "installedTimestamp": 1768889206275,
+    "pinned": false,
+    "source": "gallery",
+    "id": "4e4743d1-e423-44b9-88a4-d639da0996d1",
+    "publisherId": "4a9e9d34-3546-42a6-971d-5a640a726245",
+    "publisherDisplayName": "Altimate Inc.",
+    "targetPlatform": "universal",
+    "updated": false,
+    "private": false,
+    "isPreReleaseVersion": false,
+    "hasPreReleaseVersion": false
+  }
 }
 ```
 
 /// admonition | Validate your JSON
-    type: info
+type: info
 
 If `extensions.json` already has other entries, make sure to add a comma separator between objects so the JSON remains valid.
 ///
@@ -83,7 +88,7 @@ If `extensions.json` already has other entries, make sure to add a comma separat
 - Press `Cmd + Shift + P` (macOS) or `Ctrl + Shift + P` (Windows/Linux)
 - Type **"Developer: Reload Window"** and press Enter
 
-**Step 6.** Open the dbt Power User extension page. You will see an error that the extension files don't exist — this is expected:
+**Step 6.** Open the Power User for dbt extension page. You will see an error that the extension files don't exist — this is expected:
 
 ![Extension page showing error](images/cursor_workaround_step_2.png)
 
@@ -117,7 +122,7 @@ The extension will install directly from the file, bypassing the marketplace fet
 ---
 
 /// admonition | Still having issues?
-    type: tip
+type: tip
 
-If neither workaround resolves the problem, please reach out on the [#tools-dbt-power-user](https://getdbt.slack.com/archives/C05KPDGRMDW) Slack channel or [contact support](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs).
+If neither workaround resolves the problem, please reach out on the [#tools-dbt-power-user](https://getdbt.slack.com/archives/C05KPDGRMDW) Slack channel or [contact support](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link).
 ///

--- a/documentation/docs/setup/faq.md
+++ b/documentation/docs/setup/faq.md
@@ -1,14 +1,19 @@
+---
+title: Setup FAQ — Power User for dbt
+description: "Answers to common setup questions for Power User for dbt: connection issues, configuration, and extension settings."
+---
+
 ## Frequently Asked Questions
 
 - **Why am I receiving a "Network Error" message when trying to log into my Altimate AI account on the Sign In page?**
 
 When logging into your Altimate AI account on the Sign In page, if you encounter a "Network Error" message, it's likely due to the use of the general URL: https://app.myaltimate.com/login. At Altimate AI, we assign a unique URL to each tenant as part of our commitment to ensuring data isolation and providing a seamless user experience. Therefore, to access your account without any issues, it's crucial to use the specific URL that was uniquely created for you at the time of your account registration.
 
-- **How to Customize the Target Profile for VS Code dbt Power User Extension Functions?**
+- **How to Customize the Target Profile for VS Code Power User for dbt Extension Functions?**
 
-To customize the target profile in VS Code for dbt Power User extension functions, follow these steps:
+To customize the target profile in VS Code for Power User for dbt extension functions, follow these steps:
 
-Open Your dbt Project: Ensure you have your dbt project open in VS Code where the dbt Power User extension is installed.
+Open Your dbt Project: Ensure you have your dbt project open in VS Code where the Power User for dbt extension is installed.
 
 Locate the profiles.yml File: This file contains the configuration for your different dbt profiles. By default, the extension uses the 'dev' profile.
 
@@ -17,7 +22,7 @@ Edit the Profile: In the profiles.yml file, you can define multiple profiles. Ea
 Set Your Desired Profile:
 
 To change the active profile, you can use the dbt CLI command `dbt --profile your_profile_name debug` in the integrated terminal of VS Code.
-Alternatively, some extensions allow profile selection through the extension settings. Check if dbt Power User has such an option by going to the extension settings in VS Code.
+Alternatively, some extensions allow profile selection through the extension settings. Check if Power User for dbt has such an option by going to the extension settings in VS Code.
 Restart VS Code: After making changes, restart VS Code to ensure that the new profile settings are loaded.
 
 Verify the Change: Run a command like "compiled dbt preview" or "query preview" to verify that the extension is now using your specified profile.

--- a/documentation/docs/setup/installation.md
+++ b/documentation/docs/setup/installation.md
@@ -1,4 +1,9 @@
-/// admonition | We've released our [Datamates Extension](https://marketplace.visualstudio.com/items?itemName=altimateai.vscode-altimate-mcp-server) - to give you the power to use AI TeamMates! [Click here](https://datamates-docs.myaltimate.com/) to learn more.
+---
+title: Install Power User for dbt — VS Code Extension
+description: "Install Power User for dbt from the VS Code Marketplace or via the Datamates extension. Step-by-step guide."
+---
+
+/// admonition | We've released our [Datamates Extension](https://marketplace.visualstudio.com/items?itemName=altimateai.vscode-altimate-mcp-server) - to give you the power to use AI TeamMates! [Click here](/datamates/) to learn more.
 ///
 
 There are a few different ways in which extension can be installed.
@@ -11,11 +16,10 @@ You can install the extension from VSCode directly or from the [VSCode Marketpla
 You can install the extension from Cursor or any other VSCode compatible editors directly or from the [Open VSX Registry](https://open-vsx.org/extension/innoverio/vscode-dbt-power-user)
 
 /// admonition | Cursor IDE users: Installation may freeze
-    type: warning
+type: warning
 
 Some Cursor users experience the extension installation freezing for several minutes and showing a "Failed to fetch" error. This is a known Cursor issue. If you encounter this, please follow the [Cursor installation workaround](cursor_installation_workaround.md) to resolve it.
 ///
-
 
 /// details | Here's how to install the extension in VSCode
 
@@ -25,12 +29,12 @@ Some Cursor users experience the extension installation freezing for several min
 
 ///
 
-/// admonition | Need to setup environment variables? Refer to this [section](https://docs.myaltimate.com/setup/optConfig/#environment-variables-setup)
-    type: warning
+/// admonition | Need to setup environment variables? Refer to this [section](/setup/optConfig/#environment-variables-setup)
+type: warning
 ///
 
 /// admonition | If you are seeing the message "Reload required", please reload the VSCode or restart the VSCode.
-    type: info
+type: info
 ///
 
 ## Install the extension in a dev container (or in codespaces)
@@ -61,5 +65,5 @@ Please add the following configuration in to your devcontainer.json file:
 ```
 
 /// admonition | Please do NOT forget to do required configuration based on your dbt setup: [dbt Core](reqdConfig.md), [dbt Cloud](reqdConfigCloud.md), or [dbt Fusion](reqdConfigFusion.md), and [optional configuration](optConfig.md)!!
-    type: warning
+type: warning
 ///

--- a/documentation/docs/setup/optConfig.md
+++ b/documentation/docs/setup/optConfig.md
@@ -1,3 +1,8 @@
+---
+title: Optional Configuration — Power User for dbt
+description: "Optional VS Code settings for Power User for dbt including formatting preferences, UI options, and advanced configuration."
+---
+
 ## Environment Variables Setup
 
 There are multiple sources from where the extension reads the environment variables.
@@ -7,7 +12,7 @@ There are multiple sources from where the extension reads the environment variab
 - [dot env file (we get this from python extension)](#environment-variables-through-pythonenvfile)
 
 /// admonition | Environment variable available in vscode terminal doesn't necessarily will be available to the extension. Extension can only read environment variables if available in the above sources
-    type: warning
+type: warning
 ///
 
 ### Environment variables set outside of Visual Code (.zshrc, .bashrc, ...)
@@ -16,7 +21,7 @@ If you have variables set in .zshrc or .bashrc the extension automatically picks
 These environment variables will be passed to all operations of the extension. If you make changes to the environment variables you need to restart vscode.
 
 /// admonition | The environment variable should be valid for all your dbt projects. For example DBT_PROFILES_DIR can be set to ., that way dbt will lookup the profiles.yaml file inside the root of the dbt project.
-    type: info
+type: info
 ///
 
 ### Environment variables setup using the integrated Terminal Profiles ( .vscode/settings.json )
@@ -51,7 +56,7 @@ Linux:
 The official documentation can be found [here](https://code.visualstudio.com/docs/terminal/profiles)
 
 /// admonition | Visual Code variable substitution is not supported except the environment variable pattern ${env:*} and ${workspaceFolder}.
-    type: warning
+type: warning
 ///
 
 ### Environment variables through python.envFile
@@ -61,7 +66,7 @@ The extension also loads an environment variable definitions file identified by 
 This way supports all Visual Code variable substitution patterns but the environment variables will not be available to the vscode terminal. Read all about [environment variables](https://code.visualstudio.com/docs/python/environments#_environment-variables) supported by the Visual Code Python extension.
 
 /// admonition | Make sure the .env file is in the [right format](https://www.dotenv.org/docs/security/env) or else the extension won't be able to detected the variables.
-    type: warning
+type: warning
 ///
 
 ### Listing Environment Variables detected by the extension
@@ -69,13 +74,13 @@ This way supports all Visual Code variable substitution patterns but the environ
 We have a debugging utility available within the extension that lists down the environment variables available to the extension and the source from where it is read. Here is how you can trigger the debugging utility
 
 1. Cmd +Shift + P (Ctrl + Shift + P in case of windows) to start the VSCode command bar
-2. Select the option dbt Power User: Print environment variable
+2. Select the option Power User for dbt: Print environment variable
    ![Debug Command](images/debugCmd.png)
 3. It should print all the environment variables detected and the sources as well
    ![Sample Output](images/listEnvVariables.png)
 
 /// admonition | In certain scenarios, step 3 has to be executed twice to get the environment variables printed.
-    type: warning
+type: warning
 ///
 
 ### Default DBT Env Support
@@ -124,7 +129,7 @@ For more information you can check out these resources:
 ## [Deprecated] MSSQL, Synapse, Oracle - Query Preview Config
 
 /// admonition | It is no longer required to specify query template for any of the adapter.
-    type: warning
+type: warning
 ///
 
 Your database may not support standard SQL LIMIT statements like `SELECT * from table LIMIT 10`. You can override this default behaviour through `dbt.queryTemplate`.
@@ -150,7 +155,7 @@ These instructions are for setting the TERM environment variable to xterm-256col
 ```
 
 /// admonition | Above instructions for color highlighting are for Windows machines only
-    type: warning
+type: warning
 ///
 
 ## Skip Project
@@ -196,7 +201,7 @@ You can configure the path to sqlfmt through `dbt.sqlFmtPath` and you can config
 
 ### Usage
 
-Please select "dbt Power User" (extension id:`innoverio.vscode-dbt-power-user`) as the default formatter. You can do this either by using the context menu (right click on a open dbt model in the editor) and select "Format Document With...", or you can add the following to your settings:
+Please select "Power User for dbt" (extension id:`innoverio.vscode-dbt-power-user`) as the default formatter. You can do this either by using the context menu (right click on a open dbt model in the editor) and select "Format Document With...", or you can add the following to your settings:
 
 ```json
   "[jinja-sql]": {

--- a/documentation/docs/setup/reqdConfig.md
+++ b/documentation/docs/setup/reqdConfig.md
@@ -1,11 +1,16 @@
+---
+title: Required Configuration — Power User for dbt
+description: "Required VS Code settings to configure Power User for dbt: dbt project path, profile, target, and connection details."
+---
+
 /// admonition | Only use the following steps for "dbt Core" environments. If you have a dbt Cloud environment, use the [required config instructions for "dbt Cloud" environments](./reqdConfigCloud.md). If you have a dbt Fusion environment, use the [required config instructions for "dbt Fusion" environments](./reqdConfigFusion.md).
-    type: warning
+type: warning
 ///
 
 ## Use the setup wizard for configuration (recommended)
 
-/// admonition | Need to setup environment variables? Refer to this [section](https://docs.myaltimate.com/setup/optConfig/#environment-variables-setup)
-    type: warning
+/// admonition | Need to setup environment variables? Refer to this [section](/setup/optConfig/#environment-variables-setup)
+type: warning
 ///
 
 This method will save a bunch of time for you, and you can also validate your configuration. Setup wizard will help you in associating sql files with jinja-sql, selecting the right Python interpreter, make sure dbt dependencies are correctly installed etc. In the end, it will also validate your configuration.
@@ -15,7 +20,7 @@ You can start the setup wizard by clicking on dbt status icon in bottom status b
 <interactive demo for setup wizard>
 
 <div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.50; padding: 40px 0 40px 0;">
-  <iframe src="https://app.supademo.com/embed/cmnsywfgw4brfcr4j1npz9esr?embed_v=2&utm_source=embed" loading="lazy" title="dbt Power User Setup guide-Core" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+  <iframe src="https://app.supademo.com/embed/cmnsywfgw4brfcr4j1npz9esr?embed_v=2&utm_source=embed" loading="lazy" title="Power User for dbt Setup guide-Core" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
 **Here are steps covered in the setup wizard**
 
@@ -24,7 +29,7 @@ You can start the setup wizard by clicking on dbt status icon in bottom status b
 Click on the action button - "Select Python Interpreter" and choose your preferred python interpreter. Usually, choosing interpreter that's recommended, or mapped to your virtual environment software (e.g. venv) as per the list is a good idea. If you know the path of your Python environment, you can choose it from the list or if the path is not present there, you can enter it manually.
 
 /// admonition | If needed, please run 'where python' command on terminal to see if it shows path to Python interpreter that you are using.
-    type: tip
+type: tip
 ///
 
 **Install dbt**
@@ -41,14 +46,14 @@ Many times project failures or weird errors are seen if dbt dependencies are not
 Last step is clicking on button - "Validate Project" It will run a bunch of checks to make sure your dbt environment and project are setup correctly.
 If there are some issues, it will tell you exactly what's wrong as well.
 
-/// admonition | If you still can't get the extension setup correctly, please contact us via slack or chat through [support page](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs)
-    type: tip
+/// admonition | If you still can't get the extension setup correctly, please contact us via slack or chat through [support page](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: tip
 ///
 
 ## Manual method of configuration
 
 /// admonition | Please follow the manual method only if you couldn't use the setup wizard above.
-    type: info
+type: info
 
 ///
 
@@ -92,14 +97,14 @@ Select the Python interpreter that has dbt installed.
 ![Select Python interpreter](images/selectInterpreter.gif)
 
 /// admonition | Tip
-    type: info
+type: info
 
 If you select a python environment with dbt already installed, the dbt label on the bottom strip of the VS Code will show a checkmark.
 
 ///
 
 /// details | If dbt is shown as not installed in the extension, the extension can install dbt for you automatically - just click on the dbt status icon on the bottom strip of the VSCode.
-    type: tip
+type: tip
 
 <interactive demo to install dbt in Python environment>
 
@@ -108,7 +113,7 @@ If you select a python environment with dbt already installed, the dbt label on 
 ///
 
 /// admonition | Warning for Python path overrides
-    type: warning
+type: warning
 
 Avoid using the setting dbt.dbtPythonPathOverride unless using Meltano, the extension depends on the Python interpreter for visual code compatible environment variable parsing.
 
@@ -118,7 +123,7 @@ Avoid using the setting dbt.dbtPythonPathOverride unless using Meltano, the exte
 
 There are multiple features in the extension, including [generate dbt documentation](../document/generatedoc.md), [column lineage](../test/lineage.md), [query explanation](../develop/explanation.md), [generate dbt model from SQL](../develop/genmodelSQL.md) that require an API key.
 
-/// details | You can get an API key for free by signing up at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
+/// details | You can get an API key for free by signing up at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
 
 <interactive demo to get an API key>
 

--- a/documentation/docs/setup/reqdConfigCloud.md
+++ b/documentation/docs/setup/reqdConfigCloud.md
@@ -1,16 +1,21 @@
+---
+title: dbt Cloud Configuration — Power User for dbt
+description: "Configure Power User for dbt to connect to dbt Cloud with your service token and account details."
+---
+
 /// admonition | Only use the following steps for "dbt Cloud" environments. If you have a dbt Core environment, use the [required config instructions for "dbt Core" environments](./reqdConfig.md). If you have a dbt Fusion environment, use the [required config instructions for "dbt Fusion" environments](./reqdConfigFusion.md).
-    type: warning
+type: warning
 ///
 
 /// admonition | dbt Cloud integration is available as beta functionality
-    type: tip
+type: tip
 ///
 
 ## Enable dbt Cloud Integration by adding an API key
 
 dbt Cloud integration in Power User VSCode extension requires an API key. There are also multiple preview features in the extension including [generate dbt documentation](../document/generatedoc.md), [column lineage](../test/lineage.md), [query explanation](../develop/explanation.md), [generate dbt model from SQL](../develop/genmodelSQL.md) that are also enabled with an API key.
 
-/// details | You can get an API key for free by signing up at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
+/// details | You can get an API key for free by signing up at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
 
 <interactive demo to get an API key>
 
@@ -31,8 +36,8 @@ Go to the VSCode extension settings, and then add an API key and instance name.
 
 ## Use the setup wizard for configuration (recommended)
 
-/// admonition | Need to setup environment variables? Refer to this [section](https://docs.myaltimate.com/setup/optConfig/#environment-variables-setup)
-    type: warning
+/// admonition | Need to setup environment variables? Refer to this [section](/setup/optConfig/#environment-variables-setup)
+type: warning
 ///
 
 This method will save a bunch of time for you, and you can also validate your configuration. Setup wizard will help you in associating sql files with jinja-sql, selecting the right Python interpreter, make sure dbt dependencies are correctly installed etc. In the end, it will also validate your configuration.
@@ -40,7 +45,7 @@ This method will save a bunch of time for you, and you can also validate your co
 You can start the setup wizard by clicking on dbt status icon in bottom status bar, and performing following necessary steps as shown in the recorded demo below:
 
 <div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.50; padding: 40px 0 40px 0;">
-  <iframe src="https://app.supademo.com/embed/cmnt0ivy300g4w80j5zufa5p7?embed_v=2&utm_source=embed" loading="lazy" title="dbt Power User Setup guide-Cloud" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+  <iframe src="https://app.supademo.com/embed/cmnt0ivy300g4w80j5zufa5p7?embed_v=2&utm_source=embed" loading="lazy" title="Power User for dbt Setup guide-Cloud" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
 **Here are the steps covered in the setup wizard**
 
@@ -49,7 +54,7 @@ You can start the setup wizard by clicking on dbt status icon in bottom status b
 Click on the action button - "Select Python Interpreter" and choose your preferred python interpreter. Usually, choosing interpreter that's recommended, or mapped to your virtual environment software (e.g. venv) as per the list is a good idea. If you know the path of your Python envionment, you can choose it from the list or if the path is not present there, you can enter it manually.
 
 /// admonition | If needed, please run 'where python' command on terminal to see if it shows path to Python interpreter that you are using.
-    type: tip
+type: tip
 ///
 
 **Install dbt**
@@ -62,7 +67,7 @@ Last step is clicking on button - "Validate Project" It will run a bunch of chec
 If there are some issues, it will tell you exactly what's wrong as well.
 
 /// admonition | If you still can't get the extension setup correctly, please check the [troubleshooting page](../troubleshooting.md)
-    type: tip
+type: tip
 ///
 
 ## Questions and Answers
@@ -83,7 +88,7 @@ A direct line of communication with our users is established with the authentica
 
 #### What if I don't want to use preview features or accidentally send data to Altimate?
 
-We understand the concern about using preview features and the risk of accidental data transmission. To address this, we have implemented stringent data security practices, which you can review in our [security FAQ](https://docs.myaltimate.com/arch/faq/). Our solutions have passed security reviews by several large organizations in the US, and we are open to undergoing similar reviews for your organization. Additionally, we are working on making some preview features available offline through our [open-source Python CLI package](https://github.com/AltimateAI/datapilot-cli).
+We understand the concern about using preview features and the risk of accidental data transmission. To address this, we have implemented stringent data security practices, which you can review in our [security FAQ](/arch/faq/). Our solutions have passed security reviews by several large organizations in the US, and we are open to undergoing similar reviews for your organization. Additionally, we are working on making some preview features available offline through our [open-source Python CLI package](https://github.com/AltimateAI/datapilot-cli).
 
 #### How are you addressing concerns about data transmission in preview features?
 

--- a/documentation/docs/setup/reqdConfigFusion.md
+++ b/documentation/docs/setup/reqdConfigFusion.md
@@ -1,9 +1,14 @@
+---
+title: dbt Fusion Configuration — Power User for dbt
+description: "Configure Power User for dbt to work with dbt Fusion for improved performance and cloud integration."
+---
+
 /// admonition | Only use the following steps for "dbt Fusion" environments. If you have a dbt Core environment, use the [required config instructions for "dbt Core" environments](./reqdConfig.md). If you have a dbt Cloud environment, use the [required config instructions for "dbt Cloud" environments](./reqdConfigCloud.md).
-    type: warning
+type: warning
 ///
 
 /// admonition | dbt Fusion integration provides enhanced performance and features
-    type: tip
+type: tip
 ///
 
 ## What is dbt Fusion?
@@ -11,6 +16,7 @@
 dbt Fusion is a command-line interface that provides enhanced dbt functionality with improved performance and additional features. Unlike standard dbt Core, dbt Fusion is a standalone executable that doesn't require a Python environment, making it easier to install and manage.
 
 ### Key Benefits of dbt Fusion Integration:
+
 - **Standalone Installation**: No Python environment required
 - **Enhanced Performance**: Optimized execution compared to standard dbt
 - **Cross-Platform Support**: Available for macOS, Linux, and Windows
@@ -19,8 +25,8 @@ dbt Fusion is a command-line interface that provides enhanced dbt functionality 
 
 ## Use the setup wizard for configuration (recommended)
 
-/// admonition | Need to setup environment variables? Refer to this [section](https://docs.myaltimate.com/setup/optConfig/#environment-variables-setup)
-    type: warning
+/// admonition | Need to setup environment variables? Refer to this [section](/setup/optConfig/#environment-variables-setup)
+type: warning
 ///
 
 This method will save a bunch of time for you, and you can also validate your configuration. The setup wizard will help you in associating SQL files with jinja-sql, installing dbt Fusion if needed, and validating your project configuration.
@@ -28,7 +34,7 @@ This method will save a bunch of time for you, and you can also validate your co
 You can start the setup wizard by clicking on the dbt status icon in the bottom status bar, and perform the following necessary steps:
 
 <div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.50; padding: 40px 0 40px 0;">
-  <iframe src="https://app.supademo.com/embed/cmnt1t4jz4hj3cr4j3knosm74?embed_v=2&utm_source=embed" loading="lazy" title="dbt Power User Setup guide-Fusion" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+  <iframe src="https://app.supademo.com/embed/cmnt1t4jz4hj3cr4j3knosm74?embed_v=2&utm_source=embed" loading="lazy" title="Power User for dbt Setup guide-Fusion" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
 **Here are the steps covered in the setup wizard**
 
@@ -51,14 +57,14 @@ The wizard will help you associate `*.sql` files with `jinja-sql` language mode 
 
 The last step is clicking the "Validate Project" button. It will run a bunch of checks to make sure your dbt Fusion environment and project are set up correctly. If there are issues, it will tell you exactly what's wrong.
 
-/// admonition | If you still can't get the extension setup correctly, please contact us via slack or chat through [support page](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs)
-    type: tip
+/// admonition | If you still can't get the extension setup correctly, please contact us via slack or chat through [support page](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: tip
 ///
 
 ## Manual method of configuration
 
 /// admonition | Please follow the manual method only if you couldn't use the setup wizard above.
-    type: info
+type: info
 ///
 
 ### Step 1: Install dbt Fusion
@@ -66,18 +72,20 @@ The last step is clicking the "Validate Project" button. It will run a bunch of 
 #### Automatic Installation via Extension
 
 1. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
-2. Type "dbt Power User: Install dbt"
+2. Type "Power User for dbt: Install dbt"
 3. Select the command and choose "dbt Fusion" when prompted
 4. The extension will automatically download and install dbt Fusion for your platform
 
 #### Manual Installation
 
 **macOS and Linux:**
+
 ```bash
 curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 irm https://public.cdn.getdbt.com/fs/install/install.ps1 | iex
 ```
@@ -85,6 +93,7 @@ irm https://public.cdn.getdbt.com/fs/install/install.ps1 | iex
 #### Verify Installation
 
 After installation, verify that dbt Fusion is properly installed by running:
+
 ```bash
 dbt --version
 ```
@@ -96,36 +105,42 @@ You should see output that includes "dbt-fusion" in the version information.
 Set the integration type to fusion in your VSCode settings:
 
 #### Method 1: Via VSCode Settings UI
+
 1. Open VSCode Settings (`Ctrl+,` / `Cmd+,`)
 2. Search for "dbt integration"
 3. Set "Dbt: Dbt Integration" to "fusion"
 
 #### Method 2: Via settings.json
+
 Add the following to your VSCode settings.json:
+
 ```json
 {
-    "dbt.dbtIntegration": "fusion"
+  "dbt.dbtIntegration": "fusion"
 }
 ```
 
-### Step 3: Associate *.sql files with jinja-sql
+### Step 3: Associate \*.sql files with jinja-sql
 
 #### Method 1: Configure in Preferences > Settings
+
 ![File Associations](images/associations.png)
 
 #### Method 2: Update settings.json directly
+
 ```json
 {
-    "files.associations": {
-        "*.sql": "jinja-sql",
-        "*.yml": "jinja-yaml"
-    }
+  "files.associations": {
+    "*.sql": "jinja-sql",
+    "*.yml": "jinja-yaml"
+  }
 }
 ```
 
 ### Step 4: Verify Configuration
 
 After configuration, check that:
+
 1. The bottom status bar shows "dbt fusion" with a checkmark
 2. You can execute dbt commands through the extension
 3. IntelliSense and syntax highlighting work in your dbt files
@@ -134,7 +149,7 @@ After configuration, check that:
 
 There are multiple features in the extension, including [generate dbt documentation](../document/generatedoc.md), [column lineage](../test/lineage.md), [query explanation](../develop/explanation.md), [generate dbt model from SQL](../develop/genmodelSQL.md) that require an API key.
 
-/// details | You can get an API key for free by signing up at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
+/// details | You can get an API key for free by signing up at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
 
 <interactive demo to get an API key>
 
@@ -158,6 +173,7 @@ Go to VSCode extension settings, and add API key and instance name there.
 dbt Fusion integration supports most extension features with some exceptions:
 
 ### ✅ Supported Features
+
 - **Query Execution**: Execute models and preview results
 - **SQL Compilation**: View compiled SQL code
 - **Auto-completion**: IntelliSense for models, macros, and sources
@@ -168,6 +184,7 @@ dbt Fusion integration supports most extension features with some exceptions:
 - **Query Explanation**: AI-powered SQL explanation
 
 ### ❌ Limited Features
+
 - **Documentation Generation**: Not supported in dbt Fusion CLI
 - **Some Advanced Features**: May have limitations compared to dbt Core integration
 

--- a/documentation/docs/setup/sso.md
+++ b/documentation/docs/setup/sso.md
@@ -1,3 +1,8 @@
+---
+title: SSO Setup — Power User for dbt
+description: "Configure single sign-on (SSO) for Power User for dbt with your identity provider for team authentication."
+---
+
 If you would like to use SSO for authentication, please follow the instructions below. <br>
 
 We support OIDC (OpenID Connect) today, and SAML is not yet supported. We will explain the process for Okta as authentication provider below, but
@@ -19,7 +24,7 @@ Add additional config for -
 Your instance-url may be either "instance-name".app.getaltimate.com or "instance-name".app.myaltimate.com
 
 /// admonition | If you don't know the instance-name in above URIs, please contact the support team
-    type: tip
+type: tip
 ///
 
 Also, in "Assignments" section, please choose "skip group assignments" for now.
@@ -44,7 +49,7 @@ Please use URL as https://<tenant>.getaltimate.com/login-redirect/okta or https:
 After this point, you can start using your Altimate AI instance with SSO and start onboarding users!
 
 /// admonition | You need to have an enterprise plan for the SSO integration.
-    type: info
+type: info
 ///
 
 ## Azure AD SSO Setup
@@ -66,7 +71,7 @@ Enter a valid application name and in “Redirect URI” section, select “Web�
 Your instance-url may be either "instance-name".app.getaltimate.com or "instance-name".app.myaltimate.com
 
 /// admonition | If you don't know the instance-name in above URIs, please contact the support team
-    type: tip
+type: tip
 ///
 
 After registration, in overview section of the application, copy and save “Application (client) ID”. Then, Click “Add a certificate or secret”
@@ -78,7 +83,7 @@ click “New client secret”. Enter description and select expiration according
 ![Add Client Secret](images/addClientSecret.png)
 
 /// admonition | Make sure to contact us to update the secrets if it is expired.
-    type: tip
+type: tip
 ///
 
 Copy and save the secret value
@@ -131,7 +136,7 @@ Once you've configured your app to enable user assignment, you can go ahead and 
 ![App Users](images/appUsers.png)
 
 /// admonition | If needed, please check Microsoft Entra documentation [here](https://learn.microsoft.com/en-us/entra/identity-platform/howto-restrict-your-app-to-a-set-of-users)
-    type: tip
+type: tip
 ///
 
 ## Azure AD Troubleshooting

--- a/documentation/docs/studio.md
+++ b/documentation/docs/studio.md
@@ -1,3 +1,8 @@
+---
+title: Studio — Natural Language dbt Queries
+description: "Studio is a specialized AI agent in Power User for dbt for natural language data queries, lineage exploration, and performance analysis."
+---
+
 # Studio
 
 ## What is Studio?
@@ -47,13 +52,13 @@ Traditional AI approaches have critical limitations. These limitations are well 
 ## Extending Context
 
 Beyond the integrations already connected to your SaaS instance, Studio allows you to enrich your queries with additional context:
-![Studio Datamates and Knowledge Base](studio/images/Studio-context.png)
+![Studio Altimate MCP and Knowledge Base](studio/images/Studio-context.png)
 
-| Option               | Description                                                                                                                                                      |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Datamates**        | Select any [Datamate](https://datamates-docs.myaltimate.com/user-guide/home/) to widen the context based on tools                                                |
-| **Knowledge Bases**  | Connect organizational knowledge repositories from [Knowledge Hub](https://datamates-docs.myaltimate.com/user-guide/components/knowledgehub/) for deeper context |
-| **File Attachments** | Upload documents, queries, or data files directly into your conversation                                                                                         |
+| Option               | Description                                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Altimate MCP**     | Select any [Altimate MCP](/datamates/user-guide/home/) to widen the context based on tools                                            |
+| **Knowledge Bases**  | Connect organizational knowledge repositories from [Knowledge Hub](/datamates/user-guide/components/knowledgehub/) for deeper context |
+| **File Attachments** | Upload documents, queries, or data files directly into your conversation                                                              |
 
 This flexibility ensures you can ask questions across a broader tool set while providing the agent with the context it needs to deliver accurate, actionable insights.
 
@@ -66,7 +71,7 @@ When starting a conversation, users have multiple ways to provide context:
 | Option                  | Description                                                                    |
 | ----------------------- | ------------------------------------------------------------------------------ |
 | **Ask a question**      | Type your query directly in the chat input                                     |
-| **Add Datamate**        | Select a Datamate to access any tool specific information                      |
+| **Add Altimate MCP**    | Select an Altimate MCP to access any tool specific information                 |
 | **Attach files**        | Upload files for analysis (via "+" menu)                                       |
 | **Knowledge Base**      | Access organizational knowledge repositories from Knowledge Hub (via "+" menu) |
 | **View Prompt Library** | Browse pre-built prompts for common tasks (via 'Select Prompt Library')        |
@@ -234,9 +239,9 @@ When accessing Studio from the **Infra** page, you get assistance for infrastruc
 | **Chat History**            | The history for all the chats done through SaaS pages is retained and can be viewed on the main Studio page                    |
 
 /// admonition | Studio is currently in Beta. We're continuously improving the platform based on user feedback.
-    type: info
+type: info
 ///
 
 /// admonition | For more information and access to Studio, visit [app.myaltimate.com](https://app.myaltimate.com)
-    type: tip
+type: tip
 ///

--- a/documentation/docs/teammates/altimate-code.md
+++ b/documentation/docs/teammates/altimate-code.md
@@ -1,12 +1,14 @@
 ---
 status: new
+title: Altimate Code Teammate — Power User for dbt
+description: "Use Altimate Code as an AI teammate inside Power User for dbt for automated model building, testing, and review."
 ---
 
 # Altimate Code in IDE
 
 ## What is Altimate Code?
 
-[Altimate Code](https://docs.altimate.sh) is the open-source data engineering harness with 100+ deterministic tools for building, validating, optimizing, and shipping data products. It brings AI-powered data engineering directly into your IDE through the Datamates extension, or can be used standalone via CLI and TUI.
+[Altimate Code](/code/) is the open-source data engineering harness with 100+ deterministic tools for building, validating, optimizing, and shipping data products. It brings AI-powered data engineering directly into your IDE through the Datamates extension, or can be used standalone via CLI and TUI.
 
 ## Getting Started in Your IDE
 
@@ -18,8 +20,8 @@ status: new
 ### Open Altimate Code Chat
 
 1. Press `Cmd+Shift+P` (macOS) or `Ctrl+Shift+P` (Windows/Linux) to open the command palette
-2. Type `Datamates`
-3. Select **Datamates: Open Altimate Code Chat**
+2. Type `Altimate MCP`
+3. Select **Altimate MCP: Open Altimate Code Chat**
 
 This opens the Altimate Code chat panel where you can interact with agents and run data engineering tools.
 
@@ -29,11 +31,11 @@ This opens the Altimate Code chat panel where you can interact with agents and r
 
 Altimate Code provides three agent modes to match your workflow:
 
-| Mode | Access Level | Use Case |
-|------|-------------|----------|
+| Mode        | Access Level    | Use Case                                                            |
+| ----------- | --------------- | ------------------------------------------------------------------- |
 | **Builder** | Full read/write | Scaffolding dbt projects, writing models, generating tests and docs |
-| **Analyst** | Read-only | Exploring schemas, running queries, analyzing lineage |
-| **Plan** | Minimal access | Planning changes, reviewing impact before execution |
+| **Analyst** | Read-only       | Exploring schemas, running queries, analyzing lineage               |
+| **Plan**    | Minimal access  | Planning changes, reviewing impact before execution                 |
 
 ### 100+ Data Engineering Tools
 
@@ -52,20 +54,20 @@ Altimate Code is **#1 on ADE-Bench** — the industry benchmark for AI data engi
 
 ### ADE-Bench (DuckDB Local)
 
-| Tool | Model | Score | Pass Rate |
-|------|-------|-------|-----------|
-| **Altimate Code** | Sonnet 4.6 | **32/43** | **74.4%** |
-| Cortex Code CLI | Opus 4.6 | 28/43 | 65% |
-| dbt Labs | Sonnet 4.5 | ~25/43 | 59% |
-| Claude Code (baseline) | Sonnet 4.6 | ~17/43 | 40% |
+| Tool                   | Model      | Score     | Pass Rate |
+| ---------------------- | ---------- | --------- | --------- |
+| **Altimate Code**      | Sonnet 4.6 | **32/43** | **74.4%** |
+| Cortex Code CLI        | Opus 4.6   | 28/43     | 65%       |
+| dbt Labs               | Sonnet 4.5 | ~25/43    | 59%       |
+| Claude Code (baseline) | Sonnet 4.6 | ~17/43    | 40%       |
 
 ### Other Benchmarks
 
-| Benchmark | Result |
-|-----------|--------|
-| **SQL Anti-Pattern Detection** | 100% accuracy across 1,077 queries, 19 categories. Zero false positives. |
-| **Column-Level Lineage** | 100% edge match across 500 queries with complex joins, CTEs, and subqueries. |
-| **Snowflake Query Optimization (TPC-H)** | 16.8% average execution speedup (3.6x vs baseline). |
+| Benchmark                                | Result                                                                       |
+| ---------------------------------------- | ---------------------------------------------------------------------------- |
+| **SQL Anti-Pattern Detection**           | 100% accuracy across 1,077 queries, 19 categories. Zero false positives.     |
+| **Column-Level Lineage**                 | 100% edge match across 500 queries with complex joins, CTEs, and subqueries. |
+| **Snowflake Query Optimization (TPC-H)** | 16.8% average execution speedup (3.6x vs baseline).                          |
 
 [Full benchmark details →](https://www.altimate.sh/benchmarks)
 
@@ -80,13 +82,13 @@ Two options for powering the AI chat:
 
 Altimate Code can also be used outside the IDE:
 
-| Interface | Description |
-|-----------|-------------|
-| **TUI** | Interactive terminal UI — `altimate` |
-| **CLI** | Command-line for scripting — `altimate run` |
-| **Web UI** | Browser-based interface — `altimate web` |
-| **CI/CD** | Headless mode for pipelines — `altimate check` |
-| **GitHub/GitLab** | Automated PR review and issue triage |
+| Interface         | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| **TUI**           | Interactive terminal UI — `altimate`           |
+| **CLI**           | Command-line for scripting — `altimate run`    |
+| **Web UI**        | Browser-based interface — `altimate web`       |
+| **CI/CD**         | Headless mode for pipelines — `altimate check` |
+| **GitHub/GitLab** | Automated PR review and issue triage           |
 
 Install standalone:
 
@@ -96,5 +98,5 @@ npm install -g altimate-code
 
 ## Full Documentation
 
-- **Altimate Code docs** — [docs.altimate.sh](https://docs.altimate.sh)
-- **Datamates docs** — [datamates-docs.myaltimate.com](https://datamates-docs.myaltimate.com/)
+- **Altimate Code docs** — [Altimate Code section](/code/)
+- **Altimate MCP docs** — [Altimate MCP section](/datamates/)

--- a/documentation/docs/teammates/coach.md
+++ b/documentation/docs/teammates/coach.md
@@ -1,10 +1,15 @@
+---
+title: Coach Teammate — Power User for dbt
+description: "The Coach teammate in Power User for dbt reviews your dbt code and teaches best practices as you work."
+---
+
 You can coach and personalize your AI teammates by giving instructions in the natural language.
 
 First, enable AI teammates functionality by going in settings -> teammates menu.
 ![enableTeammates](images/enableTeammates.png)<br>
 
 /// admonition | Unless you enable teammates in the SaaS instance, coaching and personalization outlined below won't work.
-    type: warning
+type: warning
 ///
 
 ## Documentation Writer

--- a/documentation/docs/teammates/introduction.md
+++ b/documentation/docs/teammates/introduction.md
@@ -1,3 +1,8 @@
+---
+title: AI Teammates — Power User for dbt
+description: "Introduction to AI Teammates in Power User for dbt: specialized agents for building, coaching, and reviewing dbt projects."
+---
+
 ## What are AI Teammates?
 
 As AI is evolving, now we can create virtual AI teammates where some pieces of work can be done autonomously by them. You can coach these virtual teammates just like new members of your team, so the work they deliver is perfectly tailored for your organizations requirements.
@@ -10,6 +15,6 @@ In certain scenarios, they can assist you vs. doing work completely autonomously
 
 AI teammates are integrated in day to day work of data teams through Power User VSCode extension, Python package, and SaaS UI. Power User extension already has comprehensive AI functionality ranging from dbt model,test,docs generation to SQL query translation & explanation.
 
-/// admonition | For more info, please check [our website](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
-    type: tip
+/// admonition | For more info, please check [our website](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: tip
 ///

--- a/documentation/docs/test/adhocquery.md
+++ b/documentation/docs/test/adhocquery.md
@@ -1,3 +1,8 @@
+---
+title: Ad-Hoc Query Runner — Power User for dbt
+description: "Run ad-hoc SQL queries against your connected warehouse directly from VS Code with Power User for dbt."
+---
+
 You can run ad hoc SQL queries or dbt Models in the "Query Results" tab
 
 ## Click on the "New Query" Button

--- a/documentation/docs/test/bigquerycost.md
+++ b/documentation/docs/test/bigquerycost.md
@@ -1,3 +1,8 @@
+---
+title: BigQuery Query Cost Preview — Power User for dbt
+description: "Preview BigQuery query costs before running them with Power User for dbt's cost estimation feature."
+---
+
 For dbt models running in Big Query, you can get the estimate of the data processed for that model right inside VSCode as below:
 
 <div style="position: relative; padding-bottom: calc(63.5% + 44px); height: 0;"><iframe src=https://app.supademo.com/embed/clpzoqwia2r0jpezy954p5v7h frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>

--- a/documentation/docs/test/defertoprod.md
+++ b/documentation/docs/test/defertoprod.md
@@ -1,3 +1,10 @@
+---
+title: Defer to Production — Power User for dbt
+description: "Use dbt's defer feature in Power User for dbt to run only changed models against production data during development."
+video_id: r91_NShqhlU
+video_upload_date: "2026-06-11T00:00:00Z"
+---
+
 Defer functionality in dbt allows the user to run a subset of models or tests without having to first build their upstream parents. Usually, it leads to significant cost and time savings during testing of the dbt models. More information about this functionality is available in [dbt docs](https://docs.getdbt.com/blog/defer-to-prod).
 
 ### Step 1: Enable Defer to production functionality in the "Actions" panel as below
@@ -17,13 +24,13 @@ Choose the location of your local manifest file as shown in the image below:
 ## SaaS Mode
 
 /// admonition | To use the Altimate SaaS instance, you will need to install the `altimate-datapilot` python package. You can install it using the following command: `pip install altimate-datapilot`. This package is required to upload the manifest file to the SaaS instance. You can find more information about the package [here](https://github.com/AltimateAI/datapilot).
-    type: tip
+type: tip
 ///
 
 First, create the dbt integration in the Altimate AI SaaS instance by going to Settings -> Integrations from left side navigation menu. This is just to create a reference where you can upload respective manifest files to point to.
 
-/// admonition | If you would like to connect your on-premise storage for manifest file uploads, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via chat or Slack.
-    type: info
+/// admonition | If you would like to connect your on-premise storage for manifest file uploads, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via chat or Slack.
+type: info
 ///
 
 ![addIntegration](images/addIntegration.png)<br>
@@ -37,7 +44,7 @@ The command will look something like this - <br>
 (You need to replace 'Path/to/file' with the path to your manifest file e.g. /Users/mrx/documents/repos/jaffle_shop/target/manifest.json)
 
 /// admonition | You can use this command to run at regular intervals in your CI/CD or orchestration tool so the latest manifest is always available for reference automatically in other environments
-    type: tip
+type: tip
 ///
 
 Now, choose the right dbt integration to reference in your VSCode as below:
@@ -56,6 +63,6 @@ Turn on favor-state if you need it. If it's turned on, the defer functionality w
 
 <div style="position: relative; padding-bottom: calc(88.35733099209834% + 42px); height: 0;"><iframe src="https://app.supademo.com/embed/cltlt0f7g1tk6cd1jy5qo12ym" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
-/// admonition | Using defer to prod with SaaS instance requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs) Local mode doesn't require an API key.
-    type: info
+/// admonition | Using defer to prod with SaaS instance requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) Local mode doesn't require an API key.
+type: info
 ///

--- a/documentation/docs/test/lineage.md
+++ b/documentation/docs/test/lineage.md
@@ -1,3 +1,8 @@
+---
+title: Column Lineage — Power User for dbt
+description: "Trace column-level lineage through your dbt project to understand data flow and dependencies."
+---
+
 Lineage is available as model level lineage and column level lineage. You need to add an API key to view column level lineage. You can view model level lineage without an API key.
 
 ## Model lineage
@@ -35,17 +40,17 @@ You can adjust the lineage scope without re-opening it:
 ![Transformation Code](images/TranformationCode.png)
 
 /// admonition | Column lineage with code transformation is also available in SaaS UI. Please refer to the section on [SaaS Discovery UI](../discover/viewlineage.md)
-    type: tip
+type: tip
 ///
 
 ![Lineage SaaS](images/lineageSaaS.png)
 
 /// details | Following are a few limitations in the column level lineage
-    type: note
+type: note
 
 - Snapshots are not supported (coming soon)
 - Operators that may result in an incomplete lineage - Unnest - Lateral View Flatten - Json flatten to columns
-///
+  ///
 
 ## Export lineage
 
@@ -59,6 +64,6 @@ You can export lineage view to a web page. Please check more details [here](../g
 
 <div style="position: relative; padding-bottom: 62.5%; height: 0;"><iframe src="https://www.loom.com/embed/24c9230c94854443a17d85de78f90ea8?sid=ba72566e-20e0-4ea2-a16a-55c8d5751c9e" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
-/// admonition | Column lineage requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=dbt-power-user&utm_medium=docs)
-    type: info
+/// admonition | Column lineage requires an API key. You can get it by signing up for free at [www.altimate.ai](https://www.altimate.ai?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link)
+type: info
 ///

--- a/documentation/docs/test/queryResults.md
+++ b/documentation/docs/test/queryResults.md
@@ -1,3 +1,8 @@
+---
+title: Query Results Panel — Power User for dbt
+description: "View query results in a rich, filterable table panel inside VS Code with Power User for dbt."
+---
+
 You can preview the resulting data and SQL query from your code with the extension, export it as CSV and do further analysis. You can also use [Altimate Code](../teammates/altimate-code.md) to explain your SQL or to profile a query for performance.
 
 ## Preview results, export and analyze

--- a/documentation/docs/test/runctes.md
+++ b/documentation/docs/test/runctes.md
@@ -1,6 +1,11 @@
+---
+title: Run CTEs — Power User for dbt
+description: "Execute individual CTEs within a dbt model to inspect intermediate results without running the full model."
+---
+
 # Preview CTEs (Common Table Expressions)
 
-dbt Power User allows you to preview individual CTEs (Common Table Expressions) within your dbt models, making it easier to debug and understand complex queries by examining each component separately.
+Power User for dbt allows you to preview individual CTEs (Common Table Expressions) within your dbt models, making it easier to debug and understand complex queries by examining each component separately.
 
 <div style="position: relative; box-sizing: content-box; max-height: 80vh; max-height: 80svh; width: 100%; aspect-ratio: 1.5470008952551477; padding: 40px 0 40px 0;"><iframe src="https://app.supademo.com/embed/cmc2e5dnokjiqsn1rupca8l9o?embed_v=2" loading="lazy" title="Preview CTE Results using Power User for dbt Extension" allow="clipboard-write" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 

--- a/documentation/docs/test/runtests.md
+++ b/documentation/docs/test/runtests.md
@@ -1,3 +1,8 @@
+---
+title: Run dbt Tests — Power User for dbt
+description: "Run dbt tests from the editor toolbar or the side panel in Power User for dbt for quick validation."
+---
+
 There are two methods to run dbt model tests. You can either do it from the top right corner toolbar or from the extension side panel.
 
 ### Method 1: Run tests from the toolbar
@@ -8,7 +13,7 @@ The toolbar action to run tests is present on the top right corner of the VSCode
 
 ### Method 2: Run tests from the side panel
 
-On the left side of the navigation, click on the dbt power user extension icon to open the left-side panel, as shown in the image below.
+On the left side of the navigation, click on the Power User for dbt extension icon to open the left-side panel, as shown in the image below.
 Then, click on the "Test dbt Model" button (hover over the area shown by the red circle to make it visible) to execute dbt model tests.
 
 ![Run tests in the side panel](images/testsPanel.png)

--- a/documentation/docs/test/sqlvalidation.md
+++ b/documentation/docs/test/sqlvalidation.md
@@ -1,3 +1,8 @@
+---
+title: SQL Validation — Power User for dbt
+description: "Validate SQL syntax and semantics in real time while editing dbt models in VS Code with Power User for dbt."
+---
+
 Identify SQL issues like non-existent columns, keyword typos, extra parentheses easily
 
 Following SQL checks are available:
@@ -14,17 +19,17 @@ Every error popup raised by Validate SQL includes a **Fix with Altimate Code** b
 
 In addition to the SQL checks above, the four pre-execution paths that previously failed silently now each show a descriptive error popup with its own Fix button:
 
-| Path | What you'll see |
-|---|---|
-| dbt manifest not loaded | *dbt manifest not loaded. Run `dbt parse`…* |
-| Model not present in manifest | *Model `X` not found in manifest…* |
-| Parent graph entry missing | *Could not find model graph entry…* |
-| SQL compilation failed (broken `ref()` etc.) | *Unable to compile SQL for model `X`…* |
+| Path                                         | What you'll see                             |
+| -------------------------------------------- | ------------------------------------------- |
+| dbt manifest not loaded                      | _dbt manifest not loaded. Run `dbt parse`…_ |
+| Model not present in manifest                | _Model `X` not found in manifest…_          |
+| Parent graph entry missing                   | _Could not find model graph entry…_         |
+| SQL compilation failed (broken `ref()` etc.) | _Unable to compile SQL for model `X`…_      |
 
 After Validate SQL writes diagnostics to the Problems panel, an error notification with a **Fix this SQL** button also appears. The prompt sent to Altimate Code contains the compiled SQL plus the validation errors.
 
 /// admonition | See also: Problems panel quick fix
-    type: tip
+type: tip
 
 The Validate SQL errors that land in the Problems panel also get the **Fix with Altimate Code** quick-fix light-bulb and inline link covered in [Troubleshooting → Fix with Altimate Code (any error row)](../troubleshooting.md#fix-with-altimate-code-any-error-row).
 ///

--- a/documentation/docs/test/sqlvisualizer.md
+++ b/documentation/docs/test/sqlvisualizer.md
@@ -1,3 +1,8 @@
+---
+title: SQL Visualizer — Power User for dbt
+description: "Visualize the logical structure and execution plan of SQL queries inside VS Code with Power User for dbt."
+---
+
 # SQL Visualizer (Beta)
 
 The new SQL visualizer translates complex SQL queries into intuitive graphical representations. SQL visualizer functionality shows the SQL structure of your code and how different components of the code are connected.
@@ -12,7 +17,7 @@ The provided SQL query is visually broken down into nodes representing CTEs, joi
 - Simplified Debugging: Identify and correct errors quickly by visually tracing query logic.
 
 /// admonition | This functionality is still in beta. The functionality may change further to streamline the experience
-    type: info
+type: info
 ///
 
 ## Trigger the functionality

--- a/documentation/docs/test/utilities.md
+++ b/documentation/docs/test/utilities.md
@@ -1,3 +1,8 @@
+---
+title: Test Utilities — Power User for dbt
+description: "Utility commands and helpers for managing dbt tests, including bulk run, filtering, and result inspection."
+---
+
 ## dbt logs viewer (force tailing)
 
 ![dbt-logviewer](images/dbt-log.gif)

--- a/documentation/docs/test/writetests.md
+++ b/documentation/docs/test/writetests.md
@@ -1,3 +1,8 @@
+---
+title: Write dbt Tests with AI — Power User for dbt
+description: "Auto-generate dbt tests for your models using AI in Power User for dbt. Covers generic and custom test generation."
+---
+
 You can generate, view, edit and delete dbt tests in VS Code under the Documentation Editor section.
 
 /// details | Following are a few limitations
@@ -19,20 +24,20 @@ You can add default dbt tests: unique, not_null, accepted_values, relationship b
 
 ![Add tests](images/addGenericTest.gif)
 
-## Generate dbt Tests 
+## Generate dbt Tests
 
 You can also generate test code for custom tests based on `dbt_utils` and `dbt_expectations` packages.
 
 In the Documentation Editor, click the **(+)** sign next to the **Tests:** label and choose **custom tests**. Altimate Code opens in a side panel, asks any clarifying questions it needs, and writes the test (using `dbt_utils` / `dbt_expectations` if installed, or a custom macro otherwise).
 
 /// admonition | Requires the Datamates extension
-    type: info
+type: info
 
 Custom test generation runs through Altimate Code, which is powered by the **[Datamates](https://marketplace.visualstudio.com/items?itemName=altimateai.vscode-altimate-mcp-server)** extension. Make sure Datamates is installed and active before invoking custom test generation.
 ///
 
 /// admonition | Altimate Code may occasionally retry dbt commands before producing a successful test, and in rare cases may ignore installed packages or generate inaccurate code. Review the generated test before saving.
-    type: info
+type: info
 ///
 
 ![Generate tests via Altimate Code](images/testGeneration.png)
@@ -49,7 +54,7 @@ by clicking on the test and using the "trash can icon" from the details screen
 As shown in the image above, there is a button to quickly get distinct values for a specific column with a click of a button. This helps you write the "accepted_values" test easily.
 
 /// admonition | Save changes in YAML file
-    type: tip
+type: tip
 
 You can save the changes in the existing or a new YAML file with save button at the bottom of the panel.
 If you see any issues with the content that's saved in the YAML file, please check the [optional config section](../setup/optConfig.md/#column-name-setup-for-yaml-file-updates).

--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -1,23 +1,28 @@
+---
+title: Troubleshooting Power User for dbt
+description: "Diagnose and fix common Power User for dbt issues using the Get Started panel and command palette shortcuts."
+---
+
 ## Troubleshooting Steps
 
 Follow these steps to effectively troubleshoot and resolve issues with the extension:
 
 ### Get Started panel (recommended)
 
-The fastest way to detect and resolve environment issues is the **Get Started with dbt Power User** panel. It runs through every prerequisite the extension needs — Python interpreter, dbt installation, dbt project detection, dbt deps, and database connection — and flags exactly what's missing.
+The fastest way to detect and resolve environment issues is the **Get Started with Power User for dbt** panel. It runs through every prerequisite the extension needs — Python interpreter, dbt installation, dbt project detection, dbt deps, and database connection — and flags exactly what's missing.
 
 Open it from the command palette:
 
 - macOS: `Cmd + Shift + P`
 - Windows / Linux: `Ctrl + Shift + P`
-- Type `Get Started with dbt Power User` and run it.
+- Type `Get Started with Power User for dbt` and run it.
 
-You can also launch it from the **Project Actions ✨** view in the dbt Power User side panel, or by clicking the **dbt** status item in the bottom status bar and choosing "Setup Extension".
+You can also launch it from the **Project Actions ✨** view in the Power User for dbt side panel, or by clicking the **dbt** status item in the bottom status bar and choosing "Setup Extension".
 
 /// admonition | Demo from an earlier UI
-    type: warning
+type: warning
 
-The recording below was captured before the status-bar "Setup Extension" wizard was replaced by the **Get Started with dbt Power User** panel. The steps are the same — only the panel UI has changed.
+The recording below was captured before the status-bar "Setup Extension" wizard was replaced by the **Get Started with Power User for dbt** panel. The steps are the same — only the panel UI has changed.
 ///
 
 <div style="position: relative; padding-bottom: calc(57.25% + 44px); height: 0;"><iframe src=https://app.supademo.com/embed/clph7wqbu4xjbpe69qnl0m9pf frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
@@ -32,7 +37,7 @@ If the extension is using the wrong Python interpreter (e.g. it sees a global Py
 The extension reads the active Python path directly from the shell and switches to it. This is the quickest fix for the most common "dbt not found" / "wrong dbt version" issues.
 
 /// admonition | Requires shell integration
-    type: info
+type: info
 
 The command needs VS Code's terminal shell integration to read the Python path from your shell. If no terminal is open or shell integration is not active, the extension will prompt you to open one.
 ///
@@ -47,13 +52,13 @@ Open the **Problems** tab (View → Problems, or `Cmd+Shift+M` / `Ctrl+Shift+M`)
 
 Every error row in the Problems panel carries a 💡 light-bulb button. Click it to open the **Quick Fix** dropdown and pick **Fix with Altimate Code** — this routes the error (file path, code, and message) to the Altimate Code chat panel, pre-filled and auto-sent.
 
-The light-bulb is registered by the bundled **Datamates** extension (`altimateai.vscode-altimate-mcp-server`), so it appears on errors from any source — TypeScript, Python, ESLint, dbt YAML, SQL, dbt Power User itself.
+The light-bulb is registered by the bundled **Datamates** extension (`altimateai.vscode-altimate-mcp-server`), so it appears on errors from any source — TypeScript, Python, ESLint, dbt YAML, SQL, Power User for dbt itself.
 
 ![Quick Fix dropdown on a Problems-panel row showing "Fix with Altimate Code"](images/troubleshootQuickFix.png)
 
 #### Inline `Fix with Altimate Code` link on extension diagnostics
 
-For diagnostics created by the dbt Power User extension itself, a clickable **Fix with Altimate Code** text link is rendered directly in the Problems panel row — no light-bulb hover needed. This currently covers:
+For diagnostics created by the Power User for dbt extension itself, a clickable **Fix with Altimate Code** text link is rendered directly in the Problems panel row — no light-bulb hover needed. This currently covers:
 
 - Python bridge errors
 - dbt manifest / rebuild errors
@@ -64,7 +69,7 @@ For diagnostics created by the dbt Power User extension itself, a clickable **Fi
 Clicking the link opens the Altimate Code chat with the same pre-filled context. The first click shows VS Code's one-time **"Always Allow"** popup for the deep-link — accept it once and subsequent clicks are silent.
 
 /// admonition | Works in VS Code, Cursor, and Windsurf
-    type: info
+type: info
 
 The deep-link uses `vscode.env.uriScheme` to pick the host editor's scheme automatically, so the same flow opens the right chat in VS Code, Cursor, and Windsurf without manual configuration.
 ///
@@ -93,7 +98,7 @@ The diagnostics command in the VSCode Power User extension provides a comprehens
 Running the command
 
 - On Mac, press `Cmd + Shift + P` or On Windows/Linux, use `Ctrl + Shift + P`
-- type diagnostics and pick the option listed under the dbt power user extension name and press enter
+- type diagnostics and pick the option listed under the Power User for dbt extension name and press enter
   ![Diagnostics](images/diagnostics.png)
 - this should start a terminal window and print the diagnostic information
 
@@ -119,14 +124,14 @@ For more in-depth diagnostics, use the developer tools in Visual Studio Code (VS
 
 ### Contact Support
 
-If issues still remain unresolved, please [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via Slack or chat for further assistance.
+If issues still remain unresolved, please [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via Slack or chat for further assistance.
 
 /// admonition | Feedback Widgets
-    type: tip
+type: tip
 
 There are also feedback widgets in the extension embedded in various features, where you can directly provide feedback on the roadmap or any issues that you encountered.
 ///
 
-/// admonition | Still stuck? [contact us](https://www.altimate.ai/support?utm_source=dbt-power-user&utm_medium=docs) via Slack or chat
-    type: tip
+/// admonition | Still stuck? [contact us](https://www.altimate.ai/support?utm_source=help-docs&utm_medium=referral&utm_campaign=docs-inline-link) via Slack or chat
+type: tip
 ///

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -8,148 +8,125 @@ theme:
     repo: fontawesome/brands/github
   custom_dir: docs/overrides
   features:
-    - announce.dismiss
-    - content.action.edit
-    - content.action.view
-    - content.code.annotate
-    - content.code.copy
-    # - content.code.select
-    # - content.tabs.link
-    - content.tooltips
-    # - header.autohide
-    # - navigation.expand
-    - navigation.footer
-    - navigation.indexes
-    # - navigation.instant
-    # - navigation.instant.prefetch
-    # - navigation.instant.progress
-    # - navigation.prune
-    # - navigation.sections
-    # - navigation.tabs
-    # - navigation.tabs.sticky
-    - navigation.top
-    - navigation.tracking
-    - search.highlight
-    - search.share
-    - search.suggest
-    - toc.follow
-    # - toc.integrate
-
+  - announce.dismiss
+  - content.action.edit
+  - content.action.view
+  - content.code.annotate
+  - content.code.copy
+  - content.tooltips
+  - navigation.footer
+  - navigation.indexes
+  - navigation.top
+  - navigation.tracking
+  - search.highlight
+  - search.share
+  - search.suggest
+  - toc.follow
   palette:
-    # Palette toggle for automatic mode
-    - media: "(prefers-color-scheme)"
-      toggle:
-        icon: material/brightness-auto
-        name: Switch to light mode
-      primary: white
-      accent: blue
-
-    # Palette toggle for light mode
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-      primary: white
-      accent: blue
-
-    # Palette toggle for dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      toggle:
-        icon: material/brightness-4
-        name: Switch to system preference
-      primary: black
-      accent: blue
-
+  - media: (prefers-color-scheme)
+    toggle:
+      icon: material/brightness-auto
+      name: Switch to light mode
+    primary: white
+    accent: blue
+  - media: '(prefers-color-scheme: light)'
+    scheme: default
+    toggle:
+      icon: material/brightness-7
+      name: Switch to dark mode
+    primary: white
+    accent: blue
+  - media: '(prefers-color-scheme: dark)'
+    scheme: slate
+    toggle:
+      icon: material/brightness-4
+      name: Switch to system preference
+    primary: black
+    accent: blue
   font:
     text: Roboto
     code: Roboto Mono
     logo: logo
-
 extra_css:
-  - stylesheets/extra.css
-
+- stylesheets/extra.css
 markdown_extensions:
-  - pymdownx.blocks.admonition
-  - markdown.extensions.codehilite:
-      guess_lang: false
-  - pymdownx.highlight:
-      anchor_linenums: true
-      line_spans: __span
-      pygments_lang_class: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
-  - pymdownx.superfences
-  - pymdownx.blocks.details
+- pymdownx.blocks.admonition
+- markdown.extensions.codehilite:
+    guess_lang: false
+- pymdownx.highlight:
+    anchor_linenums: true
+    line_spans: __span
+    pygments_lang_class: true
+- pymdownx.inlinehilite
+- pymdownx.snippets
+- pymdownx.superfences
+- pymdownx.blocks.details
 plugins:
-  - search
-  - git-revision-date-localized:
-      enable_creation_date: true
-      type: date
-      fallback_to_build_date: true
-
+- search
+- git-revision-date-localized:
+    enable_creation_date: true
+    type: date
+    fallback_to_build_date: true
 nav:
-  - Welcome: index.md
-  - Setup:
-      - Install the extension: setup/installation.md
-      - Cursor IDE workaround: setup/cursor_installation_workaround.md
-      - Required config:
-        - dbt Core: setup/reqdConfig.md
-        - dbt Cloud: setup/reqdConfigCloud.md
-        - dbt Fusion: setup/reqdConfigFusion.md
-      - Optional config: setup/optConfig.md
-      - All configurations: setup/configuration.md
-      - SSO: setup/sso.md
-      - FAQ: setup/faq.md
-  - Develop:
-      - Autocomplete and go to definition: develop/autocomplete.md
-      - Click to build parent/child models: develop/clicktorun.md
-      - Preview compiled code (SQL): develop/compiledCode.md
-      - Generate dbt model from source: develop/genmodelSource.md
-      - Generate dbt model from SQL: develop/genmodelSQL.md
-      - SQL validation: test/sqlvalidation.md
-      - Query explanation: develop/explanation.md
-      - Optimize SQL with Altimate: develop/optimize.md
-      - Update dbt model using natural language: develop/updatemodel.md
-      - Translate SQL queries (dialects): develop/translateSQL.md
-  - Test:
-      - Preview query results: test/queryResults.md
-      - Preview CTEs: test/runctes.md
-      - Run ad hoc query: test/adhocquery.md
-      - SQL Visualizer: test/sqlvisualizer.md
-      - Generate and edit tests: test/writetests.md
-      - Run tests: test/runtests.md
-      - Column Lineage: test/lineage.md
-      - Defer to prod: test/defertoprod.md
-  - Document:
-      - Write documentation: document/write.md
-      - Generate documentation: document/generatedoc.md
-      - Support for doc blocks: document/docblocks.md
-  - Collaborate: 
-      - Project Governance: govern/governance.md
-      - Notebooks for ad-hoc analysis: govern/notebooks.md
-      - Collaborate via IDE & UI: govern/collaboration.md
-      - Multi-project Support with dbt-loom: govern/multiproject.md
-      - Query Bookmarks and History: govern/querybookmarks.md
-  - Discover:
-      - Setup UI for docs & lineage: discover/setupui.md
-      - Search and view docs: discover/viewdocs.md
-      - Column lineage with Xformations: discover/viewlineage.md
-  - Utilities:
-      - Big Query cost estimator: test/bigquerycost.md
-      - Logs force tailing: test/utilities.md
-  - AI Teammates:
-      - Introduction: teammates/introduction.md
-      - Coach & Personalize: teammates/coach.md
-  - Altimate Code: teammates/altimate-code.md
-  - Altimate LLM Gateway: arch/llm-gateway.md
-  - Datamates: https://datamates-docs.myaltimate.com/
-  - Studio (Beta): studio.md
-  - Support & FAQ:
-      - Troubleshooting: troubleshooting.md
-      - Security FAQ: arch/faq.md
-      - Pricing FAQ: arch/pricingfaq.md
+- Overview: index.md
+- Setup:
+  - Install the extension: setup/installation.md
+  - Cursor IDE workaround: setup/cursor_installation_workaround.md
+  - Required config:
+    - dbt Core: setup/reqdConfig.md
+    - dbt Cloud: setup/reqdConfigCloud.md
+    - dbt Fusion: setup/reqdConfigFusion.md
+  - Optional config: setup/optConfig.md
+  - All configurations: setup/configuration.md
+  - SSO: setup/sso.md
+  - FAQ: setup/faq.md
+- Develop:
+  - Autocomplete and go to definition: develop/autocomplete.md
+  - Click to build parent/child models: develop/clicktorun.md
+  - Preview compiled code (SQL): develop/compiledCode.md
+  - Generate dbt model from source: develop/genmodelSource.md
+  - Generate dbt model from SQL: develop/genmodelSQL.md
+  - SQL validation: test/sqlvalidation.md
+  - Query explanation: develop/explanation.md
+  - Optimize SQL with Altimate: develop/optimize.md
+  - Update dbt model using natural language: develop/updatemodel.md
+  - Translate SQL queries (dialects): develop/translateSQL.md
+- Test:
+  - Preview query results: test/queryResults.md
+  - Preview CTEs: test/runctes.md
+  - Run ad hoc query: test/adhocquery.md
+  - SQL Visualizer: test/sqlvisualizer.md
+  - Generate and edit tests: test/writetests.md
+  - Run tests: test/runtests.md
+  - Column Lineage: test/lineage.md
+  - Defer to prod: test/defertoprod.md
+- Document:
+  - Write documentation: document/write.md
+  - Generate documentation: document/generatedoc.md
+  - Support for doc blocks: document/docblocks.md
+- Collaborate:
+  - Project Governance: govern/governance.md
+  - Notebooks for ad-hoc analysis: govern/notebooks.md
+  - Collaborate via IDE & UI: govern/collaboration.md
+  - Multi-project Support with dbt-loom: govern/multiproject.md
+  - Query Bookmarks and History: govern/querybookmarks.md
+- Discover:
+  - Setup UI for docs & lineage: discover/setupui.md
+  - Search and view docs: discover/viewdocs.md
+  - Column lineage with Xformations: discover/viewlineage.md
+- Utilities:
+  - Big Query cost estimator: test/bigquerycost.md
+  - Logs force tailing: test/utilities.md
+- AI Teammates:
+  - Introduction: teammates/introduction.md
+  - Coach & Personalize: teammates/coach.md
+- Altimate Code: teammates/altimate-code.md
+- Altimate LLM Gateway: arch/llm-gateway.md
+- Studio (Beta): studio.md
+- Support & FAQ:
+  - Troubleshooting: troubleshooting.md
+  - Security FAQ: arch/faq.md
+  - Pricing FAQ: arch/pricingfaq.md
 extra:
   status:
     new: Recently added
@@ -159,34 +136,28 @@ extra:
     feedback:
       title: Was this page helpful?
       ratings:
-        - icon: material/emoticon-happy-outline
-          name: This page was helpful
-          data: 1
-          note: >-
-            Thanks for your feedback!
-        - icon: material/emoticon-sad-outline
-          name: This page could be improved
-          data: 0
-          note: >-
-            Thanks for your feedback! Help us improve this page by
-            using our <a href="https://github.com/altimateai/vscode-dbt-power-user/issues/new/?title=[DocsFeedback]+{title}+-+{url}" target="_blank" rel="noopener">feedback form</a>.
+      - icon: material/emoticon-happy-outline
+        name: This page was helpful
+        data: 1
+        note: Thanks for your feedback!
+      - icon: material/emoticon-sad-outline
+        name: This page could be improved
+        data: 0
+        note: Thanks for your feedback! Help us improve this page by using our <a
+          href="https://github.com/altimateai/vscode-dbt-power-user/issues/new/?title=[DocsFeedback]+{title}+-+{url}"
+          target="_blank" rel="noopener">feedback form</a>.
   consent:
     title: Cookie consent
-    description: >-
-      We use cookies to recognize your repeated visits and preferences, as well
-      as to measure the effectiveness of our documentation and whether users
-      find what they're searching for. With your consent, you're helping us to
-      make our documentation better.
+    description: We use cookies to recognize your repeated visits and preferences,
+      as well as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us to make
+      our documentation better.
     actions:
-      - accept
-      - reject
-copyright: >
-  Copyright &copy; 2022 - 2026 Altimate Inc –
-  <a href="#__consent">Change cookie settings</a>
+    - accept
+    - reject
+copyright: 'Copyright &copy; 2022 - 2026 Altimate Inc – <a href="#__consent">Change
+  cookie settings</a>
 
-copyright: >
-  Copyright &copy; 2022 - 2026 Altimate Inc –
-  <a href="#__consent">Change cookie settings</a>
-
+  '
 repo_url: https://github.com/AltimateAI/vscode-dbt-power-user
 edit_uri: edit/master/docs/


### PR DESCRIPTION
Initial docs sync from **AltimateAI/help-docs**, which is now the source of truth for documentation.

- Content-only mirror generated by help-docs` tools/sync_to_oss.py`.
- **Edit docs in help-docs, not here** — each file carries a do-not-edit banner; this copy is regenerated automatically.
- Non-destructive: repo-only files (CNAME, overrides/, css, requirements, and any repo-only pages) are preserved, not deleted.
- Unified-site links de-prefixed; `mkdocs.yml` nav regenerated from help-docs.

First sync is large because help-docs content was developed substantially post-migration. Please review; anything here that should live in help-docs instead can be pulled back before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added titles, descriptions, video metadata, and improved page discoverability across the documentation.
  - Reorganized the homepage with installation and FAQ links, feature navigation, comparison information, and support details.
  - Clarified pricing, credit expiration, setup guidance, troubleshooting, and optional artifact-upload instructions.
  - Updated product naming, command labels, links, tables, screenshots, and examples for consistency.
  - Standardized notices, warnings, tips, and informational callouts throughout the documentation.
- **Style**
  - Refined navigation, theme settings, formatting, and consent messaging for a more consistent documentation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->