### PR TITLE
fix: scan skips projects whose dbt integration is not initialized

### DIFF
--- a/src/commands/altimateScan.ts
+++ b/src/commands/altimateScan.ts
@@ -81,6 +81,7 @@ export class AltimateScan {
   async getProblems() {
     this.telemetry.sendTelemetryEvent("altimateScan:Start");
     let totalProblems: number = 0;
+    let skippedProjects: number = 0;
     window.withProgress(
       {
         location: ProgressLocation.Notification,
@@ -90,6 +91,19 @@ export class AltimateScan {
       async () => {
         const projects = this.dbtProjectContainer.getProjects();
         for (const project of projects) {
+          // A project whose dbt integration never (re)initialized has no
+          // Python-side state to scan: every step would fail with a
+          // misleading error (historically `NameError: name 'project' is
+          // not defined`). Skip it — the init failure itself is already
+          // surfaced by diagnostics/the status bar.
+          if (!project.isBridgeInitialized()) {
+            skippedProjects += 1;
+            this.dbtTerminal.debug(
+              "altimateScan:getProblems",
+              `Skipping ${project.getProjectName()}: dbt project is not initialized`,
+            );
+            continue;
+          }
           try {
             const scanContext: ScanContext = new ScanContext(
               project,
@@ -109,6 +123,7 @@ export class AltimateScan {
         await commands.executeCommand("workbench.actions.view.problems");
         this.telemetry.sendTelemetryEvent("altimateScan:Done", {
           problemsFound: totalProblems.toString(),
+          projectsSkipped: skippedProjects.toString(),
         });
       },
     );

--- a/src/dbt_client/dbtProject.ts
+++ b/src/dbt_client/dbtProject.ts
@@ -433,6 +433,17 @@ export class DBTProject implements Disposable {
     return this.dbtProjectIntegration.getPythonBridgeStatus();
   }
 
+  // Whether the integration finished initializing its execution state (for
+  // dbt-core: the Python-side `project` binding exists on the current
+  // bridge). Feature-detected: dbt-integration < 0.3.10 has no
+  // isInitialized(), and those versions must keep today's behavior (ready).
+  isBridgeInitialized(): boolean {
+    const integration = this.dbtProjectIntegration as {
+      isInitialized?: () => boolean;
+    };
+    return integration.isInitialized?.() ?? true;
+  }
+
   getAllDiagnostic(): Diagnostic[] {
     const projectURI = Uri.file(
       path.join(this.projectRoot.fsPath, DBT_PROJECT_FILE),


### PR DESCRIPTION
## What this PR is for

One thing only: **the startup scan must not run features against a project whose dbt integration never initialized.** Live correlation on the associated telemetry cluster showed the scan invoking `project.*` on dead bridges at t=0 on 49 of 61 affected machines — every step then failed with the misleading `NameError: name 'project' is not defined` family instead of the real init failure (which diagnostics and the status bar already surface).

## The change

`AltimateScan.getProblems` skips projects whose integration reports not-initialized, counts them into the existing `altimateScan:Done` telemetry event (`projectsSkipped`), and logs each skip at debug level. `DBTProject.isBridgeInitialized()` is the probe behind it.

## Status: parked until `@altimateai/dbt-integration` 0.3.11

The readiness signal this needs — `isInitialized()` on the integration **adapter** — ships in 0.3.11 (AltimateAI/altimate-dbt-integration#165). The current head's feature-probe targets the adapter, which no released library exposes the method on, so the skip does not fire yet; the final revision (staged) drops the probe for the direct typed call and bumps the dependency to `^0.3.11`. That lands as one small commit the day 0.3.11 is on npm — this PR then goes ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AgkYtRZ5cr3w4cUKXVZvt
