### PR TITLE
fix: scan skips projects whose dbt integration is not initialized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@altimateai/dbt-integration": "^0.3.9",
+        "@altimateai/dbt-integration": "^0.3.11",
         "@jupyterlab/coreutils": "^6.2.4",
         "@jupyterlab/nbformat": "^4.2.4",
         "@jupyterlab/services": "^7.0.0",
@@ -186,24 +186,19 @@
       }
     },
     "node_modules/@altimateai/dbt-integration": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.9.tgz",
-      "integrity": "sha512-dVxNBUjq1IpA3wISF1y0EsOhC6pRXz/N7nqbRTFQTpj757phY3/locLN9Uy8qzKrdXKz7UDjcNWEmMU40ZtUPQ==",
-      "hasInstallScript": true,
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@altimateai/dbt-integration/-/dbt-integration-0.3.11.tgz",
+      "integrity": "sha512-eHBMgtwWoOlYloUBOl+HGZhRe1g9wj785Pf8ieE576ybzapOWTWDl+21qTMRxRBqmr69ZaZ4IFfpQmhP7fe1fQ==",
       "license": "MIT",
       "dependencies": {
         "@altimateai/altimate-core": "0.5.0",
         "node-abort-controller": "^3.1.1",
         "node-fetch": "^3.3.2",
-        "python-bridge": "^1.1.0",
         "semver": "^7.6.3",
         "yaml": "^2.5.0"
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "patch-package": "^8.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3973,6 +3968,7 @@
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/accepts": {
@@ -4639,6 +4635,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -5420,6 +5417,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -6464,6 +6462,7 @@
     },
     "node_modules/find-yarn-workspace-root": {
       "version": "2.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
@@ -6880,6 +6879,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -7260,6 +7260,7 @@
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -7438,6 +7439,7 @@
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -8576,6 +8578,7 @@
     },
     "node_modules/json-stable-stringify": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -8598,6 +8601,7 @@
     },
     "node_modules/json-stable-stringify/node_modules/isarray": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -8626,6 +8630,7 @@
     },
     "node_modules/jsonify": {
       "version": "0.0.1",
+      "dev": true,
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8712,6 +8717,7 @@
     },
     "node_modules/klaw-sync": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
@@ -10186,6 +10192,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10562,6 +10569,7 @@
     },
     "node_modules/patch-package": {
       "version": "8.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
@@ -10589,6 +10597,7 @@
     },
     "node_modules/patch-package/node_modules/ci-info": {
       "version": "3.9.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10602,6 +10611,7 @@
     },
     "node_modules/patch-package/node_modules/fs-extra": {
       "version": "10.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -10614,6 +10624,7 @@
     },
     "node_modules/patch-package/node_modules/open": {
       "version": "7.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0",
@@ -10628,6 +10639,7 @@
     },
     "node_modules/patch-package/node_modules/slash": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11913,6 +11925,7 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1295,7 +1295,7 @@
     "altimateai.vscode-altimate-mcp-server"
   ],
   "dependencies": {
-    "@altimateai/dbt-integration": "^0.3.9",
+    "@altimateai/dbt-integration": "^0.3.11",
     "@jupyterlab/coreutils": "^6.2.4",
     "@jupyterlab/nbformat": "^4.2.4",
     "@jupyterlab/services": "^7.0.0",

--- a/src/commands/altimateScan.ts
+++ b/src/commands/altimateScan.ts
@@ -81,6 +81,7 @@ export class AltimateScan {
   async getProblems() {
     this.telemetry.sendTelemetryEvent("altimateScan:Start");
     let totalProblems: number = 0;
+    let skippedProjects: number = 0;
     window.withProgress(
       {
         location: ProgressLocation.Notification,
@@ -90,6 +91,19 @@ export class AltimateScan {
       async () => {
         const projects = this.dbtProjectContainer.getProjects();
         for (const project of projects) {
+          // A project whose dbt integration never (re)initialized has no
+          // Python-side state to scan: every step would fail with a
+          // misleading error (historically `NameError: name 'project' is
+          // not defined`). Skip it — the init failure itself is already
+          // surfaced by diagnostics/the status bar.
+          if (!project.isBridgeInitialized()) {
+            skippedProjects += 1;
+            this.dbtTerminal.debug(
+              "altimateScan:getProblems",
+              `Skipping ${project.getProjectName()}: dbt project is not initialized`,
+            );
+            continue;
+          }
           try {
             const scanContext: ScanContext = new ScanContext(
               project,
@@ -109,6 +123,7 @@ export class AltimateScan {
         await commands.executeCommand("workbench.actions.view.problems");
         this.telemetry.sendTelemetryEvent("altimateScan:Done", {
           problemsFound: totalProblems.toString(),
+          projectsSkipped: skippedProjects.toString(),
         });
       },
     );

--- a/src/dbt_client/dbtProject.ts
+++ b/src/dbt_client/dbtProject.ts
@@ -433,6 +433,13 @@ export class DBTProject implements Disposable {
     return this.dbtProjectIntegration.getPythonBridgeStatus();
   }
 
+  // Whether the integration finished initializing its execution state (for
+  // dbt-core: the Python-side `project` binding exists on the current
+  // bridge). Non-core integrations report ready.
+  isBridgeInitialized(): boolean {
+    return this.dbtProjectIntegration.isInitialized();
+  }
+
   getAllDiagnostic(): Diagnostic[] {
     const projectURI = Uri.file(
       path.join(this.projectRoot.fsPath, DBT_PROJECT_FILE),

--- a/src/test/suite/isBridgeInitialized.test.ts
+++ b/src/test/suite/isBridgeInitialized.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "@jest/globals";
+import { DBTProject } from "../../dbt_client/dbtProject";
+
+/**
+ * The scan-skip contract (altimateScan) rests on this one method: it must
+ * report exactly what the integration adapter's isInitialized() says. The
+ * adapter delegation exists since dbt-integration 0.3.11, which is this
+ * package's dependency floor — an adapter without the member is out of
+ * contract. (The original feature detection probed for the member and fell
+ * back to "ready"; it silently never fired because no released adapter
+ * carried the method before 0.3.11.)
+ */
+describe("DBTProject.isBridgeInitialized", () => {
+  const call = (integration: unknown): boolean =>
+    DBTProject.prototype.isBridgeInitialized.call({
+      dbtProjectIntegration: integration,
+    } as unknown as DBTProject);
+
+  it("reports the adapter's isInitialized verdict — both ways", () => {
+    expect(call({ isInitialized: () => true })).toBe(true);
+    expect(call({ isInitialized: () => false })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this PR is for

One thing only: **the startup scan must not run features against a project whose dbt integration never initialized.** Live correlation on the associated telemetry cluster showed the scan invoking `project.*` on dead bridges at t=0 on 49 of 61 affected machines — every step then failed with the misleading `NameError: name 'project' is not defined` family instead of the real init failure (which diagnostics and the status bar already surface).

*(Supersedes #2077, closed to shed a cluttered review history.)*

## The change

- `AltimateScan.getProblems` skips projects whose integration reports not-initialized, counts them into the existing `altimateScan:Done` telemetry event (`projectsSkipped`), and logs each skip at debug level.
- `DBTProject.isBridgeInitialized()` delegates directly to the integration adapter's typed `isInitialized()` — reachable since `@altimateai/dbt-integration` **0.3.11** (AltimateAI/altimate-dbt-integration#165); the dependency floor moves to `^0.3.11` (lockfile resolved against the registry). No feature probes: #2077's original detection probed the adapter, which no pre-0.3.11 release exposed the method on, so its skip silently never fired.
- Test pins the delegation both ways.

Single commit; ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AgkYtRZ5cr3w4cUKXVZvt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scans now skip projects whose dbt integration has not initialized, avoiding misleading errors and allowing other projects to be scanned successfully.
  - Scan reporting now includes the number of projects skipped due to initialization issues.

- **Improvements**
  - Updated the dbt integration runtime to improve initialization status handling and scan reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->