### PR TITLE
chore: bump dbt-integration to 0.3.9 and release 0.64.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-dbt-power-user",
-  "version": "0.64.3",
+  "version": "0.64.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-dbt-power-user",
-      "version": "0.64.3",
+      "version": "0.64.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.3.8",
+        "@altimateai/dbt-integration": "^0.3.9",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.8.tgz",
-      "integrity": "sha512-U8E4bZbL24NRr9NqZjCvqcJ/hFi/nRW6Puo7+l2M1e7jDobx+JAQhelxwBVX9/1u1xPZTU6En0DLbEWKoo3IcQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.9.tgz",
+      "integrity": "sha512-dVxNBUjq1IpA3wISF1y0EsOhC6pRXz/N7nqbRTFQTpj757phY3/locLN9Uy8qzKrdXKz7UDjcNWEmMU40ZtUPQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1295,7 +1295,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.3.8",
+    "@altimateai/dbt-integration": "^0.3.9",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/AltimateAI/vscode-dbt-power-user/issues"
   },
-  "version": "0.64.3",
+  "version": "0.64.4",
   "engines": {
     "vscode": "^1.95.0",
     "node": ">=20.0.0"


### PR DESCRIPTION
## What

Moves `@altimateai/dbt-integration` from `0.3.8` to `0.3.9` and cuts the extension release that carries it: `0.64.3` → `0.64.4`.

## Why

0.3.9 carries three error-path guards fixed upstream in the library. The extension currently resolves `0.3.8`, which predates all three, so every install still ships the unguarded paths:

| Fix | Effect | Machines affected |
|---|---|---|
| dead-IPC-channel guard in `rebuildManifest` | unhandled `ERR_IPC_CHANNEL_CLOSED` when the python-bridge dies mid-send; now degrades to warn-and-reconnect | **330** |
| manifest resolution guard | `generateModel` crashed with a `NoneType` error when invoked before project init; now an actionable "still initializing" message | 14 |
| limit-subquery macro fallback | `Macro resolver was None` is a recoverable fallback (the query still runs unlimited) — warns instead of emitting error telemetry | 60 |

## The diff

Three commits, all mechanical, `+8/-8` across two files:

- `package.json` — dependency floor `^0.3.8` → `^0.3.9`. Not strictly required (`^0.3.8` already admits `0.3.9`); it stops a fresh resolve landing back on `0.3.8` without the guards.
- `package-lock.json` — resolved version and integrity for the dependency.
- `package.json` + `package-lock.json` — extension version `0.64.3` → `0.64.4`.

The dependency integrity was verified against the registry rather than trusting the resolver:

```
registry: sha512-dVxNBUjq1IpA3wISF1y0EsOhC6pRXz/N7nqbRTFQTpj757phY3/locLN9Uy8qzKrdXKz7UDjcNWEmMU40ZtUPQ==
lockfile: sha512-dVxNBUjq1IpA3wISF1y0EsOhC6pRXz/N7nqbRTFQTpj757phY3/locLN9Uy8qzKrdXKz7UDjcNWEmMU40ZtUPQ==
```

## Note on shape

Dependency bumps here normally land without the extension version (see #2059, which bumped to `^0.3.8` and left the release cut to a separate `bump:` PR the next day, #2064). This one folds both together deliberately, because we are releasing off it now.

## Verification

Each guard carries unit tests in its originating library PR, plus a real-bridge fire-and-forget E2E for the IPC guard. There is no extension-side behavior change to exercise beyond CI resolving and building against the new version — the guards are internal to the library.

Post-merge validation is a telemetry diff on the three event names across the next release window; the IPC crash is the one to watch, at 330 machines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension to version 0.64.4.
  * Updated the dbt integration to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->