### PR TITLE
ci: notify help-docs hub on docs changes

### DIFF
--- a/.github/workflows/notify-help-docs.yml
+++ b/.github/workflows/notify-help-docs.yml
@@ -26,12 +26,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           J="$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0] // {}')"
-          LOGIN="$(echo "$J" | jq -r '.user.login // ""')"
           echo "num=$(echo "$J" | jq -r '.number // ""')" >> "$GITHUB_OUTPUT"
-          echo "login=$LOGIN" >> "$GITHUB_OUTPUT"
+          echo "login=$(echo "$J" | jq -r '.user.login // ""')" >> "$GITHUB_OUTPUT"
           echo "url=$(echo "$J" | jq -r '.html_url // ""')" >> "$GITHUB_OUTPUT"
-          EMAIL=""; [ -n "$LOGIN" ] && EMAIL="$(gh api users/$LOGIN --jq '.email // ""' 2>/dev/null || echo '')"
-          echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
 
       - uses: actions/create-github-app-token@v1
         id: tok
@@ -47,4 +44,4 @@ jobs:
           repository: AltimateAI/help-docs
           event-type: promote-from-product
           client-payload: |
-            {"product":"dbt-power-user","before":"${{ github.event.before }}","after":"${{ github.sha }}","source_pr":"${{ steps.src.outputs.num }}","source_author":"${{ steps.src.outputs.login }}","source_url":"${{ steps.src.outputs.url }}","source_email":"${{ steps.src.outputs.email }}"}
+            {"product":"dbt-power-user","before":"${{ github.event.before }}","after":"${{ github.sha }}","source_pr":"${{ steps.src.outputs.num }}","source_author":"${{ steps.src.outputs.login }}","source_url":"${{ steps.src.outputs.url }}"}

--- a/.github/workflows/notify-help-docs.yml
+++ b/.github/workflows/notify-help-docs.yml
@@ -1,0 +1,34 @@
+name: Notify help-docs (docs changed)
+
+# On a merge that touches docs on the default branch, tell the help-docs hub to
+# promote the change up (product -> help-docs). Requires the shared docs-sync
+# GitHub App: set vars.DOCS_SYNC_APP_ID and secrets.DOCS_SYNC_APP_PRIVATE_KEY.
+# Sync-generated merges carry a [docs-sync] marker and are skipped (no loop).
+
+on:
+  push:
+    branches: [master]
+    paths: ["documentation/docs/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: ${{ !contains(github.event.head_commit.message, '[docs-sync]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: tok
+        with:
+          app-id: ${{ vars.DOCS_SYNC_APP_ID }}
+          private-key: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
+          owner: AltimateAI
+          repositories: help-docs
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.tok.outputs.token }}
+          repository: AltimateAI/help-docs
+          event-type: promote-from-product
+          client-payload: |
+            {"product":"dbt-power-user","before":"${{ github.event.before }}","after":"${{ github.sha }}"}

--- a/.github/workflows/notify-help-docs.yml
+++ b/.github/workflows/notify-help-docs.yml
@@ -15,22 +15,43 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: notify-help-docs-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   notify:
     if: ${{ !contains(github.event.head_commit.message, '[docs-sync]') }}
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-gke
     steps:
       - name: Resolve merged PR (author for notifications)
         id: src
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          J="$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0] // {}')"
-          echo "num=$(echo "$J" | jq -r '.number // ""')" >> "$GITHUB_OUTPUT"
-          echo "login=$(echo "$J" | jq -r '.user.login // ""')" >> "$GITHUB_OUTPUT"
-          echo "url=$(echo "$J" | jq -r '.html_url // ""')" >> "$GITHUB_OUTPUT"
+          J="$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0] // {}' 2>/dev/null || echo '{}')"
+          {
+            echo "num=$(echo "$J" | jq -r '.number // ""')"
+            echo "login=$(echo "$J" | jq -r '.user.login // ""')"
+            echo "url=$(echo "$J" | jq -r '.html_url // ""')"
+          } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/create-github-app-token@v1
+      - name: Build dispatch payload
+        id: payload
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          SRC_PR: ${{ steps.src.outputs.num }}
+          SRC_AUTHOR: ${{ steps.src.outputs.login }}
+          SRC_URL: ${{ steps.src.outputs.url }}
+        run: |
+          JSON="$(jq -cn --arg product dbt-power-user \
+            --arg before "$BEFORE" --arg after "$AFTER" \
+            --arg source_pr "$SRC_PR" --arg source_author "$SRC_AUTHOR" --arg source_url "$SRC_URL" \
+            '{product:$product,before:$before,after:$after,source_pr:$source_pr,source_author:$source_author,source_url:$source_url}')"
+          echo "json=$JSON" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: tok
         with:
           app-id: ${{ vars.DOCS_SYNC_APP_ID }}
@@ -38,10 +59,9 @@ jobs:
           owner: AltimateAI
           repositories: help-docs
 
-      - uses: peter-evans/repository-dispatch@v3
+      - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ steps.tok.outputs.token }}
           repository: AltimateAI/help-docs
           event-type: promote-from-product
-          client-payload: |
-            {"product":"dbt-power-user","before":"${{ github.event.before }}","after":"${{ github.sha }}","source_pr":"${{ steps.src.outputs.num }}","source_author":"${{ steps.src.outputs.login }}","source_url":"${{ steps.src.outputs.url }}"}
+          client-payload: ${{ steps.payload.outputs.json }}

--- a/.github/workflows/notify-help-docs.yml
+++ b/.github/workflows/notify-help-docs.yml
@@ -1,9 +1,10 @@
 name: Notify help-docs (docs changed)
 
 # On a merge that touches docs on the default branch, tell the help-docs hub to
-# promote the change up (product -> help-docs). Requires the shared docs-sync
-# GitHub App: set vars.DOCS_SYNC_APP_ID and secrets.DOCS_SYNC_APP_PRIVATE_KEY.
-# Sync-generated merges carry a [docs-sync] marker and are skipped (no loop).
+# promote the change up (product -> help-docs) as a review PR. Requires the
+# shared docs-sync GitHub App: vars.DOCS_SYNC_APP_ID +
+# secrets.DOCS_SYNC_APP_PRIVATE_KEY. Sync-generated merges carry a [docs-sync]
+# marker and are skipped, so this never loops.
 
 on:
   push:
@@ -12,12 +13,26 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   notify:
     if: ${{ !contains(github.event.head_commit.message, '[docs-sync]') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve merged PR (author for notifications)
+        id: src
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          J="$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0] // {}')"
+          LOGIN="$(echo "$J" | jq -r '.user.login // ""')"
+          echo "num=$(echo "$J" | jq -r '.number // ""')" >> "$GITHUB_OUTPUT"
+          echo "login=$LOGIN" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "$J" | jq -r '.html_url // ""')" >> "$GITHUB_OUTPUT"
+          EMAIL=""; [ -n "$LOGIN" ] && EMAIL="$(gh api users/$LOGIN --jq '.email // ""' 2>/dev/null || echo '')"
+          echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
+
       - uses: actions/create-github-app-token@v1
         id: tok
         with:
@@ -25,10 +40,11 @@ jobs:
           private-key: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
           owner: AltimateAI
           repositories: help-docs
+
       - uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ steps.tok.outputs.token }}
           repository: AltimateAI/help-docs
           event-type: promote-from-product
           client-payload: |
-            {"product":"dbt-power-user","before":"${{ github.event.before }}","after":"${{ github.sha }}"}
+            {"product":"dbt-power-user","before":"${{ github.event.before }}","after":"${{ github.sha }}","source_pr":"${{ steps.src.outputs.num }}","source_author":"${{ steps.src.outputs.login }}","source_url":"${{ steps.src.outputs.url }}","source_email":"${{ steps.src.outputs.email }}"}

--- a/.github/workflows/notify-help-docs.yml
+++ b/.github/workflows/notify-help-docs.yml
@@ -64,7 +64,7 @@ jobs:
             '{product:$product,before:$before,after:$after,source_pr:$source_pr,source_author:$source_author,source_url:$source_url}')"
           echo "json=$JSON" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: tok
         if: steps.config.outputs.enabled == 'true'
         with:
@@ -72,6 +72,7 @@ jobs:
           private-key: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
           owner: AltimateAI
           repositories: help-docs
+          permission-contents: write
 
       - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         if: steps.config.outputs.enabled == 'true'

--- a/.github/workflows/notify-help-docs.yml
+++ b/.github/workflows/notify-help-docs.yml
@@ -1,31 +1,44 @@
 name: Notify help-docs (docs changed)
 
-# On a merge that touches docs on the default branch, tell the help-docs hub to
-# promote the change up (product -> help-docs) as a review PR. Requires the
-# shared docs-sync GitHub App: vars.DOCS_SYNC_APP_ID +
-# secrets.DOCS_SYNC_APP_PRIVATE_KEY. Sync-generated merges carry a [docs-sync]
-# marker and are skipped, so this never loops.
+# When a push to the default branch changes published docs, tell the help-docs
+# hub to promote the change up (product -> help-docs) as a review PR. Requires
+# the shared docs-sync GitHub App as repo secrets: DOCS_SYNC_APP_ID and
+# DOCS_SYNC_APP_PRIVATE_KEY — if either is unset the job skips (no red run).
+# The loop guard checks every commit in the push for the [docs-sync] marker, so
+# it holds across squash, rebase, and merge-commit strategies.
 
 on:
   push:
     branches: [master]
     paths: ["documentation/docs/**"]
+  workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: read
 
-concurrency:
-  group: notify-help-docs-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   notify:
-    if: ${{ !contains(github.event.head_commit.message, '[docs-sync]') }}
-    runs-on: arc-runner-gke
+    if: ${{ !contains(toJSON(github.event.commits.*.message), '[docs-sync]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
+      - name: Check docs-sync App is configured
+        id: config
+        env:
+          APP_ID: ${{ secrets.DOCS_SYNC_APP_ID }}
+          APP_KEY: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "$APP_ID" ] && [ -n "$APP_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::docs-sync App not configured — skipping dispatch."
+          fi
+
       - name: Resolve merged PR (author for notifications)
         id: src
+        if: steps.config.outputs.enabled == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -38,6 +51,7 @@ jobs:
 
       - name: Build dispatch payload
         id: payload
+        if: steps.config.outputs.enabled == 'true'
         env:
           BEFORE: ${{ github.event.before }}
           AFTER: ${{ github.sha }}
@@ -53,13 +67,15 @@ jobs:
 
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: tok
+        if: steps.config.outputs.enabled == 'true'
         with:
-          app-id: ${{ vars.DOCS_SYNC_APP_ID }}
+          app-id: ${{ secrets.DOCS_SYNC_APP_ID }}
           private-key: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
           owner: AltimateAI
           repositories: help-docs
 
       - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        if: steps.config.outputs.enabled == 'true'
         with:
           token: ${{ steps.tok.outputs.token }}
           repository: AltimateAI/help-docs

--- a/.github/workflows/notify-help-docs.yml
+++ b/.github/workflows/notify-help-docs.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches: [master]
     paths: ["documentation/docs/**"]
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a tiny workflow that, when a PR touching docs merges to the default branch, notifies the **help-docs** hub (`repository_dispatch`) so the change is promoted up into help-docs as a review PR.

Part of the bidirectional docs-sync (help-docs is the source-of-truth hub). See `tools/DOCS_SYNC.md` in help-docs.

**Requires** the shared docs-sync GitHub App and these Actions settings on this repo (or org-level):
- secret `DOCS_SYNC_APP_ID`
- secret `DOCS_SYNC_APP_PRIVATE_KEY`

Inert until those are set. Sync-generated merges (marker `[docs-sync]`) are skipped, so it never loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added automated notifications when documentation changes are published.
  * Documentation updates now include relevant product and source-change details.
  * Added safeguards to prevent duplicate or unintended documentation notifications.
  * Improved consistency and timeliness when routing documentation changes for review and publication.
  * Added an option to trigger documentation notifications manually when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->